### PR TITLE
Fix na colname

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -223,6 +223,7 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ', padding = 0
   }
   l = apply(x, 2, function(z) max(nchar(z), na.rm = TRUE))
   cn = colnames(x)
+  cn[is.na(cn)] <- "NA"
   if (!is.null(cn)) {
     if (sep.col == '|') cn = gsub('\\|', '&#124;', cn)
     if (grepl('^\\s*$', cn[1L])) cn[1L] = rownames.name  # no empty cells for reST

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -112,3 +112,16 @@ assert(
     c('|   |  B|  B|', '|:--|--:|--:|', '|A  |  1|  1|', '|A  |  1|  1|')
   )
 )
+
+assert(
+  'kable() works on matrices with NA colname',
+  identical(
+    kable2(matrix(c(1, 1, 1, 1), ncol = 2, dimnames = list(c('A', NA), c('B', NA)))),
+    c("|   |  B| NA|", "|:--|--:|--:|", "|A  |  1|  1|", "|NA |  1|  1|")
+  )
+)
+
+
+
+
+


### PR DESCRIPTION
Hi,

In the current `knitr` version, applying `kable` to a table or matrix with missing colname generates an error : 

``` r
> m <- matrix(c(1, 1, 1, 1), ncol = 2, dimnames = list(c('A', NA), c('B', NA)))
> m
     B <NA>
A    1    1
<NA> 1    1
> kable(m)
Erreur dans rep.int(string[i], times[i]) : valeur 'times' incorrecte
```

This pull request fixes this error by replacing any missing column name with the `"NA"` character string. Then `kable(m)` gives : 

``` r
> kable(m)


|   |  B| NA|
|:--|--:|--:|
|A  |  1|  1|
|NA |  1|  1|
```
