### PR TITLE
Fix the toggle_R() example.

### DIFF
--- a/inst/misc/toggleR.js
+++ b/inst/misc/toggleR.js
@@ -15,8 +15,7 @@ function toggle_R() {
         break;
       case 'code':
         var z = y.parentNode;
-        // pandoc uses the class 'sourceCode r' on both pre and code
-        if (z.tagName.toLowerCase() == 'pre' && z.className != 'sourceCode r') {
+        if (z.tagName.toLowerCase() == 'pre' && z.className != 'r') {
           toggle_vis(z);
         }
         break;


### PR DESCRIPTION
See example: 
It appears pandoc no longer uses class "sourceCode r", but rather just 'r'. 

Rpubs: http://rpubs.com/Kevin-M-Smith/39263

View source at this page to see javascript: http://rstudio-pubs-static.s3.amazonaws.com/39263_d9bc838e057749b9a8c98613ebd406f5.html
