### PR TITLE
hooks-chunk.R::run_hooks - Add the hook name to options.

### DIFF
--- a/R/hooks-chunk.R
+++ b/R/hooks-chunk.R
@@ -9,6 +9,7 @@ run_hooks = function(before, options, envir = knit_global()) {
   for (i in nms) {
     if (!is.null(options[[i]])) {
       ## run only when option is not NULL
+      options$hook <- i
       res = hooks.a[[i]](before = before, options = options, envir = envir)
       if (is.character(res)) out = c(out, res)
     }


### PR DESCRIPTION
- Generic hook functions should have a way to know which param was used to trigger them.

Signed-off-by: Thell Fowler thell@tbfowler.name

Yihui,
If a third party package provides a function for a document author to use then the document author should be free to name the param as they desire and the hook function should be allowed to discover that name.

If you need any convincing just say the word.
