### PR TITLE
pandoc() do not set '-t html' option if configuration provides '-t' opti...

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -67,7 +67,7 @@ pandoc_one = function(input, format, ext, cfg) {
   })
   cfg = cfg[setdiff(names(cfg), c('o', 'output', 'format'))]
   cmd = paste('pandoc', pandoc_arg(cfg), pandoc_arg(cmn), '-f markdown',
-              '-t', format, '-o', out, paste(shQuote(input), collapse = ' '))
+              if ('-t' %in% names(cfg) && '-t' %in% names(cmn)) {c('-t', format)}, '-o', out, paste(shQuote(input), collapse = ' '))
   message('executing ', cmd)
   if (system(cmd) == 0L) out else stop('conversion failed')
 }


### PR DESCRIPTION
pandoc() do not set '-t html' option if configuration provides '-t' options. (fixes #697)
