### PR TITLE
Code for issue #362

### DIFF
--- a/R/defaults.R
+++ b/R/defaults.R
@@ -87,7 +87,8 @@ opts_knit = new_defaults(list(
   tangle = FALSE, child = FALSE, parent = FALSE,
   cache.extra = NULL, aliases = NULL, root.dir = NULL,
   self.contained = TRUE, filter.chunk.end = TRUE, use.highlight = FALSE,
-  header = c(highlight = '', tikz = '', framed = '')
+  header = c(highlight = '', tikz = '', framed = ''),
+  md.dropback = 'html'
 ))
 ## header should not be set by hand unless you know what you are doing
 

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -15,9 +15,13 @@ hook_plot_md = function(x, options) {
     is.null(s <- options$out.extra)) {
     return(sprintf('![%s](%s%s) ', cap, base, .upload.url(x)))
   }
-  # additional styles require the HTML syntax
-  add = paste(sprintf('width="%s"', w), sprintf('height="%s"', h), s)
-  sprintf('<img src="%s%s" %s alt="%s" title="%s" /> ', base, .upload.url(x), add, cap, cap)
+  # additional styles require the HTML or LaTeX syntax
+  if (opts_knit$get('md.dropback') == 'html') {
+    add = paste(sprintf('width="%s"', w), sprintf('height="%s"', h), s)
+    sprintf('<img src="%s%s" %s alt="%s" title="%s" /> ', base, .upload.url(x), add, cap, cap)
+  } else if(opts_knit$get('md.dropback') == 'latex') {
+    return(hook_plot_tex(x, options))
+  }
 }
 
 #' @rdname output_hooks


### PR DESCRIPTION
Related to issue #362, I added a knitr option `md.dropback` which is by default set to `html`. If set to `latex`, then the output is redirected to the latex plot hook.

I think this option may be needed elsewhere when the code falls back to html for advanced options.

could you tell me what you think?

this works fo my simple case at least.
