### PR TITLE
Make error message more explicit

### DIFF
--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -65,7 +65,7 @@ register_vignette_engines = function(pkg) {
       vweave_rmarkdown(...)
     } else {
       if (!is_R_CMD_check())
-        warning('Pandoc is not available. Please install Pandoc.')
+        warning('Pandoc (>= 1.12.3) and/or pandoc-citeproc is not available. Please install both.')
       vweave(...)
     }
   } else {


### PR DESCRIPTION
This may save some time for others, as it took me a while to get to reading the source code of pandoc_available() to figure out that pandoc-citeproc (not pandoc) was missing on my system.
