### PR TITLE
Add support for tikzscale package, remove extra whitespace

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -20,7 +20,8 @@ make_header_latex = function() {
             opts_knit$get('latex.options.color') %n% ''),
     .header.maxwidth, opts_knit$get('header'),
     if (getOption('OutDec') != '.') '\\usepackage{amsmath}',
-    if (out_format('latex')) '\\usepackage{alltt}'
+    if (out_format('latex')) '\\usepackage{alltt}',
+    if (test_latex_pkg('tikzscale', '', FALSE)) '\\usepackage{tikzscale}'
   ), collapse = '\n')
   if (opts_knit$get('self.contained')) h else {
     writeLines(h, 'knitr.sty')

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -64,6 +64,7 @@ hook_plot_tex = function(x, options) {
   }
 
   tikz = is_tikz_dev(options)
+  tikzscale = test_latex_pkg('tikzscale', '', FALSE) & xor(!is.null(options$out.width), !is.null(options$out.height))
 
   a = options$fig.align
   fig.cur = options$fig.cur %n% 1L
@@ -139,9 +140,9 @@ hook_plot_tex = function(x, options) {
 
   paste(
     fig1, align1, sub1, resize1,
-    if (tikz) {
+    if (tikz && !tikzscale) {
       sprintf('\\input{%s}', x)
-    } else if (animate) {
+    } else if (!tikz && animate) {
       # \animategraphics{} should be inserted only *once*!
       aniopts = options$aniopts
       aniopts = if (is.na(aniopts)) NULL else gsub(';', ',', aniopts)
@@ -151,7 +152,7 @@ hook_plot_tex = function(x, options) {
               sub(sprintf('%d$', fig.num), '', sans_ext(x)), 1L, fig.num)
     } else {
       if (nzchar(size)) size = sprintf('[%s]', size)
-      sprintf('\\includegraphics%s{%s} ', size, sans_ext(x))
+      sprintf('\\includegraphics%s{%s} ', size, x)
     },
 
     resize2, sub2, align2, fig2,

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -85,7 +85,7 @@ hook_plot_tex = function(x, options) {
 
   # open align code if this picture is standalone/first in set
   align1 = if (plot1)
-    switch(a, left = '\n\n', center = '\n\n{\\centering ', right = '\n\n\\hfill{}', '\n')
+    switch(a, left = '\n\n', center = '\n\n{\\centering ', right = '\n\n\\hfill{}', '%\n')
   # close align code if this picture is standalone/last in set
   align2 = if (plot2)
     switch(a, left = '\\hfill{}\n\n', center = '\n\n}\n\n', right = '\n\n', '')
@@ -128,7 +128,7 @@ hook_plot_tex = function(x, options) {
   } else if (pandoc_to(c('latex', 'beamer'))) {
     # use alignment environments for R Markdown latex output (\centering won't work)
     align.env = switch(a, left = 'flushleft', center = 'center', right = 'flushright')
-    align1 = if (plot1) if (a == 'default') '\n' else sprintf('\n\n\\begin{%s}', align.env)
+    align1 = if (plot1) if (a == 'default') '%\n' else sprintf('\n\n\\begin{%s}', align.env)
     align2 = if (plot2) if (a == 'default') '' else sprintf('\\end{%s}\n\n', align.env)
   }
 
@@ -168,7 +168,7 @@ hook_plot_tex = function(x, options) {
   k2 = '\\end{kframe}'
   x = .rm.empty.envir(paste(k1, x, k2, sep = ''))
   size = if (options$size == 'normalsize') '' else sprintf('\\%s', options$size)
-  if (!ai) x = sprintf('\\begin{knitrout}%s\n%s\n\\end{knitrout}', size, x)
+  if (!ai) x = sprintf('\\begin{knitrout}%s%%\n%s%%\n\\end{knitrout}%%', size, x)
   if (options$split) {
     name = fig_path('.tex', options, NULL)
     if (!file.exists(dirname(name)))
@@ -268,7 +268,7 @@ render_latex = function() {
     inline = .inline.hook.tex, chunk = .chunk.hook.tex,
     plot = function(x, options) {
       # escape plot environments from kframe
-      paste('\\end{kframe}', hook_plot_tex(x, options), '\n\\begin{kframe}', sep = '')
+      paste('\\end{kframe}', hook_plot_tex(x, options), '%\n\\begin{kframe}', sep = '')
     }
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -273,11 +273,20 @@ eval_lang = function(x, envir = knit_global()) {
 isFALSE = function(x) identical(x, FALSE)
 
 # check latex packages; if not exist, copy them over to ./
-test_latex_pkg = function(name, path) {
+test_latex_pkg = function(name, path, copy=TRUE) {
   res = try_silent(system(sprintf('%s %s.sty', kpsewhich(), name), intern = TRUE))
   if (inherits(res, 'try-error') || !length(res)) {
-    warning("unable to find LaTeX package '", name, "'; will use a copy from knitr")
-    file.copy(path, '.')
+    args <- list("unable to find LaTeX package '", name, "'")
+    if (copy) {
+      args <- c(args, "; will use a copy from knitr")
+    }
+    do.call(warning, args)
+    if (copy) {
+      file.copy(path, '.')
+    }
+    FALSE
+  } else {
+    TRUE
   }
 }
 


### PR DESCRIPTION
This patch adds support for the tikzscale package, making it possible to generate tikz plots with external=FALSE while still being able to scale them to the desired size. In addition, several linebreaks in the generated LaTeX code are commented out, as they led to extra whitespace being inserted before the plot, which is very annoying when trying to have multiple plots in one figure using the subfig package.
