### PR TITLE
latex header added to wrong child when compiling a child that uses set_parent() and has children of its own

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -36,7 +36,7 @@ insert_header_latex = function(doc, b) {
     i = i[1L]; l = str_locate(doc[i], b)
     tmp = str_sub(doc[i], l[, 1], l[, 2])
     str_sub(doc[i], l[,1], l[,2]) = str_c(tmp, make_header_latex())
-  } else if (parent_mode()) {
+  } else if (parent_mode() && !child_mode()) {
     # in parent mode, we fill doc to be a complete document
     doc[1L] = str_c(c(getOption('tikzDocumentDeclaration'), make_header_latex(),
                       .knitEnv$tikzPackages, "\\begin{document}", doc[1L]), collapse = '\n')


### PR DESCRIPTION
This solves an issue were only the inner most child document would get a document header (documentclass and premble) when compiling a child that sets set_parent() which also contains sub-children.

Without this the .tex file of such a document would look like this:

``` latex
Outer child output

\documentclass{...}
\usepackage{...}
\begin{document}

Inner child output

\end{document}

Further output from outer child
```

I have no idea if this breaks something else but everything seems to work fine for me.
