### PR TITLE
added coffeescript engine

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -48,7 +48,7 @@ engine_output = function(options, code, out, extra = NULL) {
 eng_interpreted = function(options) {
   code = str_c(options$code, collapse = '\n')
   code_option = switch(options$engine, bash = '-c', haskell = '-e', perl = '-e',
-                       python = '-c', ruby = '-e', sh = '-c', zsh = '-c', '')
+                       python = '-c', ruby = '-e', sh = '-c', zsh = '-c', coffee = '-p -e', '')
   cmd = paste(shQuote(options$engine.path %n% options$engine),
               code_option, shQuote(code), options$engine.opts)
   out = if (options$eval) system(cmd, intern = TRUE) else ''
@@ -152,7 +152,7 @@ eng_sas = function(options) {
 }
 
 # set engines for interpreted languages
-for (i in c('awk', 'bash', 'gawk', 'haskell', 'perl', 'python', 'ruby', 'sed', 'sh', 'zsh')) {
+for (i in c('awk', 'bash', 'gawk', 'haskell', 'perl', 'python', 'ruby', 'sed', 'sh', 'zsh', 'coffee')) {
   knit_engines$set(setNames(list(eng_interpreted), i))
 }
 # additional engines


### PR DESCRIPTION
Added support for [CoffeeScript](http://coffeescript.org/). The `coffee` executable has an option to accept inline input `-e` and another option to print the compiled javascript `-p`. The usage would have to be:

``````
    <script type="text/javascript">
    ```{r , engine="coffee", results="asis"}
        alert "Hi!"
    ```
    </script>
``````

but I wonder if `results="asis"` could be set up as a default when using the `coffee` engine, and if the script tags could be auto-generated.
