### PR TITLE
No warning if chunk with child has only whitespace

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -31,7 +31,7 @@ call_block = function(block) {
   if (opts_knit$get('progress')) print(block)
 
   if (!is.null(params$child)) {
-    if (length(params$code)) warning(
+    if (!is_blank(params$code)) warning(
       "The chunk '", params$label, "' has the 'child' option, ",
       "and this code chunk must be empty. Its code will be ignored."
     )


### PR DESCRIPTION
This warning is useful to make sure authors are aware that code in
the chunk will not be run. But because pure whitespace is not code,
there is no concern.

This commit has the extra benefit of increasing compatibility with
LyX's chunk inset. An empty chunk inset in LyX consists of a blank
line, and would thus trigger the warning without this commit.