### PR TITLE
is_lyx now works when lyx is run without GUI

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -157,7 +157,7 @@ is_lyx = function() {
   args = commandArgs(TRUE)
   if (length(args) < 4) return(FALSE)
   grepl('[.]Rnw$', args[1]) &&
-    !is.na(Sys.getenv('LyXDir', NA)) && !is.na(Sys.getenv('LYXSOCKET', NA))
+    !is.na(Sys.getenv('LyXDir', NA))
 }
 
 # scientific notation in TeX, HTML and reST


### PR DESCRIPTION
To detect whether LyX is calling knitr, the environment variable
LYXSOCKET should not be checked because it is only set if LyX is
run with a GUI (a LyX server is not useful when there is no GUI).

It is useful to run LyX in the terminal (that is, no GUI) for the
following reasons:
- to have a quick way to convert .lyx files to .pdf
- to use the lyx command in a Makefile
- to run LyX through a server
- for continuous testing.

This commit is related to #809.
