### PR TITLE
Add an extra newline to markdown tables generated from kable

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -115,7 +115,7 @@ print.knitr_kable = function(x, ...) {
 #' @export
 knit_print.knitr_kable = function(x, ...) {
   x = paste(c(
-    if (!(attr(x, 'format') %in% c('html', 'latex'))) c('', ''), x, ''
+    if (!(attr(x, 'format') %in% c('html', 'latex'))) c('', ''), x, '\n'
   ), collapse = '\n')
   asis_output(x)
 }


### PR DESCRIPTION
fixes jimhester/knitrBootstrap#70

pandoc needs a blank line at the end of the markdown table in order to parse it correctly.  Without the blank line  extra content gets included in the table and formatting gets broken.  This simply adds the missing newline.
