### PR TITLE
Automatic test coverage reports with coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - sudo apt-get install -qq pandoc pandoc-citeproc texlive-latex-recommended > /dev/null
   - "wget -q -O - http://yihui.name/xran/r-config | bash"
   - Rscript -e 'devtools::install_deps(dep = TRUE)'
+  - Rscript -e 'devtools::install_github("jimhester/covr")'
 
 # run tests
 script:
@@ -37,3 +38,6 @@ script:
 after_success:
   - export R_PKG="$(basename $TRAVIS_REPO_SLUG)"
   - "[ $TARGET = integration ] && (wget -q -O - http://yihui.name/xran/r-xran | bash)"
+
+  # run test coverage only for the travis build
+  - "[ $TARGET = travis ] && Rscript -e 'library(covr);coveralls()'"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # knitr
 
 [![Build Status](https://travis-ci.org/yihui/knitr.svg)](https://travis-ci.org/yihui/knitr)
+[![Coverage Status](https://img.shields.io/coveralls/yihui/knitr.svg)](https://coveralls.io/r/yihui/knitr?branch=master)
 
 The R package **knitr** is a general-purpose literate programming engine,
 with lightweight API's designed to give users full control of the output


### PR DESCRIPTION
You will have to enable this repo on coveralls at https://coveralls.io/repos/new before merging this pull request for the report to work the first time.