### PR TITLE
Math mode should be always enabled for inline numbers in LaTeX

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,13 +14,15 @@
 
 ## BUG FIXES
 
-- fixed a regression bug that makes knitr fail to add `\ensuremath{}` to scientific notations of numbers of the form `10^{n}` in LaTeX output (thanks, Jeffrey Racine)
-
 - due to the change in evaluate v0.5, evaluate() may return the raw values of expressions, but the S3 method wrap() does not know how to handle them; now these values are just ignored (thanks, Dan Tenenbaum)
 
 - fixed a bug for dep_auto() that may occur if old cache files generated from previous versions of knitr are used (thanks, Jeffrey Racine)
 
 - fixed the bug reported at http://stackoverflow.com/q/19166724/559676: the inline hook did not work well with non-numeric values, e.g. Date (thanks, Waldir Leoncio)
+
+## MINOR CHANGES
+
+- all numbers are formatted as math in inline LaTeX, for negative numbers, old-style vs. lining figures, infinity symbol, corner cases such as `10^{n}`, ... (thanks, Jeffrey Racine and Kirill Müller)
 
 # CHANGES IN knitr VERSION 1.5
 

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -179,8 +179,7 @@ hook_plot_tex = function(x, options) {
 .inline.hook.tex = function(x) {
   if (is.numeric(x)) {
     x = format_sci(x, 'latex')
-    i = grep('(^|\\\\times )10\\^\\{-?\\d+\\}$', x)
-    x[i] = sprintf('\\ensuremath{%s}', x[i])
+    x = sprintf('\\ensuremath{%s}', x)
     if (getOption('OutDec') != '.') x = sprintf('\\text{%s}', x)
   }
   .inline.hook(x)

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -33,7 +33,7 @@ assert(
   'the inline hook for Rnw applies \\ensuremath{} correctly',
   .inline.hook.tex(1e4) == '\\ensuremath{10^{4}}',
   .inline.hook.tex(c(1.2345e10,2* pnorm(-(3:4)))) ==
-    "\\ensuremath{1.2345\\times 10^{10}}, 0.0027, \\ensuremath{6.3342\\times 10^{-5}}"
+    "\\ensuremath{1.2345\\times 10^{10}}, \\ensuremath{0.0027}, \\ensuremath{6.3342\\times 10^{-5}}"
 )
 
 assert(


### PR DESCRIPTION
Reasons:
- Negative numbers get a proper "minus" sign (not a dash)
- Old-style figures can be enabled for a document, but usually aren't for math
  mode (cf. texdoc newtxdoc)
- Special characters such as \infty (cf. #629)
