### PR TITLE
new 'asis' engine that will output the code without trying to process it

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -202,6 +202,13 @@ eng_cat = function(options) {
   ''
 }
 
+## output the code without processing it
+eng_asis = function(options) {
+  options$results = if (options$eval) 'asis' else 'hide'
+  options$echo = FALSE
+  engine_output(options, options$code, options$code)
+}
+
 # set engines for interpreted languages
 for (i in c('awk', 'bash', 'coffee', 'gawk', 'haskell', 'perl', 'python',
             'Rscript', 'ruby', 'sas', 'sed', 'sh', 'zsh')) {
@@ -212,7 +219,7 @@ rm(i)
 # additional engines
 knit_engines$set(
   highlight = eng_highlight, Rcpp = eng_Rcpp, tikz = eng_tikz, dot = eng_dot,
-  c = eng_c, asy = eng_dot, cat = eng_cat
+  c = eng_c, asy = eng_dot, cat = eng_cat, asis = eng_asis
 )
 
 # possible values for engines (for auto-completion in RStudio)


### PR DESCRIPTION
I did not figure how to do something like the following without a new engine. I wanted to be able to conditionally (based on some R variables) output some LaTeX code without using `cat` and having to protect characters in large amounts of text.
But may be I missed something...

``` latex

\documentclass[a4paper, 11pt]{article}
\begin{document}

<<choose>>=
res <- runif(1)
res
@

<<this, eval=res<0.5, engine='asis'>>=
\begin{itemize}
  \item I did \emph{this} because $res<0.5$.
  \item I might do \emph{that} another time.
\end{itemize}
@

<<that, eval=res>=0.5, engine='asis'>>=
I did \emph{that} because $res>=0.5$ but I might do \emph{this} another time.
@

\end{document}
```
