### PR TITLE
Fix link to source document for gfm example

### DIFF
--- a/_posts/2011-12-03-minimal.md
+++ b/_posts/2011-12-03-minimal.md
@@ -64,17 +64,17 @@ Two main differences among different file formats are: they use different syntax
   - md source: [knitr-minimal.Rmd](https://raw.github.com/yihui/knitr/master/inst/examples/knitr-minimal.Rmd)
   - output: [knitr-minimal.md](https://github.com/yihui/knitr/blob/master/inst/examples/knitr-minimal.md) (GitHub does the job of parsing the md file to HTML)
 - HTML
-  - html source: [knitr-minimal\_knit\_.html](https://github.com/yihui/knitr/blob/master/inst/examples/knitr-minimal_knit_.html)
+  - html source: [knitr-minimal.Rhtml](https://github.com/yihui/knitr/blob/master/inst/examples/knitr-minimal.Rhtml)
   - output: [knitr-minimal.html](https://github.com/downloads/yihui/knitr/knitr-minimal.html)
 - LaTeX
-  - tex source: [knitr-latex\_knit\_.tex](https://github.com/yihui/knitr/blob/master/inst/examples/knitr-latex_knit_.tex)
+  - tex source: [knitr-latex.Rtex](https://github.com/yihui/knitr/blob/master/inst/examples/knitr-latex.Rtex)
 
 Except the GFM demo, you can directly use `knit()` to knit the input file, e.g.,
 
 {% highlight r %}
 library(knitr)
 knit('knitr-minimal.Rnw')
-knit('knitr-minimal_knit_.html')
+knit('knitr-minimal.Rhtml')
 {% endhighlight %}
 
 The instructions on how to knit the GFM demo are in the md file. Note for the HTML demo, you need to install the **rgl** package to get the snapshot in the output.


### PR DESCRIPTION
The link for the gfm example was out-of-date.
