### PR TITLE
knit() should no longer output to a file in child_mode()

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -138,7 +138,7 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL,
     input.dir = .knitEnv$input.dir; on.exit({.knitEnv$input.dir = input.dir}, add = TRUE)
     .knitEnv$input.dir = dirname(input) # record input dir
     ext = tolower(file_ext(input))
-    if (is.null(output)) output = basename(auto_out_name(input, ext))
+    if (is.null(output) && !child_mode()) output = basename(auto_out_name(input, ext))
     options(tikzMetricsDictionary = tikz_dict(input)) # cache tikz dictionary
     knit_concord$set(infile = input)
   }


### PR DESCRIPTION
Since 7d741e76dc6b3b58308c0bc6215091daf39cbae1 child documents are supposed to be directly appended to the final document and not \input'ed from external files. This commit prevents the external files from being written.
