### PR TITLE
Start header in a new line

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -15,7 +15,7 @@ insert_header = function(doc) {
 # Makes latex header with macros required for highlighting, tikz and framed
 make_header_latex = function() {
   h = paste(c(
-    sprintf('\\usepackage[%s]{graphicx}\\usepackage[%s]{color}',
+    sprintf('\n\n\\usepackage[%s]{graphicx}\\usepackage[%s]{color}',
             opts_knit$get('latex.options.graphicx') %n% '',
             opts_knit$get('latex.options.color') %n% ''),
     .header.maxwidth, opts_knit$get('header'),


### PR DESCRIPTION
Currently, the insertions in `LaTeX` are directly after the `\documentclass{}` command. This works but is not very pretty in the output. Pehaps a newline (`\n\n`) would be benefitial. 

Furthermore, one could add some comments to the definitions and also wrap the whole block in a comment which I didn't do at the moment but am happy to contribute.