### PR TITLE
Added luatex tikz support

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -39,7 +39,8 @@ tikz_dev = function(...) {
   packages = switch(
     getOption('tikzDefaultEngine'),
     pdftex = getOption('tikzLatexPackages'),
-    xetex = getOption('tikzXelatexPackages')
+    xetex = getOption('tikzXelatexPackages'),
+    luatex = getOption('tikzLualatexPackages')
   )
   get('tikz', envir = as.environment('package:tikzDevice'))(
     ..., packages = c('\n\\nonstopmode\n', packages, .knitEnv$tikzPackages)
@@ -111,6 +112,7 @@ save_plot = function(plot, name, dev, ext, dpi, options) {
     system(str_c(switch(getOption("tikzDefaultEngine"),
                         pdftex = getOption('tikzLatex'),
                         xetex = getOption("tikzXelatex"),
+                        luatex = getOption("tikzLualatex"),
                         stop("a LaTeX engine must be specified for tikzDevice",
                              call. = FALSE)), shQuote(basename(path)), sep = ' '),
            ignore.stdout = TRUE)


### PR DESCRIPTION
Hi yihui,

Sorry for the delay. I was away on holiday for a few days. Here's my addition to plot.R that allows knitr users to set the tikzDefaultEngine to 'luatex' and use lualatex to compile tikz images. This is my first attempt at contributing to any project via github, so I hope I've done it right. I've pushed the changes into my github master copy, then I tested it out by using the install_github("knitr", "alastairandrew") from devtools and it all seems to work. As you'd noted there were only two lines that actually needed altered. Anyway I hope that's useful to you and the other knitr users and that my changes meet the grade for inclusion. 

Best wishes,
Alastair
