### PR TITLE
Add envir as parameter to knit2pdf

### DIFF
--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -41,8 +41,8 @@ rst2pdf = function(input, command = 'rst2pdf', options = '') {
 #' ## compile a reST file with rst2pdf
 #'
 #' ## knit2pdf(..., compiler = 'rst2pdf')
-knit2pdf = function(input, output = NULL, compiler = NULL, encoding = getOption('encoding'), ...) {
-  out = knit(input, output, envir = parent.frame(), encoding = encoding)
+knit2pdf = function(input, output = NULL, compiler = NULL, encoding = getOption('encoding'), envir = parent.frame(), ...) {
+  out = knit(input, output, envir = envir, encoding = encoding)
   owd = setwd(dirname(out)); on.exit(setwd(owd))
   if (!is.null(compiler)) {
     if (compiler == 'rst2pdf') {

--- a/man/knit2pdf.Rd
+++ b/man/knit2pdf.Rd
@@ -3,7 +3,7 @@
 \title{Convert Rnw or Rrst files to PDF using knit() and texi2pdf() or rst2pdf()}
 \usage{
 knit2pdf(input, output = NULL, compiler = NULL, encoding = getOption("encoding"), 
-    ...)
+    envir = parent.frame(), ...)
 }
 \arguments{
   \item{compiler}{a character string which gives the LaTeX
@@ -27,6 +27,10 @@ knit2pdf(input, output = NULL, compiler = NULL, encoding = getOption("encoding")
 
   \item{encoding}{the encoding of the input file; see
   \code{\link{file}}}
+
+  \item{envir}{the environment in which the code chunks are
+  to be evaluated (can use \code{\link{new.env}()} to
+  guarantee an empty new environment)}
 }
 \description{
   Knit the input Rnw or Rrst document, and compile to PDF


### PR DESCRIPTION
Also add "@param envir" line to knit2html documentation so that roxygen
doesn't overwrite knit2html man page.

The whitespace changes in knit2pdf.Rd are due to re-running `document('.')`
