### PR TITLE
Added 'http:' prefix in links

### DIFF
--- a/inst/misc/datatables.html
+++ b/inst/misc/datatables.html
@@ -1,6 +1,6 @@
-<link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.3/css/jquery.dataTables.css">
-<script type="text/javascript" charset="utf8" src="//code.jquery.com/jquery-2.1.1.min.js"></script>
-<script type="text/javascript" charset="utf8" src="//cdn.datatables.net/1.10.3/js/jquery.dataTables.js"></script>
+<link rel="stylesheet" type="text/css" href="http://cdn.datatables.net/1.10.3/css/jquery.dataTables.css">
+<script type="text/javascript" charset="utf8" src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
+<script type="text/javascript" charset="utf8" src="http://cdn.datatables.net/1.10.3/js/jquery.dataTables.js"></script>
 <style type="text/css">
 p{clear:both;}
 </style>


### PR DESCRIPTION
Hi Yihui
Adding the http prefix allows to load the css and js files also when opening the html reports from a file. 
Cheers Moritz

PS Now in a separate branch.