### PR TITLE
Expose 'env' argument of 'system2()'

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -114,7 +114,7 @@ eng_interpreted = function(options) {
   cmd = options$engine.path %n% engine
   out = if (options$eval) {
     message('running: ', cmd, ' ', code)
-    tryCatch(system2(cmd, code, stdout = TRUE, stderr = TRUE), error = function(e) {
+    tryCatch(system2(cmd, code, stdout = TRUE, stderr = TRUE, env=options$engine.env), error = function(e) {
       if (!options$error) stop(e)
       paste('Error in running command', cmd)
     })


### PR DESCRIPTION
... so that it can be supplied through chunk option `engine.env`. This might be useful with `engine="bash"` to (pretend to) emulate interactive bash session.

I use it here (https://github.com/mbojan/gitjestgit/blob/master/gitjestgit.Rmd) in a git tutorial (it is in Polish) to modify OS prompt on the fly. HTML preview: https://htmlpreview.github.io/?https://github.com/mbojan/gitjestgit/blob/master/gitjestgit.html