### PR TITLE
Promote envir to named argument in kint2html

### DIFF
--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -74,12 +74,12 @@ knit2pdf = function(input, output = NULL, compiler = NULL, encoding = getOption(
 #' writeLines(c("# hello markdown", '```{r hello-random, echo=TRUE}', 'rnorm(5)', '```'), 'test.Rmd')
 #' if (require('markdown')) {knit2html('test.Rmd')
 #' if (interactive()) browseURL('test.html')}
-knit2html = function(input, ..., text = NULL, encoding = getOption('encoding')){
+knit2html = function(input, ..., envir = parent.frame(), text = NULL, encoding = getOption('encoding')){
   if (is.null(text)) {
-    out = knit(input, envir = parent.frame(), encoding = encoding)
+    out = knit(input, envir = envir, encoding = encoding)
     markdown::markdownToHTML(out, str_c(file_path_sans_ext(out), '.html'), ...)
   } else {
-    out = knit(text = text, envir = parent.frame(), encoding = encoding)
+    out = knit(text = text, envir = envir, encoding = encoding)
     markdown::markdownToHTML(text = out, ...)
   }
 }

--- a/man/knit2html.Rd
+++ b/man/knit2html.Rd
@@ -2,13 +2,18 @@
 \alias{knit2html}
 \title{Convert markdown to HTML using knit() and markdownToHTML()}
 \usage{
-knit2html(input, ..., text = NULL, encoding = getOption("encoding"))
+  knit2html(input, ..., envir = parent.frame(),
+    text = NULL, encoding = getOption("encoding"))
 }
 \arguments{
   \item{...}{options passed to
   \code{\link[markdown]{markdownToHTML}}}
 
   \item{input}{path of the input file}
+
+  \item{envir}{the environment in which the code chunks are
+  to be evaluated (can use \code{\link{new.env}()} to
+  guarantee an empty new environment)}
 
   \item{text}{a character vector as an alternative way to
   provide the input file}


### PR DESCRIPTION
Added an explicit named argument `envir` to the signature of `knit2html`
(after the `...` argument) because calls to `knit2html` from `knit_rd`
specified an `envir` argument which was being passed to
`markdown::markdonwToHTML` (via `...`) which does not have that argument
and it was not being passed to `kint` which is where it was supposed to go.

This caused two errors in `knit_rd()` The first was an error on every page with examples. Here is the output of one of those:

``` r
** knitting documentation of aes
  |>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                 |  50%
label: unnamed-chunk-1
  |>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>| 100%
  ordinary text without R code


Error in markdown::markdownToHTML(text = out, ...) : 
  unused argument(s) (envir = <environment>)
```

The second problem was that evaluation of the examples could overwrite variables in the `knit_rd` function if they had the same name. This happened with `ggplot2`'s `aes_group_order` page which defined `p` as a `ggplot` object while `p` was the iterating index in `knit_rd` and so when passed to `str_c` to create the output file name gave the error

> Error: Input to str_c should be atomic vectors

which would terminate the knitting.
