### PR TITLE
fix computation of chunk lines in current_line() so that chunk header and footer are not included

### DIFF
--- a/R/concordance.R
+++ b/R/concordance.R
@@ -14,8 +14,8 @@ concord_mode = function() {
 current_lines = function(i) {
   # a helpr function to return line numbers for block i
   n = knit_concord$get('inlines')
-  n0 = sum(head(n, i - 1L)) + 1L; n1 = n0 + n[i] - 1L
-  c(n0, n1)
+  n1 = sum(head(n, i)); n0 = n1 - n[i] + 2
+  unique(c(min(n0, n1), n1))
 }
 
 ## generate concordance for RStudio


### PR DESCRIPTION
- if chunk has length 1, returned vector has only one instead of 2 elements
- if (and only if) chunk has length 0, line with chunk header is reported

See `git log` for a sample test file.
