### PR TITLE
uniform syntax for Rcpp code chunks

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -62,9 +62,9 @@ eng_Rcpp = function(options) {
   # engine.opts is a list of arguments to be passed to Rcpp function, e.g.
   # engine.opts=list(plugin='RcppArmadillo')
   if (options$eval) {
-    message('Building shared library for Rcpp code chunk:')
+    message('Building shared library for Rcpp code chunk...')
     do.call(
-      if (grepl('\\[\\[Rcpp::', code)) Rcpp::sourceCpp else Rcpp::cppFunction,
+      Rcpp::sourceCpp,
       c(list(code = code, env = knit_global()), options$engine.opts)
     )
   }


### PR DESCRIPTION
Eliminate ambiguity caused by supporting multiple conventions for embedding Rcpp code.  This has a number of benefits:

(1) A common problem is to forget to adorn a function with // [[Rcpp::export]]. Unfortunately with the implicit mode switching we now have this unexpectedly "faults" the user into the cppFunction invocation style.

(2) Users will commonly need to do more than cppFunction offers (e.g. define multiple functions, define constants, define helper classes, etc.) so getting them used to sourceCpp up front will help them in the long run.

(3) Code chunks formatted for sourceCpp can be copied and pasted unmodified into a C++ file whereas code chunks formatted for cppFunction need the extra scaffolding added.

I'll send a pull request to update the knitr-examples document as well.
