### PR TITLE
Support for rst2pdf in knitr package

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -351,10 +351,8 @@ knit_global = function() {
 #' @examples ## compile a reST file using rst2pdf
 #'
 #' ## rst2pdf(...)
-rst2pdf = function(input, rst2pdfpath = "rst2pdf", options = NULL) {
-  rst2pdf_args = input
-  if (!is.null(options)) rst2pdf_args = paste(rst2pdf_args, options)
-  system2(rst2pdfpath, rst2pdf_args)
+rst2pdf = function(input, rst2pdfpath = "rst2pdf", options = "") {
+  system2(rst2pdfpath, paste(input, options))
 }
 
 #' Convert Rnw or Rrst file to PDF using knit() and texi2pdf() or rst2pdf()


### PR DESCRIPTION
First I want to thank you for the knitr package. I only recently started using it, but it has made documenting my research much easier (I am a doctoral student in geography and use R for all my statistics).

Lately I have been experimenting with using reStructuredText with knitr. These changes allow using rst2pdf (http://rst2pdf.ralsina.com.ar) to convert reST files to PDF using knitr. The advantage of using rst2pdf is it can convert reST to PDF without a LaTeX installation. These changes would allow using rst2pdf if the user so desires. Otherwise, knit2pdf defaults back to using LaTeX as before.

I have tested on on Linux (R 2.14.1) and on Windows (R 2.15.1) and it seems to be working on both.
