### PR TITLE
Use `[[` rather than `$` to extract/subassign options

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -24,7 +24,7 @@ call_block = function(block) {
 
   label = ref.label = params$label
   if (!is.null(params$ref.label)) ref.label = sc_split(params$ref.label)
-  params$code = params$code %n% unlist(knit_code$get(ref.label), use.names = FALSE)
+  params[["code"]] = params[["code"]] %n% unlist(knit_code$get(ref.label), use.names = FALSE)
   if (opts_knit$get('progress')) print(block)
 
   if (!is.null(params$child)) {


### PR DESCRIPTION
`[[` is safer, because it doesn't perform partial matching. Partial matching in the one line that I've edited ended up costing me 5+ hours of debugging, after its revision between knitr 1.5 and 1.6 broke this piece of code: http://stackoverflow.com/questions/11030898/knitr-how-to-align-code-and-plot-side-by-side/23396783#23396783 . (The problem ended up being that the implementation of the newly exposed `code` option ended up capturing -- via partial matching -- the value of my custom `codefig` argument, using that value (TRUE) to overwrite the actual code returned by `unlist(knit_code$get(ref.label), use.names = FALSE)`.)
