### PR TITLE
Setting SAS options for compatibility with LaTeX and standard fonts

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -51,7 +51,13 @@ eng_interpreted = function(options) {
   code = if (engine %in% c('highlight', 'Rscript', 'sas')) {
     f = basename(tempfile(engine, '.', switch(engine, sas = '.sas', Rscript = '.R', '.txt')))
     # SAS runs code in example.sas and creates 'listing' file example.lst and log file example.log
-    writeLines(options$code, f)
+    writeLines(
+      ifelse(
+        engine == 'sas',
+        c(
+          "OPTIONS NONUMBER NODATE PAGESIZE = MAX FORMCHAR = '|----|+|---+=|-/<>*' FORMDLIM=' ';",
+          options$code),
+          options$code), f)
     on.exit(unlink(f))
     if (engine == 'sas') {
       saslst = sub('[.]sas$', '.lst', f)


### PR DESCRIPTION
Default SAS options have some annoying qualities.
-  Page numbers and dates are standard (avoided by applying the NONUMBER and NODATE options)
-  Output is divided into separate pages. That is, SAS inserts a page break character at times.  PAGESIZE = MAX makes the number of lines per page as great as possible, limiting the number of page breaks inserted into the middle of output.  FORMDLIM = ' ' changes the page break character SAS uses by default into the relatively innocuous space.  LaTeX does not like the page break character.  It produces errors.
-  SAS output is written as plain text, but text intended to be read with a special SAS font.  In order to get the SAS output to look "right" without using the special SAS font, the FORMCHAR option is used.

Of course, users could just insert the options statement at the beginning of their SAS chunks, but I think that at least the pagesize, formchar, and formdlim options would be preferred by most users, most of the time.

Users can easily undo any of the SAS options set by the engine by inserting their own options statement at the start of their SAS chunks.
