### PR TITLE
Proposed solution for #814

### DIFF
--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -84,10 +84,12 @@ knit2pdf = function(input, output = NULL, compiler = NULL, envir = parent.frame(
 #' if (interactive()) browseURL('test.html')
 knit2html = function(input, output = NULL, ..., envir = parent.frame(), text = NULL,
                      quiet = FALSE, encoding = getOption('encoding')) {
-  out = knit(input, output, text = text, envir = envir, encoding = encoding, quiet = quiet)
+  out = knit(input, text = text, envir = envir, encoding = encoding, quiet = quiet)
+  if (is.null(output))
+    output <- sub_ext(out, 'html')
   if (is.null(text)) {
-    markdown::markdownToHTML(out, outfile <- sub_ext(out, 'html'), encoding = encoding, ...)
-    invisible(outfile)
+    markdown::markdownToHTML(out, output, encoding = encoding, ...)
+    invisible(output)
   } else markdown::markdownToHTML(text = out, ...)
 }
 


### PR DESCRIPTION
By not passing the output file to `knit` it should use the default
location for which the relative path to the images should be ok.

I made a few quick tests and it seems to work. Now, when doing `knit2html("test.Rmd", "out/test.html")` it will generate the markdown code in `test.md` instead of `out/test.html`
