### PR TITLE
Attempt to preserve the order in which packages are stored on the search...

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -66,9 +66,9 @@ new_cache = function() {
     # save or load R packages
     path = valid_path(path, '__packages')
     if (save) {
-      x = .packages()
-      if (file.exists(path)) x = setdiff(c(x, readLines(path)), .base.pkgs)
-      writeLines(sort(x), path)
+      x = rev(.packages())
+      if (file.exists(path)) x = setdiff(c(readLines(path), x), .base.pkgs)
+      writeLines(x, path)
     } else {
       if (!file.exists(path)) return()
       for (p in readLines(path))


### PR DESCRIPTION
... path by preserving their order in `__packages`. It may not always keep the order where new packages are loaded in new chunks, but does appear to keep the order for multiple packages loaded within a chunk, or a series of chunks executed together. See http://stackoverflow.com/questions/26492875 for an example of the issue.
