### PR TITLE
Change coffeescript flags so that code is evaluated, not just compiled

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -66,7 +66,7 @@ eng_interpreted = function(options) {
       f
     }, haskell = paste('-e', shQuote(paste(':script', f))), f)
   } else paste(switch(
-    engine, bash = '-c', coffee = '-p -e', perl = '-e', python = '-c',
+    engine, bash = '-c', coffee = '-e', perl = '-e', python = '-c',
     ruby = '-e', scala = '-e', sh = '-c', zsh = '-c', NULL
   ), shQuote(paste(options$code, collapse = '\n')))
   # FIXME: for these engines, the correct order is options + code + file


### PR DESCRIPTION
Currently when using `engine="coffee"` the code is run with the `-p` flag which prints the compiled code instead of the output.

For example, the following `.Rmd` file

``````
```{r engine="coffee"}
x = 42
console.log "The answer is ", x
```
``````

compiles to the following markdown

``````
```coffee
x = 42
console.log "The answer is ", x
```

```
## (function() {
##   var x;
##
##   x = 42;
##
##   console.log("The answer is ", x);
##
## }).call(this);
```
``````

By removing the `-p` flag the code is evaluated and the resulting markdown is

``````
```coffee
x = 42
console.log "The answer is ", x
```

```
## The answer is  42
```
``````

which seems to be the desired output given my experience using `knitr` with R and python.
