### PR TITLE
Rxhtml now recognised as a file extension for xhtml output

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -283,7 +283,7 @@ auto_out_name = function(input, ext = tolower(file_ext(input))) {
   base = sans_ext(input)
   name = if (opts_knit$get('tangle')) c(base, '.R') else
     if (ext %in% c('rnw', 'snw')) c(base, '.tex') else
-      if (ext %in% c('rmd', 'rmarkdown', 'rhtml', 'rhtm', 'rtex', 'stex', 'rrst', 'rtextile'))
+      if (ext %in% c('rmd', 'rmarkdown', 'rhtml', 'rhtm', 'rxhtml', 'rtex', 'stex', 'rrst', 'rtextile'))
         c(base, '.', substring(ext, 2L)) else
           if (grepl('_knit_', input)) sub('_knit_', '', input) else
             if (ext != 'txt') c(base, '.txt') else c(base, '-out.', ext)

--- a/R/pattern.R
+++ b/R/pattern.R
@@ -141,7 +141,7 @@ detect_pattern = function(text, ext) {
   if (!missing(ext)) {
     if (ext %in% c('rnw', 'snw', 'stex')) return('rnw')
     if (ext == 'brew') return('brew')
-    if (ext %in% c('htm', 'html', 'rhtm', 'rhtml')) return('html')
+    if (ext %in% c('htm', 'html', 'rhtm', 'rhtml', 'rxhtml')) return('html')
     if (ext %in% c('rmd', 'rmarkdown', 'markdown', 'md')) return('md')
     if (ext %in% c('rst', 'rrst')) return('rst')
   }


### PR DESCRIPTION
knitr already works for xhtml files, but you had to manually specify the output file name.

This small patch lets knitr recognise that input files with an Rxhtml extension should be converted in the same way as html files, and that the output should be given an xhtml extension.
