### PR TITLE
mentioning pander and ascii packages as alternative kable functions

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -19,7 +19,9 @@
 #' @param ... other arguments (see examples)
 #' @return A character vector of the table source code. When \code{output =
 #'   TRUE}, the results are also written into the console as a side-effect.
-#' @seealso Other R packages such as \pkg{xtable} and \pkg{tables}.
+#' @seealso Other R packages such as \pkg{xtable} and \pkg{tables} for HTML and
+#'   LaTeX tables, and \pkg{ascii} and \pkg{pander} for different flavors of
+#'   markdown output and some advanced features and table styles.
 #' @note The tables for \code{format = 'markdown'} also work for Pandoc when the
 #'   \code{pipe_tables} extension is enabled (this is the default behavior for
 #'   Pandoc >= 1.10).


### PR DESCRIPTION
As discussed at https://github.com/yihui/knitr/commit/057f41da16e503c2ffe991809b14021b10939a11#commitcomment-4556724, I added a few more characters to the `\seealso` sectinn of `kable` about my `pander` package:
- special function: http://rapporter.github.io/pander/#tables
- general S3 method: http://rapporter.github.io/pander/#generic-pander-method

PS: sorry for the lame updates in the `Rd` file, hopefully my Emacs did not scew up anything important. Please let me know if I should tweak something in this pull request.
