### PR TITLE
Minimum changes to use knitr as vignette engine for Rrst vignettes

### DIFF
--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -3,13 +3,12 @@
 vweave = vtangle = function(file, driver, syntax, encoding = '', quiet = FALSE, ...) {
   opts_knit$set(stop_on_error = 2L)  # should not hide errors
   if(grepl('\\.[Rr]md$', file)) {
-    engine <- knit2html 
+    knit2html(file, encoding = encoding, quiet = quiet, envir = globalenv()) 
   } else if (grepl('\\.[Rr]rst$', file)) {
-    engine <- knit2pdf
+    knit2pdf(file, encoding = encoding, envir = globalenv(), compiler="rst2pdf")
   } else {
-    engine <- knit
+    knit(file, encoding = encoding, quiet = quiet, envir = globalenv())
   }
-  engine(file, encoding = encoding, quiet = quiet, envir = globalenv())
 }
 
 body(vtangle)[3L] = expression(purl(file, encoding = encoding, quiet = quiet))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,7 +2,7 @@
   if (getRversion() >= '3.0.0') {
     tools::vignetteEngine(
       'knitr', weave = vweave, tangle = vtangle,
-      pattern = c('[.][rRsS](nw|tex)$', '[.][Rr](md|html)$', '[.][Rr]rst$',
+      pattern = c('[.][rRsS](nw|tex)$', '[.][Rr](md|html)$', '[.][Rr]rst$'),
       package = pkg
     )
   }


### PR DESCRIPTION
- I added the minimal changes to allow knitr to be a vignette engine for Rrst vignettes. 
- R CMD check knitr_\* doesn't give new warnings and I used it successfully to compile a Rrst vignette via R CMD build.  
- Maybe we should also update knit2pdf to have a `quiet` argument for consistency?
