### PR TITLE
Make knit “vanilla”

### DIFF
--- a/inst/bin/knit
+++ b/inst/bin/knit
@@ -1,4 +1,4 @@
-#!/usr/bin/env Rscript
+#!/usr/bin/env Rscript --vanilla
 
 local({
   p = commandArgs(TRUE)


### PR DESCRIPTION
Currently knit loads custom .Rprofile environment files. This is
probably not what you normally want from it – if nothing else it makes
it harder to reproduce (= recompile on another system) the document.

This pull request adds the `--vanilla` flag to change this.
