### PR TITLE
output file and line when printing error

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -13,6 +13,7 @@ call_block = function(block) {
   af = opts_knit$get('eval.after'); al = opts_knit$get('aliases')
   if (!is.null(al) && !is.null(af)) af = c(af, names(al[af %in% al]))
   params = opts_chunk$merge(block$params)
+  params$id = block$id
   for (o in setdiff(names(params), af)) params[o] = list(eval_lang(params[[o]]))
 
   params = fix_options(params)  # for compatibility

--- a/R/output.R
+++ b/R/output.R
@@ -360,6 +360,7 @@ knit_exit = function(append) {
   invisible()
 }
 
+#' @include defaults.R
 knit_log = new_defaults()  # knitr log for errors, warnings and messages
 
 #' Wrap evaluated results for output
@@ -403,8 +404,11 @@ msg_wrap = function(message, type, options) {
   # when output format is latex, do not wrap messages (let latex deal with wrapping)
   if (!length(grep('\n', message)) && !out_format(c('latex', 'listings', 'sweave')))
     message = str_wrap(message, width = getOption('width'))
+  file = knit_concord$get('infile')
+  lines = paste(current_lines(options$id), collapse = '-')
   knit_log$set(setNames(
-    list(c(knit_log$get(type), str_c('Chunk ', options$label, ':\n  ', message))),
+    list(c(knit_log$get(type), str_c(file, ':', lines,
+                                     ': Chunk ', options$label, ':\n  ', message))),
     type
   ))
   knit_hooks$get(type)(comment_out(message, options$comment), options)

--- a/tests/testit/test-parser.R
+++ b/tests/testit/test-parser.R
@@ -17,15 +17,15 @@ assert(
 
 
 res = parse_inline(c('aaa \\Sexpr{x}', 'bbb \\Sexpr{NA} and \\Sexpr{1+2}',
-                     'another expression \\Sexpr{rnorm(10)}'), all_patterns$rnw)
+                     'another expression \\Sexpr{rnorm(10)}'), all_patterns$rnw, NULL)
 assert(
   'parse_inline() parses inline text',
   identical(res$code, c('x', 'NA', '1+2', 'rnorm(10)')),
   identical(nchar(res$input), 81L),
   # empty inline code is not recognized
-  identical(parse_inline('\\Sexpr{}', all_patterns$rnw)$code, character(0)),
+  identical(parse_inline('\\Sexpr{}', all_patterns$rnw, NULL)$code, character(0)),
   # can use > in HTML inline code
-  identical(parse_inline('<!--rinline "<a>" -->', all_patterns$html)$code, ' "<a>" ')
+  identical(parse_inline('<!--rinline "<a>" -->', all_patterns$html, NULL)$code, ' "<a>" ')
 )
 
 knit_code$restore()


### PR DESCRIPTION
Example output:

```
test.Rmd:10-11: Chunk unnamed-chunk-2:
  Error: non-numeric argument to binary operator 


Number of messages:
error 
    1 
```

Input:

``````
Test.

```{r echo=F}
options(knitr.package.verbose=T)
opts_chunk$set()
```

Bar.

```{r}
1 + 'a'
```

Baz.
``````

The erroring chunk is actually three lines long, this one-off error will be handled by a separate PR.

Fixes #688.
