### PR TITLE
Change cache.extra to be a per chunk option

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -53,7 +53,7 @@ call_block = function(block) {
   # Check cache
   if (params$cache) {
     content = list(params[setdiff(names(params), 'include')], getOption('width'))
-    content[[3L]] = eval_lang(opts_knit$get('cache.extra'))
+    content[[3L]] = eval_lang(opts_chunk$get('cache.extra'))
     hash = str_c(valid_path(params$cache.path, params$label), '_', digest(content))
     params$hash = hash
     if (cache$exists(hash)) {

--- a/R/defaults.R
+++ b/R/defaults.R
@@ -35,14 +35,14 @@ new_defaults = function(value = list()) {
 #' @examples opts_chunk$get('prompt'); opts_chunk$get('fig.keep')
 opts_chunk = new_defaults(list(
   eval = TRUE, echo = TRUE, results = 'markup', tidy = TRUE,
-  cache = FALSE, dependson = NULL, cache.path = 'cache/',
+  cache = FALSE, dependson = NULL, cache.path = 'cache/', cache.extra = NULL, 
   ref.label = NULL, child = NULL, engine = 'R',
   prompt = FALSE, comment = '##', autodep = FALSE,
   fig.keep = 'high', fig.show = 'asis', fig.align = 'default',
   fig.path = 'figure/', fig.ext = NULL, dev = 'pdf', dpi = 72,
   dev.args = NULL, fig.width = 7, fig.height = 7,
-  fig.env = 'figure', fig.cap = NULL, fig.scap = NULL, fig.lp = 'fig:', fig.pos = '',
-  out.width = NULL, out.height = NULL, out.extra = NULL,
+  fig.env = 'figure', fig.cap = NULL, fig.scap = NULL, fig.lp = 'fig:', 
+  fig.pos = '', out.width = NULL, out.height = NULL, out.extra = NULL,
   resize.width = NULL, resize.height = NULL,
   external = TRUE, sanitize = FALSE,
   highlight = TRUE, size = 'normalsize',
@@ -80,13 +80,12 @@ opts_chunk_attr = (function() {
 #' @export
 #' @examples opts_knit$get('verbose'); opts_knit$set(verbose = TRUE)  # change it
 opts_knit = new_defaults(list(
-  progress = TRUE, verbose = FALSE, out.format = NULL,
-  child.command = 'input', base.dir = NULL, base.url = NULL, child.path = '',
-  upload.fun = identity, animation.fun = NULL, global.device = FALSE,
-  eval.after = NULL, concordance = FALSE, sweave.penalty = 10,
-  tangle = FALSE, child = FALSE, parent = FALSE, documentation = FALSE,
-  cache.extra = NULL, aliases = NULL, root.dir = NULL,
-  self.contained = TRUE, filter.chunk.end = TRUE, use.highlight = FALSE,
+  progress = TRUE, verbose = FALSE, out.format = NULL, child.command = 'input', 
+  base.dir = NULL, base.url = NULL, child.path = '', upload.fun = identity, 
+  animation.fun = NULL, global.device = FALSE, eval.after = NULL, 
+  concordance = FALSE, sweave.penalty = 10, tangle = FALSE, child = FALSE, 
+  parent = FALSE, documentation = FALSE, aliases = NULL, root.dir = NULL, 
+  self.contained = TRUE, filter.chunk.end = TRUE, use.highlight = FALSE, 
   header = c(highlight = '', tikz = '', framed = '')
 ))
 ## header should not be set by hand unless you know what you are doing


### PR DESCRIPTION
Changes cache.extra to the be a per chunk option rather than a package option.
This allows you to set a particular chunk's cache to be invalidated if the
modification time of the file is updated for instance, among numerous other
uses.  The previous behavior can still be used by specifying the cache.extra
chunk option in the first chunk to make it the default, as with the regular
cache option. Fixes #404
