### PR TITLE
Remove smaller digits as defaults

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -128,9 +128,9 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
     knit_log$restore()
     on.exit(chunk_counter(reset = TRUE), add = TRUE) # restore counter
     adjust_opts_knit()
-    ## turn off fancy quotes, use smaller digits/width, warn immediately
+    ## turn off fancy quotes, warn immediately
     oopts = options(
-      useFancyQuotes = FALSE, digits = 4L, width = opts_knit$get('width'),
+      useFancyQuotes = FALSE, width = opts_knit$get('width'),
       knitr.in.progress = TRUE, device = pdf_null
     )
     on.exit(options(oopts), add = TRUE)


### PR DESCRIPTION
A smaller digits value causes some problems with printing results correctly. See #768 for more details.

Also see
- http://stackoverflow.com/q/24409841/559676
- http://stackoverflow.com/q/24503264/559676
