### PR TITLE
fixed knit_child when knitting chunks with blocks that produce multiple ...

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -355,6 +355,12 @@ auto_format = function(ext) {
 #'
 #' # comment out the child doc by \Sexpr{knit_child('child-doc.Rnw', eval = FALSE)}
 knit_child = function(..., options = NULL, envir = knit_global()) {
+  old <- remove_all_hooks()
+  on.exit(restore_hooks(old), add = TRUE)
+  knit_child_unwrapped(..., options= options, envir = envir)
+}
+
+knit_child_unwrapped = function(..., options = NULL, envir = knit_global()) {
   child = child_mode()
   opts_knit$set(child = TRUE) # yes, in child mode now
   on.exit(opts_knit$set(child = child)) # restore child status
@@ -372,6 +378,26 @@ knit_child = function(..., options = NULL, envir = knit_global()) {
   res = knit(..., tangle = opts_knit$get('tangle'), envir = envir,
              encoding = opts_knit$get('encoding') %n% getOption('encoding'))
   paste(c('', res), collapse = '\n')
+}
+
+get_hook_names <- function() {
+  ls(.userHooksEnv, all.names = TRUE)
+}
+
+remove_all_hooks <- function() {
+  hook_names <-  get_hook_names()
+  old <- list()
+  for (hook_name in hook_names) {
+    old[[hook_name]] <- getHook(hook_name)
+    setHook(hook_name, NULL, action = "replace")
+  }
+  old
+}
+
+restore_hooks <- function(hooks) {
+  for (hook_name in names(hooks)) {
+    setHook(hook_name, hooks[[hook_name]], action = "replace")
+  }
 }
 
 #' Exit knitting early


### PR DESCRIPTION
fixed knit_child when knitting chunks with blocks that produce multiple plots. 
cf https://github.com/yihui/knitr/issues/824

It was difficult writing a test because I could not manage to run your testit tests without running R CMD check, and you do not seem to use sample files in your tests (is there any reason not to use testthat ?)

To test it manually:

```
library(devtools)
load_all('knitr')
res <- knit('parent.Rnw', quiet = TRUE)
lines <- readLines(res)
nb1 <- sum(grepl('includegraphics', lines, ignore.case = TRUE))
cat('nb plots=', nb1, '\n')
```

with 
parent.Rnw

```
\documentclass[letter, margin=1.90cm, 12pt]{scrartcl}
\begin{document}

<<parent_call_child, message = FALSE, include = FALSE, results = 'asis', eval = TRUE>>=
library(ggplot2)
out <- knitr::knit_child('child.Rnw', options = list(fig.keep='all'))
@
\Sexpr{paste(out, collapse="\n")}
\end{document}
```

child.Rnw

```
\section{PLOTS}
<<plots_for_loop, message = FALSE, echo = FALSE, results = 'asis', fig.keep = 'all', fig.show = 'asis', eval = TRUE>>=
{
  print(ggplot(iris, aes(x = Species)) + geom_histogram(fill = 'green') + ggtitle(paste('PLOT CHILD 1')))
  print(ggplot(iris, aes(x = Species)) + geom_histogram(fill = 'green') + ggtitle(paste('PLOT CHILD 2')))
}
@
```

The old knitr would output 1, the fixed one 2.
