### PR TITLE
remove stray rm

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -285,11 +285,12 @@ eng_asis = function(options) {
 }
 
 # set engines for interpreted languages
-for (i in c(
-  'awk', 'bash', 'coffee', 'gawk', 'groovy', 'haskell', 'node', 'perl', 'python',
-  'Rscript', 'ruby', 'sas', 'scala', 'sed', 'sh', 'stata', 'zsh'
-)) knit_engines$set(setNames(list(eng_interpreted), i))
-rm(i)
+local({
+  for (i in c(
+    'awk', 'bash', 'coffee', 'gawk', 'groovy', 'haskell', 'node', 'perl', 'python',
+    'Rscript', 'ruby', 'sas', 'scala', 'sed', 'sh', 'stata', 'zsh'
+  )) knit_engines$set(setNames(list(eng_interpreted), i))
+})
 
 # additional engines
 knit_engines$set(


### PR DESCRIPTION
The `rm(i)` looks awkward and alone here.