### PR TITLE
pandoc rather than knitr

### DIFF
--- a/_posts/2013-03-06-pandoc.md
+++ b/_posts/2013-03-06-pandoc.md
@@ -17,14 +17,14 @@ Follow the instructions on the [Pandoc website](http://johnmacfarlane.net/pandoc
 
 ## Absolute beginners
 
-If you have no experience of using command line, you can try this function without any configurations. Write a Markdown file, say, `foo.md`, and throw it into `pandoc()`:
+If you have no experience using the command line, you can try this function without any configurations. Write a Markdown file, say, `foo.md`, and throw it into `pandoc()`:
 
 {% highlight r %}
 library(knitr)
-knit('foo.md', format='html')  # HTML
-knit('foo.md', format='latex') # LaTeX/PDF
-knit('foo.md', format='docx')  # MS Word
-knit('foo.md', format='odt')   # OpenDocument
+pandoc('foo.md', format='html')  # HTML
+pandoc('foo.md', format='latex') # LaTeX/PDF
+pandoc('foo.md', format='docx')  # MS Word
+pandoc('foo.md', format='odt')   # OpenDocument
 {% endhighlight %}
 
 But you often need some custom options like what we showed in the beginning. Now we explain how to pass such options to Pandoc.


### PR DESCRIPTION
I think in the pandoc help file ("Absolute beginners") `pandoc` was the intended command rather than `knit`.
