### PR TITLE
Redirect an engine's stderr to its stdout

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -8,7 +8,7 @@
 #'
 #' The engine function has one argument \code{options}: the source code of the
 #' current chunk is in \code{options$code}. Usually we can call external
-#' programs to run the code via \code{\link{system}}. Other chunk options are
+#' programs to run the code via \code{\link{system2}}. Other chunk options are
 #' also contained in this argument, e.g. \code{options$echo} and
 #' \code{options$eval}, etc.
 #'


### PR DESCRIPTION
This replaces the `system` call with a `system2` call, which allows the standard error to be redirected to the `out` variable in `engines.R`. Hence, the new behavior is to merge stdout and stderr, i.e.

``` python
from random import choice

print(choice([1, 2, 3, 4]))
print(choice2([1, 2, 3, 4]))
```

```
## 4
## Traceback (most recent call last):
##   File "<string>", line 5, in <module>
## NameError: name 'choice2' is not defined
```

Up to now, knitr's default behavior on errors was to not include any error messages. This behavior can still be realized by using the new `engine.stderr = FALSE` code chunk option.
