### PR TITLE
Enable customization of the arguments of `highr::hilight()`

### DIFF
--- a/R/defaults.R
+++ b/R/defaults.R
@@ -144,7 +144,7 @@ opts_knit = new_defaults(list(
   base.dir = NULL, base.url = NULL, root.dir = NULL, child.path = '',
   upload.fun = identity, animation.fun = NULL, global.device = FALSE, global.par = FALSE,
   concordance = FALSE, documentation = 1L, self.contained = TRUE,
-  unnamed.chunk.label = 'unnamed-chunk',
+  unnamed.chunk.label = 'unnamed-chunk', highr.opts = NULL,
 
   # internal options; users should not touch them
   out.format = NULL, child = FALSE, parent = FALSE, tangle = FALSE, aliases = NULL,

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -2,6 +2,8 @@ hilight_source = function(x, format, options) {
   if ((format %in% c('latex', 'html')) && options$highlight) {
     if (options$engine == 'R') {
       highr::hilight(x, format, prompt = options$prompt)
+      do.call(highr::hilight, c(list(x, format, prompt = options$prompt),
+                                opts_knit$get("highr.opts")))
     } else {
       res = try(highr::hi_andre(x, options$engine, format))
       if (inherits(res, 'try-error')) {


### PR DESCRIPTION
For example, a user can call `opts_knit$set(highr.opts = list(markup = cmd_mine))` to change the default style.
