### PR TITLE
Move note about the output argument from note sec to the argument sec.

### DIFF
--- a/man/knit2pdf.Rd
+++ b/man/knit2pdf.Rd
@@ -23,7 +23,9 @@ knit2pdf(input, output = NULL, compiler = NULL, envir = parent.frame(), quiet = 
 
   \item{output}{path of the output file for \code{knit()};
   if \code{NULL}, this function will try to guess and it
-  will be under the current working directory}
+  will be under the current working directory. Note it specifies the
+  output filename to be passed to the PDF compiler (e.g. a tex
+  document) instead of the PDF filename.}
 
   \item{envir}{the environment in which the code chunks are
   to be evaluated (can use \code{\link{new.env}()} to
@@ -41,11 +43,6 @@ knit2pdf(input, output = NULL, compiler = NULL, envir = parent.frame(), quiet = 
 \description{
   Knit the input Rnw or Rrst document, and compile to PDF
   using \code{texi2pdf} or \code{rst2pdf}.
-}
-\note{
-  The \code{output} argument specifies the output filename
-  to be passed to the PDF compiler (e.g. a tex document)
-  instead of the PDF filename.
 }
 \examples{
 #' compile with xelatex


### PR DESCRIPTION
For a short note about one argument, it is better to be included in the main document of the argument, rather than in a separate note section, which is easily ignored by the users.
