### PR TITLE
Add newline to fix multiple plots in a chunk for asciidoc

### DIFF
--- a/R/hooks-asciidoc.R
+++ b/R/hooks-asciidoc.R
@@ -9,7 +9,7 @@ hook_plot_asciidoc = function(x, options) {
   align = sprintf('align=%s', options$fig.align)
   tags = paste(c(cap, width, height, align), collapse = ',')
 
-  sprintf('.%s\nimage::%s[%s]', cap, .upload.url(x), tags)
+  sprintf('.%s\nimage::%s[%s]\n', cap, .upload.url(x), tags)
 }
 
 #' @rdname output_hooks


### PR DESCRIPTION
Multiple plots in a chunk (as in a loop) would concatenate the title
of the next plot on to the code to specify the previous plot, which
confused the asciidoc program. A simple newline fixes the problem.