### PR TITLE
cleaner set_header method

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -104,10 +104,7 @@ insert_header_html = function(doc, b) {
 #' @examples set_header(tikz = '\\usepackage{tikz}')
 #' opts_knit$get('header')
 set_header = function(...) {
-  h = opts_knit$get('header')
-  z = c(...)
-  h[names(z)] = z
-  opts_knit$set(header = h)
+  opts_knit$set(header = merge_list(opts_knit$get('header'), c(...)))
 }
 
 .default.sty = inst_dir('themes', 'default.css')


### PR DESCRIPTION
This seems cleaner to me. I have tested it locally.

```r
> knitr:::opts_knit$get("header")
highlight      tikz    framed
       ""        ""        ""
> merge_list(knitr:::opts_knit$get("header"), c("framed" = "foo"))
highlight      tikz    framed
       ""        ""     "foo"
> class(merge_list(knitr:::opts_knit$get("header"), c("framed" = "foo")))
[1] "character"
```