### PR TITLE
Add trailing newline to render_html output block

### DIFF
--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -156,7 +156,7 @@ render_html = function() {
   html.hook = function(name) {
     force(name)
     function (x, options) {
-      sprintf('<div class="%s"><pre class="knitr %s">%s</pre></div>', name, tolower(options$engine), x)
+      sprintf('<div class="%s"><pre class="knitr %s">%s</pre></div>\n', name, tolower(options$engine), x)
     }
   }
   h = opts_knit$get('header')


### PR DESCRIPTION
Fix for issue #556
