### PR TITLE
Roxygenize using yihui's fork of roxygen2

### DIFF
--- a/man/Sweave2knitr.Rd
+++ b/man/Sweave2knitr.Rd
@@ -2,7 +2,8 @@
 \alias{Sweave2knitr}
 \title{Convert Sweave to knitr documents}
 \usage{
-Sweave2knitr(file, output = gsub("[.]([^.]+)$", "-knitr.\\\\1", file), 
+  Sweave2knitr(file,
+    output = gsub("[.]([^.]+)$", "-knitr.\\\\1", file),
     encoding = getOption("encoding"), text = NULL)
 }
 \arguments{
@@ -76,16 +77,16 @@ Sweave2knitr(file, output = gsub("[.]([^.]+)$", "-knitr.\\\\1", file),
   supported.
 }
 \examples{
-Sweave2knitr(text = "<<echo=TRUE>>=")  # this is valid
-Sweave2knitr(text = "<<png=true>>=")  # dev='png'
-Sweave2knitr(text = "<<eps=TRUE, pdf=FALSE, results=tex, width=5, prefix.string=foo>>=")
-Sweave2knitr(text = "<<,png=false,fig=TRUE>>=")
-Sweave2knitr(text = "\\\\SweaveOpts{echo=false}")
-Sweave2knitr(text = "\\\\SweaveInput{hello.Rnw}")
+Sweave2knitr(text='<<echo=TRUE>>=') # this is valid
+Sweave2knitr(text="<<png=true>>=") # dev='png'
+Sweave2knitr(text="<<eps=TRUE, pdf=FALSE, results=tex, width=5, prefix.string=foo>>=")
+Sweave2knitr(text="<<,png=false,fig=TRUE>>=")
+Sweave2knitr(text="\\\\SweaveOpts{echo=false}")
+Sweave2knitr(text="\\\\SweaveInput{hello.Rnw}")
 # Sweave example in utils
 testfile = system.file("Sweave", "Sweave-test-1.Rnw", package = "utils")
-Sweave2knitr(testfile, output = "Sweave-test-knitr.Rnw")
-knit("Sweave-test-knitr.Rnw")  # or knit2pdf() directly
+Sweave2knitr(testfile, output = 'Sweave-test-knitr.Rnw')
+knit('Sweave-test-knitr.Rnw') # or knit2pdf() directly
 }
 \references{
   The motivation of the changes in the syntax:
@@ -94,3 +95,4 @@ knit("Sweave-test-knitr.Rnw")  # or knit2pdf() directly
 \seealso{
   \code{\link{Sweave}}, \code{\link{gsub}}
 }
+

--- a/man/all_labels.Rd
+++ b/man/all_labels.Rd
@@ -2,7 +2,7 @@
 \alias{all_labels}
 \title{Get all chunk labels in a document}
 \usage{
-all_labels()
+  all_labels()
 }
 \value{
   A character vector.
@@ -11,3 +11,4 @@ all_labels()
   This function returns all chunk labels as a chracter
   vector.
 }
+

--- a/man/all_patterns.Rd
+++ b/man/all_patterns.Rd
@@ -12,14 +12,13 @@
  $ asciidoc:List of 6
  $ textile :List of 5}
 \usage{
-all_patterns
+  all_patterns
 }
 \description{
   This object is a named list of all built-in patterns.
 }
 \examples{
-all_patterns$rnw
-all_patterns$html
+all_patterns$rnw; all_patterns$html
 
 str(all_patterns)
 }
@@ -27,3 +26,4 @@ str(all_patterns)
   Usage: \url{http://yihui.name/knitr/patterns}
 }
 \keyword{datasets}
+

--- a/man/chunk_hook.Rd
+++ b/man/chunk_hook.Rd
@@ -6,15 +6,15 @@
 \alias{hook_webgl}
 \title{Built-in chunk hooks to extend knitr}
 \usage{
-hook_rgl(before, options, envir)
+  hook_rgl(before, options, envir)
 
-hook_pdfcrop(before, options, envir)
+  hook_pdfcrop(before, options, envir)
 
-hook_optipng(before, options, envir)
+  hook_optipng(before, options, envir)
 
-hook_plot_custom(before, options, envir)
+  hook_plot_custom(before, options, envir)
 
-hook_webgl(before, options, envir)
+  hook_webgl(before, options, envir)
 }
 \arguments{
   \item{before,options,envir}{see references}
@@ -82,3 +82,4 @@ knit_hooks$set(rgl = hook_rgl)
   \code{\link[rgl]{rgl.snapshot}},
   \code{\link[rgl]{rgl.postscript}}
 }
+

--- a/man/dep_auto.Rd
+++ b/man/dep_auto.Rd
@@ -2,7 +2,7 @@
 \alias{dep_auto}
 \title{Build automatic dependencies among chunks}
 \usage{
-dep_auto(path = opts_chunk$get("cache.path"))
+  dep_auto(path = opts_chunk$get("cache.path"))
 }
 \arguments{
   \item{path}{the path to the dependency file}
@@ -37,3 +37,4 @@ dep_auto(path = opts_chunk$get("cache.path"))
 \seealso{
   \code{\link{dep_prev}}
 }
+

--- a/man/dep_prev.Rd
+++ b/man/dep_prev.Rd
@@ -2,7 +2,7 @@
 \alias{dep_prev}
 \title{Make later chunks depend on previous chunks}
 \usage{
-dep_prev()
+  dep_prev()
 }
 \value{
   \code{NULL}; the internal dependency structure is updated
@@ -21,3 +21,4 @@ dep_prev()
 \seealso{
   \code{\link{dep_auto}}
 }
+

--- a/man/eclipse_theme.Rd
+++ b/man/eclipse_theme.Rd
@@ -2,7 +2,7 @@
 \alias{eclipse_theme}
 \title{Download and convert a theme from eclipsecolorthemes.org to CSS}
 \usage{
-eclipse_theme(id)
+  eclipse_theme(id)
 }
 \arguments{
   \item{id}{id of theme to save as CSS}
@@ -21,7 +21,7 @@ eclipse_theme(id)
 \examples{
 ## http://www.eclipsecolorthemes.org/?view=theme&id=1
 \dontrun{
-opts_knit$set(out.format = "latex")
+opts_knit$set(out.format = 'latex')
 (css = eclipse_theme(1))
 thm = knit_theme$get(css)
 knit_theme$set(thm)
@@ -36,3 +36,4 @@ knit_theme$set(thm)
 \seealso{
   \code{\link{knit_theme}}
 }
+

--- a/man/fig_path.Rd
+++ b/man/fig_path.Rd
@@ -2,7 +2,7 @@
 \alias{fig_path}
 \title{Path for figure files}
 \usage{
-fig_path(suffix = "", options = opts_current$get())
+  fig_path(suffix = "", options = opts_current$get())
 }
 \arguments{
   \item{suffix}{a suffix of the filename}
@@ -33,6 +33,7 @@ fig_path(suffix = "", options = opts_current$get())
   This makes the filenames safe to LaTeX.
 }
 \examples{
-fig_path(".pdf", list(fig.path = "figure/abc-", label = "first-plot"))
-fig_path(1:10, list(fig.path = "foo-", label = "bar"))
+fig_path('.pdf', list(fig.path='figure/abc-', label='first-plot'))
+fig_path(1:10, list(fig.path='foo-', label='bar'))
 }
+

--- a/man/hook_animation.Rd
+++ b/man/hook_animation.Rd
@@ -4,11 +4,11 @@
 \alias{hook_scianimator}
 \title{Hooks to create animations in HTML output}
 \usage{
-hook_ffmpeg_html(x, options)
+  hook_ffmpeg_html(x, options)
 
-hook_scianimator(x, options)
+  hook_scianimator(x, options)
 
-hook_r2swf(x, options)
+  hook_r2swf(x, options)
 }
 \arguments{
   \item{x}{a character vector of length 2 ; \code{x[1]} is
@@ -28,3 +28,4 @@ hook_r2swf(x, options)
   \code{animation.fun}, e.g. you can set
   \code{opts_knit$set(animation.fun = hook_scianimator)}.
 }
+

--- a/man/hook_document.Rd
+++ b/man/hook_document.Rd
@@ -2,7 +2,7 @@
 \alias{hook_movecode}
 \title{Some potentially useful document hooks}
 \usage{
-hook_movecode(x)
+  hook_movecode(x)
 }
 \arguments{
   \item{x}{a character string (the content of the whole
@@ -35,11 +35,10 @@ hook_movecode(x)
   every figure/table environment must have a label.
 }
 \examples{
-\dontrun{
-knit_hooks$set(document = hook_movecode)
-}
+\dontrun{knit_hooks$set(document = hook_movecode)}
 # see example 103 at https://github.com/yihui/knitr-examples
 }
 \references{
   \url{http://yihui.name/knitr/hooks}
 }
+

--- a/man/hook_plot.Rd
+++ b/man/hook_plot.Rd
@@ -7,17 +7,17 @@
 \alias{hook_plot_textile}
 \title{Default plot hooks for different output formats}
 \usage{
-hook_plot_tex(x, options)
+  hook_plot_tex(x, options)
 
-hook_plot_html(x, options)
+  hook_plot_html(x, options)
 
-hook_plot_md(x, options)
+  hook_plot_md(x, options)
 
-hook_plot_rst(x, options)
+  hook_plot_rst(x, options)
 
-hook_plot_asciidoc(x, options)
+  hook_plot_asciidoc(x, options)
 
-hook_plot_textile(x, options)
+  hook_plot_textile(x, options)
 }
 \arguments{
   \item{x}{a character vector of length 2 ; \code{x[1]} is
@@ -55,16 +55,15 @@ hook_plot_textile(x, options)
 ## this is what happens for a chunk like this
 
 ## <<foo-bar-plot, dev='pdf', fig.align='right'>>=
-hook_plot_tex(c("foo-bar-plot", "pdf"), opts_chunk$merge(list(fig.align = "right")))
+hook_plot_tex(c('foo-bar-plot', 'pdf'), opts_chunk$merge(list(fig.align='right')))
 
 ## <<bar, dev='tikz'>>=
-hook_plot_tex(c("bar", "tikz"), opts_chunk$merge(list(dev = "tikz")))
+hook_plot_tex(c('bar', 'tikz'), opts_chunk$merge(list(dev='tikz')))
 
 ## <<foo, dev='pdf', fig.show='animate', interval=.1>>=
 
 ## 5 plots are generated in this chunk
-hook_plot_tex(c("foo5", "pdf"), opts_chunk$merge(list(fig.show = "animate", 
-    interval = 0.1, fig.cur = 5, fig.num = 5)))
+hook_plot_tex(c('foo5', 'pdf'), opts_chunk$merge(list(fig.show='animate',interval=.1,fig.cur=5, fig.num=5)))
 }
 \references{
   \url{http://yihui.name/knitr/hooks}
@@ -72,3 +71,4 @@ hook_plot_tex(c("foo5", "pdf"), opts_chunk$merge(list(fig.show = "animate",
 \seealso{
   \code{\link{hook_plot_custom}}
 }
+

--- a/man/image_uri.Rd
+++ b/man/image_uri.Rd
@@ -2,7 +2,7 @@
 \alias{image_uri}
 \title{Encode an image file to a data URI}
 \usage{
-image_uri(f)
+  image_uri(f)
 }
 \arguments{
   \item{f}{the path to the image file}
@@ -17,9 +17,9 @@ image_uri(f)
   used in the \code{img} tag in HTML.
 }
 \examples{
-uri = image_uri(file.path(R.home("doc"), "html", "logo.jpg"))
-cat(sprintf("<img src=\"\%s\" />", uri), file = "logo.html")
-if (interactive()) browseURL("logo.html")  # you can check its HTML source
+uri = image_uri(file.path(R.home('doc'), 'html', 'logo.jpg'))
+cat(sprintf('<img src="\%s" />', uri), file = 'logo.html')
+if (interactive()) browseURL('logo.html') # you can check its HTML source
 }
 \author{
   Wush Wu and Yihui Xie
@@ -27,3 +27,4 @@ if (interactive()) browseURL("logo.html")  # you can check its HTML source
 \references{
   \url{http://en.wikipedia.org/wiki/Data_URI_scheme}
 }
+

--- a/man/imgur_upload.Rd
+++ b/man/imgur_upload.Rd
@@ -2,7 +2,7 @@
 \alias{imgur_upload}
 \title{Upload an image to imgur.com}
 \usage{
-imgur_upload(file, key = "9f3460e67f308f6")
+  imgur_upload(file, key = "9f3460e67f308f6")
 }
 \arguments{
   \item{file}{the path to the image file to be uploaded}
@@ -39,19 +39,16 @@ imgur_upload(file, key = "9f3460e67f308f6")
 }
 \examples{
 \dontrun{
-f = tempfile(fileext = ".png")
-png(f)
-plot(rnorm(100), main = R.version.string)
-dev.off()
+f = tempfile(fileext = '.png')
+png(f); plot(rnorm(100), main = R.version.string); dev.off()
 
 res = imgur_upload(f)
 res  # link to original URL of the image
-attr(res, "XML")  # all information
-if (interactive()) 
-    browseURL(res)
+attr(res, 'XML')  # all information
+if (interactive()) browseURL(res)
 
 ## to use your own key
-opts_knit$set(upload.fun = function(file) imgur_upload(file, key = "your imgur key"))
+opts_knit$set(upload.fun = function(file) imgur_upload(file, key = 'your imgur key'))
 }
 }
 \author{
@@ -62,3 +59,4 @@ opts_knit$set(upload.fun = function(file) imgur_upload(file, key = "your imgur k
   Imgur API version 3: \url{http://api.imgur.com/}; a demo:
   \url{http://yihui.name/knitr/demo/upload/}
 }
+

--- a/man/kable.Rd
+++ b/man/kable.Rd
@@ -2,8 +2,8 @@
 \alias{kable}
 \title{Create tables in LaTeX, HTML, Markdown and reStructuredText}
 \usage{
-kable(x, format, digits = getOption("digits"), row.names = NA, align, output = TRUE, 
-    ...)
+  kable(x, format, digits = getOption("digits"),
+    row.names = NA, align, output = TRUE, ...)
 }
 \arguments{
   \item{x}{an R object (typically a matrix or data frame)}
@@ -53,25 +53,25 @@ kable(x, format, digits = getOption("digits"), row.names = NA, align, output = T
   option \code{results='asis'}.
 }
 \examples{
-kable(head(iris), format = "latex")
-kable(head(iris), format = "html")
+kable(head(iris), format = 'latex')
+kable(head(iris), format = 'html')
 # use the booktabs package
-kable(mtcars, format = "latex", booktabs = TRUE)
+kable(mtcars, format = 'latex', booktabs = TRUE)
 # use the longtable package
-kable(matrix(1000, ncol = 5), format = "latex", digits = 2, longtable = TRUE)
+kable(matrix(1000, ncol=5), format = 'latex', digits = 2, longtable = TRUE)
 # add some table attributes
-kable(head(iris), format = "html", table.attr = "id=\"mytable\"")
+kable(head(iris), format = 'html', table.attr = 'id="mytable"')
 # reST output
-kable(head(mtcars), format = "rst")
+kable(head(mtcars), format = 'rst')
 # no row names
-kable(head(mtcars), format = "rst", row.names = FALSE)
+kable(head(mtcars), format = 'rst', row.names = FALSE)
 # R Markdown/Github Markdown tables
-kable(head(mtcars[, 1:5]), format = "markdown")
+kable(head(mtcars[, 1:5]), format = 'markdown')
 # Pandoc tables
-kable(head(mtcars), format = "pandoc")
+kable(head(mtcars), format = 'pandoc')
 # save the value
-x = kable(mtcars, format = "html", output = FALSE)
-cat(x, sep = "\\n")
+x = kable(mtcars, format = 'html', output = FALSE)
+cat(x, sep = '\\n')
 # can also set options(knitr.table.format = 'html') so that the output is HTML
 }
 \references{
@@ -83,3 +83,4 @@ cat(x, sep = "\\n")
 \seealso{
   Other R packages such as \pkg{xtable} and \pkg{tables}.
 }
+

--- a/man/knit.Rd
+++ b/man/knit.Rd
@@ -3,10 +3,11 @@
 \alias{purl}
 \title{Knit a document}
 \usage{
-knit(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE, 
-    envir = parent.frame(), encoding = getOption("encoding"))
+  knit(input, output = NULL, tangle = FALSE, text = NULL,
+    quiet = FALSE, envir = parent.frame(),
+    encoding = getOption("encoding"))
 
-purl(..., documentation = 1L)
+  purl(..., documentation = 1L)
 }
 \arguments{
   \item{input}{path of the input file}
@@ -141,7 +142,7 @@ purl(..., documentation = 1L)
 }
 \examples{
 library(knitr)
-(f = system.file("examples", "knitr-minimal.Rnw", package = "knitr"))
+(f = system.file('examples', 'knitr-minimal.Rnw', package = 'knitr'))
 knit(f)  # compile to tex
 
 purl(f)  # tangle R code
@@ -156,3 +157,4 @@ purl(f, documentation = 2)  # also include documentation
   See \code{citation('knitr')} for the citation
   information.
 }
+

--- a/man/knit2html.Rd
+++ b/man/knit2html.Rd
@@ -2,7 +2,8 @@
 \alias{knit2html}
 \title{Convert markdown to HTML using knit() and markdownToHTML()}
 \usage{
-knit2html(input, output = NULL, ..., envir = parent.frame(), text = NULL, quiet = FALSE, 
+  knit2html(input, output = NULL, ...,
+    envir = parent.frame(), text = NULL, quiet = FALSE,
     encoding = getOption("encoding"))
 }
 \arguments{
@@ -41,12 +42,12 @@ knit2html(input, output = NULL, ..., envir = parent.frame(), text = NULL, quiet 
 }
 \examples{
 # a minimal example
-writeLines(c("# hello markdown", "```{r hello-random, echo=TRUE}", "rnorm(5)", "```"), 
-    "test.Rmd")
-knit2html("test.Rmd")
-if (interactive()) browseURL("test.html")
+writeLines(c("# hello markdown", '```{r hello-random, echo=TRUE}', 'rnorm(5)', '```'), 'test.Rmd')
+knit2html('test.Rmd')
+if (interactive()) browseURL('test.html')
 }
 \seealso{
   \code{\link{knit}},
   \code{\link[markdown]{markdownToHTML}}
 }
+

--- a/man/knit2pdf.Rd
+++ b/man/knit2pdf.Rd
@@ -2,7 +2,8 @@
 \alias{knit2pdf}
 \title{Convert Rnw or Rrst files to PDF using knit() and texi2pdf() or rst2pdf()}
 \usage{
-knit2pdf(input, output = NULL, compiler = NULL, envir = parent.frame(), quiet = FALSE, 
+  knit2pdf(input, output = NULL, compiler = NULL,
+    envir = parent.frame(), quiet = FALSE,
     encoding = getOption("encoding"), ...)
 }
 \arguments{
@@ -61,3 +62,4 @@ knit2pdf(input, output = NULL, compiler = NULL, envir = parent.frame(), quiet = 
   \code{\link{knit}}, \code{\link[tools]{texi2pdf}},
   \code{\link{rst2pdf}}
 }
+

--- a/man/knit2wp.Rd
+++ b/man/knit2wp.Rd
@@ -2,8 +2,9 @@
 \alias{knit2wp}
 \title{Knit an R Markdown document and post it to WordPress}
 \usage{
-knit2wp(input, title = "A post from knitr", ..., shortcode = FALSE, 
-    encoding = getOption("encoding"), publish = TRUE)
+  knit2wp(input, title = "A post from knitr", ...,
+    shortcode = FALSE, encoding = getOption("encoding"),
+    publish = TRUE)
 }
 \arguments{
   \item{input}{the filename of the Rmd document}
@@ -46,3 +47,4 @@ knit2wp(input, title = "A post from knitr", ..., shortcode = FALSE,
 \references{
   \url{http://yihui.name/knitr/demo/wordpress/}
 }
+

--- a/man/knit_child.Rd
+++ b/man/knit_child.Rd
@@ -2,7 +2,7 @@
 \alias{knit_child}
 \title{Knit a child document}
 \usage{
-knit_child(..., options = NULL)
+  knit_child(..., options = NULL)
 }
 \arguments{
   \item{...}{arguments passed to \code{\link{knit}}}
@@ -35,12 +35,11 @@ knit_child(..., options = NULL)
   document.
 }
 \examples{
-## you can write \\Sexpr{knit_child('child-doc.Rnw')} in an Rnw file 'main.Rnw'
-## to input results from child-doc.Rnw in main.tex
+## you can write \\Sexpr{knit_child('child-doc.Rnw')} in an Rnw file 'main.Rnw' to input results from child-doc.Rnw in main.tex
 
-## comment out the child doc by \\Sexpr{knit_child('child-doc.Rnw', eval =
-## FALSE)}
+## comment out the child doc by \\Sexpr{knit_child('child-doc.Rnw', eval = FALSE)}
 }
 \references{
   \url{http://yihui.name/knitr/demo/child/}
 }
+

--- a/man/knit_engines.Rd
+++ b/man/knit_engines.Rd
@@ -8,7 +8,7 @@
  $ merge  :function (values)  
  $ restore:function (target = value)}
 \usage{
-knit_engines
+  knit_engines
 }
 \description{
   This object controls how to execute the code from
@@ -37,11 +37,11 @@ knit_engines
   engine.opts='-v'}.
 }
 \examples{
-knit_engines$get("python")
-knit_engines$get("awk")
+knit_engines$get('python'); knit_engines$get('awk')
 names(knit_engines$get())
 }
 \references{
   Usage: \url{http://yihui.name/knitr/objects}
 }
 \keyword{datasets}
+

--- a/man/knit_exit.Rd
+++ b/man/knit_exit.Rd
@@ -2,7 +2,7 @@
 \alias{knit_exit}
 \title{Exit knitting early}
 \usage{
-knit_exit(append)
+  knit_exit(append)
 }
 \arguments{
   \item{append}{a character vector to be appended to the
@@ -26,3 +26,4 @@ knit_exit(append)
 \examples{
 # see https://github.com/yihui/knitr-examples/blob/master/096-knit-exit.Rmd
 }
+

--- a/man/knit_expand.Rd
+++ b/man/knit_expand.Rd
@@ -2,7 +2,9 @@
 \alias{knit_expand}
 \title{A simple macro preprocessor for templating purposes}
 \usage{
-knit_expand(file, ..., text = readLines(file, warn = FALSE), delim = c("{{", "}}"))
+  knit_expand(file, ...,
+    text = readLines(file, warn = FALSE),
+    delim = c("{{", "}}"))
 }
 \arguments{
   \item{file}{the template file}
@@ -31,7 +33,7 @@ knit_expand(file, ..., text = readLines(file, warn = FALSE), delim = c("{{", "}}
 }
 \examples{
 # see the knit_expand vignette
-if (interactive()) browseVignettes(package = "knitr")
+if (interactive()) browseVignettes(package='knitr')
 }
 \references{
   This function was inspired by the pyexpander
@@ -39,3 +41,4 @@ if (interactive()) browseVignettes(package = "knitr")
   (\url{http://www.gnu.org/software/m4/}), thanks to Frank
   Harrell.
 }
+

--- a/man/knit_global.Rd
+++ b/man/knit_global.Rd
@@ -2,7 +2,7 @@
 \alias{knit_global}
 \title{The global environment in which code chunks are evaluated}
 \usage{
-knit_global()
+  knit_global()
 }
 \description{
   This function makes the environment of a code chunk
@@ -15,3 +15,4 @@ knit_global()
   R's global environment by default. You can call functions
   like \code{\link{ls}()} on this environment.
 }
+

--- a/man/knit_hooks.Rd
+++ b/man/knit_hooks.Rd
@@ -8,7 +8,7 @@
  $ merge  :function (values)  
  $ restore:function (target = value)}
 \usage{
-knit_hooks
+  knit_hooks
 }
 \description{
   A hook is a function of a pre-defined form (arguments)
@@ -17,8 +17,7 @@ knit_hooks
   set hooks in this package.
 }
 \examples{
-knit_hooks$get("source")
-knit_hooks$get("inline")
+knit_hooks$get('source'); knit_hooks$get('inline')
 }
 \references{
   Usage: \url{http://yihui.name/knitr/objects}
@@ -27,3 +26,4 @@ knit_hooks$get("inline")
   \url{http://yihui.name/knitr/hooks}
 }
 \keyword{datasets}
+

--- a/man/knit_patterns.Rd
+++ b/man/knit_patterns.Rd
@@ -8,7 +8,7 @@
  $ merge  :function (values)  
  $ restore:function (target = value)}
 \usage{
-knit_patterns
+  knit_patterns
 }
 \description{
   Patterns are regular expressions and will be used in
@@ -19,18 +19,18 @@ knit_patterns
 }
 \examples{
 library(knitr)
-opat = knit_patterns$get()  # old pattern list (to restore later)
+opat = knit_patterns$get() # old pattern list (to restore later)
 
 apats = all_patterns  # a list of all built-in patterns
 str(apats)
-knit_patterns$set(apats[["rnw"]])  # set pattern list from apats
+knit_patterns$set(apats[['rnw']]) # set pattern list from apats
 
-knit_patterns$get(c("chunk.begin", "chunk.end", "inline.code"))
+knit_patterns$get(c('chunk.begin', 'chunk.end', 'inline.code'))
 
 ## a customized pattern list; has to empty the original patterns first!
 knit_patterns$restore()
 ## we may want to use this in an HTML document
-knit_patterns$set(list(chunk.begin = "<!--helloR\\\\s+(.*)", chunk.end = "^byeR-->"))
+knit_patterns$set(list(chunk.begin = '<!--helloR\\\\s+(.*)', chunk.end = '^byeR-->'))
 str(knit_patterns$get())
 
 knit_patterns$set(opat)  # put the old patterns back
@@ -42,3 +42,4 @@ knit_patterns$set(opat)  # put the old patterns back
   \url{http://yihui.name/knitr/patterns}
 }
 \keyword{datasets}
+

--- a/man/knit_rd.Rd
+++ b/man/knit_rd.Rd
@@ -3,9 +3,10 @@
 \alias{knit_rd_all}
 \title{Knit package documentation}
 \usage{
-knit_rd(pkg, links = tools::findHTMLlinks(), frame = TRUE)
+  knit_rd(pkg, links = tools::findHTMLlinks(),
+    frame = TRUE)
 
-knit_rd_all()
+  knit_rd_all()
 }
 \arguments{
   \item{pkg}{package name}
@@ -35,12 +36,12 @@ knit_rd_all()
   (e.g.  the link to the DESCRITION file).
 }
 \examples{
-\dontrun{
-knit_rd("maps")
-knit_rd("rpart")
-setwd(system.file("html", package = "ggplot2"))
-knit_rd("ggplot2")  # time-consuming!
+\dontrun{knit_rd('maps')
+knit_rd('rpart')
+setwd(system.file('html', package = 'ggplot2'))
+knit_rd('ggplot2') # time-consuming!
 
 knit_rd_all()  # this may take really long time if you have many packages installed
 }
 }
+

--- a/man/knit_theme.Rd
+++ b/man/knit_theme.Rd
@@ -6,7 +6,7 @@
  $ set:function (theme)  
  $ get:function (theme = NULL)}
 \usage{
-knit_theme
+  knit_theme
 }
 \description{
   This object can be used to set or get themes in
@@ -22,15 +22,14 @@ knit_theme
   examples below.
 }
 \examples{
-opts_knit$set(out.format = "latex")
-knit_theme$set("edit-vim")
+opts_knit$set(out.format='latex'); knit_theme$set('edit-vim')
 
 knit_theme$get()  # names of all available themes
 
-thm = knit_theme$get("acid")  # parse the theme to a list
+thm = knit_theme$get('acid')  # parse the theme to a list
 knit_theme$set(thm)
 
-opts_knit$set(out.format = NULL)  # restore option
+opts_knit$set(out.format=NULL) # restore option
 }
 \author{
   Ramnath Vaidyanathan and Yihui Xie
@@ -44,3 +43,4 @@ opts_knit$set(out.format = NULL)  # restore option
   \code{\link{eclipse_theme}} (use Eclipse themes)
 }
 \keyword{datasets}
+

--- a/man/knitr-package.Rd
+++ b/man/knitr-package.Rd
@@ -31,3 +31,4 @@
   you are an Sweave user, see \code{\link{Sweave2knitr}} on
   how to convert Sweave files to \pkg{knitr}.
 }
+

--- a/man/opts_chunk.Rd
+++ b/man/opts_chunk.Rd
@@ -9,9 +9,9 @@
  $ merge  :function (values)  
  $ restore:function (target = value)}
 \usage{
-opts_chunk
+  opts_chunk
 
-opts_current
+  opts_current
 }
 \description{
   Options for R code chunks. When running R code, the
@@ -30,8 +30,7 @@ opts_current
   often need to set global options in a separate chunk.
 }
 \examples{
-opts_chunk$get("prompt")
-opts_chunk$get("fig.keep")
+opts_chunk$get('prompt'); opts_chunk$get('fig.keep')
 }
 \references{
   Usage: \url{http://yihui.name/knitr/objects}
@@ -40,3 +39,4 @@ opts_chunk$get("fig.keep")
   \url{http://yihui.name/knitr/options#chunk_options}
 }
 \keyword{datasets}
+

--- a/man/opts_knit.Rd
+++ b/man/opts_knit.Rd
@@ -8,7 +8,7 @@
  $ merge  :function (values)  
  $ restore:function (target = value)}
 \usage{
-opts_knit
+  opts_knit
 }
 \description{
   Options including whether to use a progress bar when
@@ -28,12 +28,11 @@ opts_knit
   without loading \pkg{knitr}.
 }
 \examples{
-opts_knit$get("verbose")
-opts_knit$set(verbose = TRUE)  # change it
+opts_knit$get('verbose'); opts_knit$set(verbose = TRUE)  # change it
 \dontrun{
 # for unnamed chunks, use 'fig' as the figure prefix
-options(knitr.unnamed.chunk.label = "fig")
-knit("001-minimal.Rmd")  # from https://github.com/yihui/knitr-examples
+options(knitr.unnamed.chunk.label='fig')
+knit('001-minimal.Rmd') # from https://github.com/yihui/knitr-examples
 }
 }
 \references{
@@ -43,3 +42,4 @@ knit("001-minimal.Rmd")  # from https://github.com/yihui/knitr-examples
   \url{http://yihui.name/knitr/options#package_options}
 }
 \keyword{datasets}
+

--- a/man/opts_template.Rd
+++ b/man/opts_template.Rd
@@ -8,7 +8,7 @@
  $ merge  :function (values)  
  $ restore:function (target = value)}
 \usage{
-opts_template
+  opts_template
 }
 \description{
   Creates a template binding a label to a set of chunk
@@ -24,3 +24,4 @@ opts_template$set(myfigures = list(fig.height = 4, fig.width = 4))
 # the above is equivalent to <<foo, fig.height=4, fig.width=4>>=
 }
 \keyword{datasets}
+

--- a/man/output_hooks.Rd
+++ b/man/output_hooks.Rd
@@ -10,23 +10,24 @@
 \alias{render_textile}
 \title{Set output hooks for different output formats}
 \usage{
-render_latex()
+  render_latex()
 
-render_sweave()
+  render_sweave()
 
-render_listings()
+  render_listings()
 
-render_html()
+  render_html()
 
-render_markdown(strict = FALSE)
+  render_markdown(strict = FALSE)
 
-render_jekyll(highlight = c("pygments", "prettify", "none"), extra = "")
+  render_jekyll(highlight = c("pygments", "prettify", "none"),
+    extra = "")
 
-render_rst(strict = FALSE)
+  render_rst(strict = FALSE)
 
-render_asciidoc()
+  render_asciidoc()
 
-render_textile()
+  render_textile()
 }
 \arguments{
   \item{strict}{whether to use strict markdown or reST
@@ -89,3 +90,4 @@ render_textile()
   prettify.js:
   \url{http://code.google.com/p/google-code-prettify/}
 }
+

--- a/man/pandoc.Rd
+++ b/man/pandoc.Rd
@@ -2,7 +2,8 @@
 \alias{pandoc}
 \title{A Pandoc wrapper to convert Markdown documents to other formats}
 \usage{
-pandoc(input, format = "html", config = getOption("config.pandoc"), ext = NA)
+  pandoc(input, format = "html",
+    config = getOption("config.pandoc"), ext = NA)
 }
 \arguments{
   \item{input}{a character vector of the Markdown
@@ -50,7 +51,7 @@ pandoc(input, format = "html", config = getOption("config.pandoc"), ext = NA)
   lines.
 }
 \examples{
-system("pandoc -h")  # see possible output formats
+system('pandoc -h') # see possible output formats
 }
 \references{
   Pandoc: \url{http://johnmacfarlane.net/pandoc/}; Examples
@@ -60,3 +61,4 @@ system("pandoc -h")  # see possible output formats
 \seealso{
   \code{\link{read.dcf}}
 }
+

--- a/man/pat_fun.Rd
+++ b/man/pat_fun.Rd
@@ -9,21 +9,21 @@
 \alias{pat_textile}
 \title{Set regular expressions to read input documents}
 \usage{
-pat_rnw()
+  pat_rnw()
 
-pat_brew()
+  pat_brew()
 
-pat_tex()
+  pat_tex()
 
-pat_html()
+  pat_html()
 
-pat_md()
+  pat_md()
 
-pat_rst()
+  pat_rst()
 
-pat_asciidoc()
+  pat_asciidoc()
 
-pat_textile()
+  pat_textile()
 }
 \value{
   The patterns object \code{\link{knit_patterns}} is
@@ -38,9 +38,8 @@ pat_textile()
 }
 \examples{
 ## see how knit_patterns is modified
-knit_patterns$get()
-pat_rnw()
-knit_patterns$get()
+knit_patterns$get(); pat_rnw(); knit_patterns$get()
 
 knit_patterns$restore()  # empty the list
 }
+

--- a/man/rand_seed.Rd
+++ b/man/rand_seed.Rd
@@ -4,7 +4,7 @@
 \title{An unevaluated expression to return .Random.seed if exists}
 \format{language {  if (exists(".Random.seed", envir = globalenv())) ; get(".Random.seed", envir = globalenv()) }}
 \usage{
-rand_seed
+  rand_seed
 }
 \description{
   This expression returns \code{.Random.seed} when
@@ -18,10 +18,11 @@ rand_seed
 }
 \examples{
 eval(rand_seed)
-rnorm(1)  # .Random.seed is created (or modified)
+rnorm(1) # .Random.seed is created (or modified)
 eval(rand_seed)
 }
 \references{
   \url{http://yihui.name/knitr/demo/cache/}
 }
 \keyword{datasets}
+

--- a/man/read_chunk.Rd
+++ b/man/read_chunk.Rd
@@ -3,10 +3,11 @@
 \alias{read_demo}
 \title{Read chunks from an external script}
 \usage{
-read_chunk(path, lines = readLines(path, warn = FALSE), labels = NULL, from = NULL, 
-    to = NULL, from.offset = 0L, to.offset = 0L)
+  read_chunk(path, lines = readLines(path, warn = FALSE),
+    labels = NULL, from = NULL, to = NULL,
+    from.offset = 0L, to.offset = 0L)
 
-read_demo(topic, package = NULL, ...)
+  read_demo(topic, package = NULL, ...)
 }
 \arguments{
   \item{path}{the path to the R script}
@@ -79,25 +80,24 @@ read_demo(topic, package = NULL, ...)
 ## put this in foo.R and read_chunk('foo.R')
 
 ## ---- my-label ----
-1 + 1
-lm(y ~ x, data = data.frame(x = 1:10, y = rnorm(10)))
+1+1
+lm(y~x, data=data.frame(x=1:10,y=rnorm(10)))
 
 ## later you can use <<my-label>>= to reference this chunk
 
 ## the 2nd approach
-code = c("#@a", "1+1", "#@b", "#@a", "rnorm(10)", "#@b")
-read_chunk(lines = code, labels = "foo")  # put all code into one chunk named foo
-read_chunk(lines = code, labels = "foo", from = 2, to = 2)  # line 2 into chunk foo
-read_chunk(lines = code, labels = c("foo", "bar"), from = c(1, 4), to = c(3, 6))
+code = c("#@a", '1+1', "#@b", "#@a", 'rnorm(10)', "#@b")
+read_chunk(lines = code, labels = 'foo') # put all code into one chunk named foo
+read_chunk(lines = code, labels = 'foo', from = 2, to = 2) # line 2 into chunk foo
+read_chunk(lines = code, labels = c('foo', 'bar'), from = c(1, 4), to = c(3, 6))
 # automatically figure out 'to'
-read_chunk(lines = code, labels = c("foo", "bar"), from = c(1, 4))
-read_chunk(lines = code, labels = c("foo", "bar"), from = "^#@a", to = "^#@b")
-read_chunk(lines = code, labels = c("foo", "bar"), from = "^#@a", to = "^#@b", 
-    from.offset = 1, to.offset = -1)
+read_chunk(lines = code, labels = c('foo', 'bar'), from = c(1, 4))
+read_chunk(lines = code, labels = c('foo', 'bar'), from = "^#@a", to = "^#@b")
+read_chunk(lines = code, labels = c('foo', 'bar'), from = "^#@a", to = "^#@b", from.offset = 1, to.offset = -1)
 
 ## later you can use, e.g., <<foo>>=
-knitr:::knit_code$get()  # use this to check chunks in the current session
-knitr:::knit_code$restore()  # clean up the session
+knitr:::knit_code$get() # use this to check chunks in the current session
+knitr:::knit_code$restore() # clean up the session
 }
 \author{
   Yihui Xie; the idea of the second approach came from
@@ -107,3 +107,4 @@ knitr:::knit_code$restore()  # clean up the session
 \references{
   \url{http://yihui.name/knitr/demo/externalization/}
 }
+

--- a/man/read_rforge.Rd
+++ b/man/read_rforge.Rd
@@ -2,7 +2,7 @@
 \alias{read_rforge}
 \title{Read source code from R-Forge}
 \usage{
-read_rforge(path, project, extra = "")
+  read_rforge(path, project, extra = "")
 }
 \arguments{
   \item{path}{relative path to the source script on
@@ -22,11 +22,10 @@ read_rforge(path, project, extra = "")
   on R-Forge.
 }
 \examples{
-\dontrun{
-read_rforge("rgl/R/axes.R", project = "rgl")
-read_rforge("rgl/R/axes.R", project = "rgl", extra = "&revision=519")
-}
+\dontrun{read_rforge('rgl/R/axes.R', project = 'rgl')
+read_rforge('rgl/R/axes.R', project = 'rgl', extra='&revision=519')}
 }
 \author{
   Yihui Xie and Peter Ruckdeschel
 }
+

--- a/man/rocco.Rd
+++ b/man/rocco.Rd
@@ -2,7 +2,7 @@
 \alias{rocco}
 \title{Knit R Markdown using the classic Docco style}
 \usage{
-rocco(input, ...)
+  rocco(input, ...)
 }
 \arguments{
   \item{input}{path of the input R Markdown file}
@@ -27,16 +27,12 @@ rocco(input, ...)
   (show code).
 }
 \examples{
-rocco_view = function(input) {
-    if (!file.exists(input)) 
-        return()
-    o = rocco(input, header = "", quiet = TRUE)
-    if (interactive()) 
-        browseURL(o)
-}
+rocco_view=function(input) {if (!file.exists(input)) return()
+o=rocco(input, header='', quiet=TRUE)
+if (interactive()) browseURL(o)}
 # knit these two vignettes using the docco style
-rocco_view(system.file("doc", "docco-classic.Rmd", package = "knitr"))
-rocco_view(system.file("doc", "knit_expand.Rmd", package = "knitr"))
+rocco_view(system.file('doc', 'docco-classic.Rmd', package = 'knitr'))
+rocco_view(system.file('doc', 'knit_expand.Rmd', package = 'knitr'))
 }
 \author{
   Weicheng Zhu and Yihui Xie
@@ -45,3 +41,4 @@ rocco_view(system.file("doc", "knit_expand.Rmd", package = "knitr"))
   The Docco package by Jeremy Ashkenas:
   \url{https://github.com/jashkenas/docco}
 }
+

--- a/man/rst2pdf.Rd
+++ b/man/rst2pdf.Rd
@@ -2,7 +2,7 @@
 \alias{rst2pdf}
 \title{A wrapper for rst2pdf}
 \usage{
-rst2pdf(input, command = "rst2pdf", options = "")
+  rst2pdf(input, command = "rst2pdf", options = "")
 }
 \arguments{
   \item{input}{the input rst file}
@@ -33,3 +33,4 @@ rst2pdf(input, command = "rst2pdf", options = "")
 \seealso{
   \code{\link{knit2pdf}}
 }
+

--- a/man/set_alias.Rd
+++ b/man/set_alias.Rd
@@ -2,7 +2,7 @@
 \alias{set_alias}
 \title{Set aliases for chunk options}
 \usage{
-set_alias(...)
+  set_alias(...)
 }
 \arguments{
   \item{...}{named arguments (argument names are aliases,
@@ -19,7 +19,7 @@ set_alias(...)
   elements in this vector are the real option names.
 }
 \examples{
-set_alias(w = "fig.width", h = "fig.height")
-# then we can use options w and h in chunk headers instead of fig.width and
-# fig.height
+set_alias(w = 'fig.width', h = 'fig.height')
+# then we can use options w and h in chunk headers instead of fig.width and fig.height
 }
+

--- a/man/set_header.Rd
+++ b/man/set_header.Rd
@@ -2,7 +2,7 @@
 \alias{set_header}
 \title{Set the header information}
 \usage{
-set_header(...)
+  set_header(...)
 }
 \arguments{
   \item{...}{the header components; currently possible
@@ -44,6 +44,7 @@ set_header(...)
   \pkg{listings} package.
 }
 \examples{
-set_header(tikz = "\\\\usepackage{tikz}")
-opts_knit$get("header")
+set_header(tikz = '\\\\usepackage{tikz}')
+opts_knit$get('header')
 }
+

--- a/man/set_parent.Rd
+++ b/man/set_parent.Rd
@@ -2,7 +2,7 @@
 \alias{set_parent}
 \title{Specify the parent document of child documents}
 \usage{
-set_parent(parent)
+  set_parent(parent)
 }
 \arguments{
   \item{parent}{path to the parent document (relative to
@@ -46,3 +46,4 @@ set_parent(parent)
 \references{
   \url{http://yihui.name/knitr/demo/child/}
 }
+

--- a/man/spin.Rd
+++ b/man/spin.Rd
@@ -2,9 +2,12 @@
 \alias{spin}
 \title{Spin goat's hair into wool}
 \usage{
-spin(hair, knit = TRUE, report = TRUE, text = NULL, envir = parent.frame(), 
-    format = c("Rmd", "Rnw", "Rhtml", "Rtex", "Rrst"), doc = "^#+'[ ]?", 
-    comment = c("^[# ]*/[*]", "^.*[*]/ *$"), precious = !knit && is.null(text))
+  spin(hair, knit = TRUE, report = TRUE, text = NULL,
+    envir = parent.frame(),
+    format = c("Rmd", "Rnw", "Rhtml", "Rtex", "Rrst"),
+    doc = "^#+'[ ]?",
+    comment = c("^[# ]*/[*]", "^.*[*]/ *$"),
+    precious = !knit && is.null(text))
 }
 \arguments{
   \item{hair}{the path to the R script}
@@ -72,23 +75,23 @@ spin(hair, knit = TRUE, report = TRUE, text = NULL, envir = parent.frame(),
 \examples{
 #' write normal text like this and chunk options like below
 
-# + label, opt=value
+#+ label, opt=value
 
 # /*
 #' these lines are treated as comments in spin()
-1 + 1
+1+1
 # */
 
-(s = system.file("examples", "knitr-spin.R", package = "knitr"))
+(s = system.file('examples', 'knitr-spin.R', package = 'knitr'))
 spin(s)  # default markdown
-o = spin(s, knit = FALSE)  # convert only; do not make a purse yet
-knit2html(o)  # compile to HTML
+o = spin(s, knit = FALSE) # convert only; do not make a purse yet
+knit2html(o) # compile to HTML
 
 # other formats
-spin(s, FALSE, format = "Rnw")  # you need to write documentclass after #'
-spin(s, FALSE, format = "Rhtml")
-spin(s, FALSE, format = "Rtex")
-spin(s, FALSE, format = "Rrst")
+spin(s, FALSE, format='Rnw')  # you need to write documentclass after #'
+spin(s, FALSE, format='Rhtml')
+spin(s, FALSE, format='Rtex')
+spin(s, FALSE, format='Rrst')
 }
 \author{
   Yihui Xie, with the original idea from Richard FitzJohn
@@ -101,3 +104,4 @@ spin(s, FALSE, format = "Rrst")
 \seealso{
   \code{\link{stitch}} (feed a template with an R script)
 }
+

--- a/man/stitch.Rd
+++ b/man/stitch.Rd
@@ -4,12 +4,13 @@
 \alias{stitch_rmd}
 \title{Automatically create a report based on an R script and a template}
 \usage{
-stitch(script, template = system.file("misc", "knitr-template.Rnw", package = "knitr"), 
+  stitch(script,
+    template = system.file("misc", "knitr-template.Rnw", package = "knitr"),
     output = NULL, text = NULL, envir = parent.frame())
 
-stitch_rhtml(...)
+  stitch_rhtml(...)
 
-stitch_rmd(...)
+  stitch_rmd(...)
 }
 \arguments{
   \item{script}{path to the R script}
@@ -57,18 +58,17 @@ stitch_rmd(...)
   chunk.
 }
 \examples{
-s = system.file("misc", "stitch-test.R", package = "knitr")
-\dontrun{
-stitch(s)
-}
+s = system.file('misc', 'stitch-test.R', package = 'knitr')
+\dontrun{stitch(s)}
 
 # HTML report
-stitch(s, system.file("misc", "knitr-template.Rhtml", package = "knitr"))
+stitch(s, system.file('misc', 'knitr-template.Rhtml', package = 'knitr'))
 
 # or convert markdown to HTML
-stitch(s, system.file("misc", "knitr-template.Rmd", package = "knitr"))
+stitch(s, system.file('misc', 'knitr-template.Rmd', package = 'knitr'))
 }
 \seealso{
   \code{\link{spin}} (turn a specially formatted R script
   to a report)
 }
+

--- a/man/wrap_rmd.Rd
+++ b/man/wrap_rmd.Rd
@@ -2,7 +2,7 @@
 \alias{wrap_rmd}
 \title{Wrap long lines in Rmd files}
 \usage{
-wrap_rmd(file, width = 80, text = NULL, backup)
+  wrap_rmd(file, width = 80, text = NULL, backup)
 }
 \arguments{
   \item{file}{the input Rmd file}
@@ -34,6 +34,7 @@ wrap_rmd(file, width = 80, text = NULL, backup)
   the future.
 }
 \examples{
-wrap_rmd(text = c("```", "1+1", "```", "- a list item", "> a quote", "", 
-    paste(rep("this is a normal paragraph", 5), collapse = " ")))
+wrap_rmd(text = c('```', '1+1', '```', '- a list item', '> a quote', '',
+paste(rep('this is a normal paragraph', 5), collapse = ' ')))
 }
+

--- a/man/write_bib.Rd
+++ b/man/write_bib.Rd
@@ -2,7 +2,7 @@
 \alias{write_bib}
 \title{Generate BibTeX bibliography databases for R packages}
 \usage{
-write_bib(x = .packages(), file = "", tweak = TRUE, 
+  write_bib(x = .packages(), file = "", tweak = TRUE,
     prefix = getOption("knitr.bib.prefix", "R-"))
 }
 \arguments{
@@ -61,13 +61,13 @@ write_bib(x = .packages(), file = "", tweak = TRUE,
   R packages are being updated.
 }
 \examples{
-write_bib(c("RGtk2", "gWidgets"), file = "R-GUI-pkgs.bib")
-write_bib(c("animation", "rgl", "knitr", "ggplot2"))
-write_bib(c("base", "parallel", "MASS"))  # base and parallel are identical
-write_bib("cluster", prefix = "")  # a empty prefix
-write_bib("digest", prefix = "R-pkg-")  # a new prefix
-write_bib(c("rpart", "survival"))
-write_bib(c("rpart", "survival"), tweak = FALSE)  # original version
+write_bib(c('RGtk2', 'gWidgets'), file = 'R-GUI-pkgs.bib')
+write_bib(c('animation', 'rgl', 'knitr', 'ggplot2'))
+write_bib(c('base', 'parallel', 'MASS'))  # base and parallel are identical
+write_bib('cluster', prefix = '')  # a empty prefix
+write_bib('digest', prefix = 'R-pkg-')  # a new prefix
+write_bib(c('rpart', 'survival'))
+write_bib(c('rpart', 'survival'), tweak = FALSE) # original version
 
 # what tweak=TRUE does
 str(knitr:::.tweak.bib)
@@ -75,3 +75,4 @@ str(knitr:::.tweak.bib)
 \author{
   Yihui Xie and Michael Friendly
 }
+


### PR DESCRIPTION
These are the differences I'm seeing on my system. Below the `sessionInfo()` after loading only `roxygen2` is shown.

```
> sessionInfo()
R version 3.0.2 (2013-09-25)
Platform: x86_64-pc-linux-gnu (64-bit)

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C              
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8   
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C            
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] roxygen2_2.2.2.99

loaded via a namespace (and not attached):
[1] brew_1.0-6    digest_0.6.3  stringr_0.6.2 tools_3.0.2  
```
