### PR TITLE
Add informative error if ffmpeg is not found

### DIFF
--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -78,6 +78,10 @@ hook_ffmpeg = function(x, options, format = '.webm') {
 
   ffmpeg.cmd = paste('ffmpeg', '-y', '-r', 1 / options$interval,
                      '-i', fig.fname, mov.fname)
+  if (nchar(Sys.which("ffmpeg")) == 0)
+    stop("Could not find ffmpeg command. You should either change the",
+         "animation.fun hook option or install ffmpeg with libvpx enabled.",
+         call. = FALSE)
   message('executing: ', ffmpeg.cmd)
   system(ffmpeg.cmd, ignore.stdout = TRUE)
 

--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -78,9 +78,9 @@ hook_ffmpeg = function(x, options, format = '.webm') {
 
   ffmpeg.cmd = paste('ffmpeg', '-y', '-r', 1 / options$interval,
                      '-i', fig.fname, mov.fname)
-  if (nchar(Sys.which("ffmpeg")) == 0)
-    stop("Could not find ffmpeg command. You should either change the",
-         "animation.fun hook option or install ffmpeg with libvpx enabled.",
+  if (Sys.which('ffmpeg') == '')
+    stop('Could not find ffmpeg command. You should either change the',
+         'animation.fun hook option or install ffmpeg with libvpx enabled.',
          call. = FALSE)
   message('executing: ', ffmpeg.cmd)
   system(ffmpeg.cmd, ignore.stdout = TRUE)


### PR DESCRIPTION
Note that `brew install ffmpeg` didn't quite work, but `brew install ffmpeg --with-libvpx` did