### PR TITLE
also check against R-devel from Michael Rutter's PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,8 @@ install:
 script:
   - make install
   - make check
+  - sudo add-apt-repository -y ppa:marutter/rdev
+  - sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/marutter-rdev-precise.list"
+      -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+  - sudo apt-get dist-upgrade
+  - make check


### PR DESCRIPTION
With this patch, after successful run of `make check`, R is upgraded to R-devel and the check is re-run. I'm not sure if it's necessary to reinstall the package for this, it's not done currently.
