### PR TITLE
Create figure directory for rgl plot if it does not already exist

### DIFF
--- a/R/hooks-extra.R
+++ b/R/hooks-extra.R
@@ -64,6 +64,8 @@ hook_rgl = function(before, options, envir) {
   # after a chunk has been evaluated
   if (before || rgl::rgl.cur() == 0) return()  # no active device
   name = fig_path('', options)
+  if (!file.exists(dirname(name)))
+    dir.create(dirname(name), recursive = TRUE) # automatically creates dir for plots
   rgl::par3d(windowRect = 100 + options$dpi * c(0, 0, options$fig.width, options$fig.height))
   Sys.sleep(.05) # need time to respond to window size change
 


### PR DESCRIPTION
Currently, if an rgl plot is the first plot in a document the snapshot will not be saved as the output figure directory does not exist. While this is currently created for 'standard' plots, it is not for rgl ones. This adds the same to the rgl hook, ensuring that documents that have an rgl plot before a 'standard' plot will build correctly.
