### PR TITLE
support for !expr in knit_params

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.10.13
+Version: 1.10.14
 Date: 2015-05-06
 Authors@R: c(
     person("Adam", "Vogt", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - added an argument `quiet` to `plot_crop()` (thanks, @WastlM, #1034)
 
+- support for !expr in knit_params (correct 'type' field for Date and POSIXct objects generated via !eval; add 'expr' field to flag when a parameter's value was the result of an R expression)
+
 ## MAJOR CHANGES
 
 - the two hook functions `hook_rgl()` and `hook_webgl()` have been moved from **knitr** to the **rgl** package (v0.95.1247) (thanks, @dmurdoch)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - added an argument `quiet` to `plot_crop()` (thanks, @WastlM, #1034)
 
-- support for !expr in knit_params (correct 'type' field for Date and POSIXct objects generated via !eval; add 'expr' field to flag when a parameter's value was the result of an R expression)
+- support for !expr in knit_params (correct 'type' field for Date and POSIXct objects generated via !expr; add 'expr' field to flag when a parameter's value was the result of an R expression)
 
 ## MAJOR CHANGES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 
 - added an argument `quiet` to `plot_crop()` (thanks, @WastlM, #1034)
 
-- support for !expr in knit_params (correct 'type' field for Date and POSIXct objects generated via !expr; add 'expr' field to flag when a parameter's value was the result of an R expression)
+- support for !expr and !r in knit_params.
+
 
 ## MAJOR CHANGES
 

--- a/R/params.R
+++ b/R/params.R
@@ -16,7 +16,7 @@
 #'     \item{\code{name}}{The parameter name.}
 #'     \item{\code{value}}{The default value for the parameter.}
 #'     \item{\code{class}}{The R class names of the parameter's default value.}
-#'     \item{\code{expr}}{The R expression that yielded the default value (if any).}
+#'     \item{\code{expr}}{The R expression (if any) that yielded the default value.}
 #'   }
 #'
 #'   In addition, other fields included in the YAML may also be present
@@ -55,7 +55,7 @@
 #' This second form is useful when you need to provide additional details
 #' about the parameter (e.g. a \code{label} field as describe above).
 #'
-#' You can use R code to yield the value of a parameter by prefacing the value
+#' You can also use R code to yield the value of a parameter by prefacing the value
 #' with \code{!r}, for example:
 #'
 #' \preformatted{

--- a/R/params.R
+++ b/R/params.R
@@ -14,12 +14,9 @@
 #'
 #'   \describe{
 #'     \item{\code{name}}{The parameter name.}
-#'     \item{\code{type}}{The parameter type. This can be a standard R object
-#'     type such as \code{character}, \code{integer}, \code{numeric}, or
-#'     \code{logical} as well as the special \code{date}, \code{datetime}, and
-#'     \code{file} types. See the \emph{Types} section below for additional
-#'     details.}
 #'     \item{\code{value}}{The default value for the parameter.}
+#'     \item{\code{class}}{The R class names of the parameter's default value.}
+#'     \item{\code{expr}}{The R expression that yielded the default value (if any).}
 #'   }
 #'
 #'   In addition, other fields included in the YAML may also be present
@@ -58,58 +55,16 @@
 #' This second form is useful when you need to provide additional details
 #' about the parameter (e.g. a \code{label} field as describe above).
 #'
-#' Parameter types are deduced implicitly based on the value provided. However
-#' in some cases additional type information is required (for example when
-#' a character vector needs to be interpreted as a date or as a file path).
-#' In these cases a special type designater precedes the value. For example:
+#' You can use R code to yield the value of a parameter by prefacing the value
+#' with \code{!r}, for example:
 #'
 #' \preformatted{
 #' ---
 #' title: My Document
 #' output: html_document
 #' params:
-#'   start: !date 2015-01-01
+#'   start: !r Sys.Date()
 #' ---
-#' }
-#'
-#' @section Types:
-#'
-#' All of the standard R types that can be parsed using
-#' \code{\link[yaml]{yaml.load}} are supported. These types are used
-#' implicitly based on the \code{value} provided so no special type
-#' designater is required. Built-in types include \code{character},
-#' \code{integer}, \code{numeric}, and \code{logical}.
-#'
-#' In addition there are a number of custom types used to represent
-#' dates and times as well as to note that character values have
-#' special semantics (e.g. are the name of a file). These types are
-#' specified by prefacing the YAML \code{value} with !\emph{typename},
-#' for example:
-#'
-#' \preformatted{
-#' ---
-#' title: My Document
-#' output: html_document
-#' params:
-#'   start: !date 2015-01-01
-#'   end: !datetime 2015-01-01 12:30:00
-#'   data: !file data.csv
-#' ---
-#' }
-#'
-#' Supported custom types include:
-#'
-#' \describe{
-#'   \item{\code{date}}{A character value representing a date.
-#'   The underlying date value is parsed from the character
-#'   value using the \code{\link[base]{as.Date}} function.}
-#'   \item{\code{datetime}}{A character value representing a
-#'   date and time. The underlying datetime value is parsed from
-#'   the character value using the \code{\link[base]{as.POSIXct}}
-#'   function. Note that these values should always speicifed using
-#'   UTC (Universal Time, Coordinated).}
-#'   \item{\code{file}}{A character value representing the name
-#'   of a file.}
 #' }
 #'
 #' @export
@@ -196,48 +151,39 @@ yaml_front_matter = function(lines) {
 # define custom handlers for knitr_params
 knit_params_handlers = function() {
 
-  # generic handler for intrinsic types that need a special 'type' designator as
-  # a hint to front-ends (e.g. 'file' to indicate a file could be uploaded)
-  type_handler = function(type) {
-    force(type)
+  # generic handler for r expressions where we want to preserve both the original
+  # code and the fact that it was an expression.
+  expr_handler = function() {
     function(value) {
-      attr(value, "type") = type
-      value
+      evaulated_value = eval(parse(text = value))
+      attr(evaulated_value, "expr") = value
+      evaulated_value
     }
   }
 
   list(
 
+    # r expressions where we want to preserve both the original code
+    # and the fact that it was an expression.
+    r = expr_handler(),
+    expr = expr_handler(),
+
+    # date and datetime (for backward compatibility with previous syntax)
+    date = function(value) {
+      value = as.Date(value)
+      value
+    },
+    datetime = function(value) {
+      value = as.POSIXct(value, tz = "GMT")
+      value
+    },
+
+    # workaround default yaml parsing behavior to allow keys named 'y' and 'n'
     `bool#yes` = function(value) {
       if (tolower(value) == "y") value else TRUE
     },
-
     `bool#no` = function(value) {
       if (tolower(value) == "n") value else FALSE
-    },
-
-    # date
-    date = function(value) {
-      value = as.Date(value)
-      attr(value, "type") = "date"
-      value
-    },
-
-    # datetime
-    datetime = function(value) {
-      value = as.POSIXct(value, tz = "GMT")
-      attr(value, "type") = "datetime"
-      value
-    },
-
-    # file
-    file = type_handler("file"),
-
-    # expr
-    expr = function(value) {
-      value = eval(parse(text = value))
-      attr(value, "expr") = TRUE
-      value
     }
   )
 }
@@ -247,32 +193,14 @@ knit_params_handlers = function() {
 # type, value, and other optional fields included)
 resolve_params = function(params) {
 
-  # get the type attribute (if any)
-  type_attr = function(value) {
-    attr(value, "type", exact = TRUE)
-  }
-
-  # was this value a result of an expression
+  # get the expr attribute (if any)
   expr_attr = function(value) {
-    isTRUE(attr(value, "expr", exact = TRUE))
+    attr(value, "expr", exact = TRUE)
   }
 
-  # deduce type from attribute or class (also resolve date / datetime types
-  # that we may have obtained from an expression)
-  param_type = function(value) {
-    type <- type_attr(value) %n% class(value)[[1]]
-    if (type == "Date")
-      "date"
-    else if (type == "POSIXct")
-      "datetime"
-    else
-      type
-  }
-
-  # return a parameter value with type and expr attributes stripped and
+  # return a parameter value with expr attribute stripped and
   # as a vector rather than list if it's unnamed
   param_value = function(value) {
-    attr(value, "type") = NULL
     attr(value, "expr") = NULL
     if (is.null(names(value))) unlist(value) else value
   }
@@ -287,15 +215,15 @@ resolve_params = function(params) {
     # get the parameter
     param = params[[name]]
 
-    # if it's not a list then a plain value was specified, create the list based
-    # on the value
+    # if it's not a list then a plain value was specified so just use the value
     if (!is.list(param)) {
+
+      value = param
 
       param = list(
         name = name,
-        type = param_type(param),
-        expr = expr_attr(param),
-        value = param_value(param)
+        expr = expr_attr(value),
+        value = value
       )
 
     } else {
@@ -306,16 +234,23 @@ resolve_params = function(params) {
              call. = FALSE)
       }
 
-      # ensure we have a name
+      # record name and expr (if available)
       param$name = name
-
-      # look for type info at the object level then value level
-      param$type = type_attr(param)
-      if (is.null(param$type)) param$type = param_type(param$value)
+      param$expr = expr_attr(param$value)
     }
 
-    # normalize parameter value
+    # normalize parameter value (i.e. strip attributes, list -> vector)
     param$value = param_value(param$value)
+
+    # record parameter class (must be explicit for null values)
+    if (!is.null(param$value)) {
+      param$class = class(param$value)
+    } else {
+      if (is.null(param$class))
+        stop("no class field specified for YAML parameter '", name, "'",
+             " (fields with a value of null must specify an explicit class)",
+             call. = FALSE)
+    }
 
     # add knit_param class
     param = structure(param, class = "knit_param")

--- a/man/knit_params.Rd
+++ b/man/knit_params.Rd
@@ -15,12 +15,9 @@ List of objects of class \code{knit_param} that correspond to the
 
   \describe{
     \item{\code{name}}{The parameter name.}
-    \item{\code{type}}{The parameter type. This can be a standard R object
-    type such as \code{character}, \code{integer}, \code{numeric}, or
-    \code{logical} as well as the special \code{date}, \code{datetime}, and
-    \code{file} types. See the \emph{Types} section below for additional
-    details.}
     \item{\code{value}}{The default value for the parameter.}
+    \item{\code{class}}{The R class names of the parameter's default value.}
+    \item{\code{expr}}{The R expression that yielded the default value (if any).}
   }
 
   In addition, other fields included in the YAML may also be present
@@ -65,58 +62,15 @@ params:
 This second form is useful when you need to provide additional details
 about the parameter (e.g. a \code{label} field as describe above).
 
-Parameter types are deduced implicitly based on the value provided. However
-in some cases additional type information is required (for example when
-a character vector needs to be interpreted as a date or as a file path).
-In these cases a special type designater precedes the value. For example:
+You can use R code to yield the value of a parameter by prefacing the value
+with \code{!r}, for example:
 
 \preformatted{
 ---
 title: My Document
 output: html_document
 params:
-  start: !date 2015-01-01
+  start: !r Sys.Date()
 ---
-}
-}
-\section{Types}{
-
-
-All of the standard R types that can be parsed using
-\code{\link[yaml]{yaml.load}} are supported. These types are used
-implicitly based on the \code{value} provided so no special type
-designater is required. Built-in types include \code{character},
-\code{integer}, \code{numeric}, and \code{logical}.
-
-In addition there are a number of custom types used to represent
-dates and times as well as to note that character values have
-special semantics (e.g. are the name of a file). These types are
-specified by prefacing the YAML \code{value} with !\emph{typename},
-for example:
-
-\preformatted{
----
-title: My Document
-output: html_document
-params:
-  start: !date 2015-01-01
-  end: !datetime 2015-01-01 12:30:00
-  data: !file data.csv
----
-}
-
-Supported custom types include:
-
-\describe{
-  \item{\code{date}}{A character value representing a date.
-  The underlying date value is parsed from the character
-  value using the \code{\link[base]{as.Date}} function.}
-  \item{\code{datetime}}{A character value representing a
-  date and time. The underlying datetime value is parsed from
-  the character value using the \code{\link[base]{as.POSIXct}}
-  function. Note that these values should always speicifed using
-  UTC (Universal Time, Coordinated).}
-  \item{\code{file}}{A character value representing the name
-  of a file.}
 }
 }

--- a/man/knit_params.Rd
+++ b/man/knit_params.Rd
@@ -17,7 +17,7 @@ List of objects of class \code{knit_param} that correspond to the
     \item{\code{name}}{The parameter name.}
     \item{\code{value}}{The default value for the parameter.}
     \item{\code{class}}{The R class names of the parameter's default value.}
-    \item{\code{expr}}{The R expression that yielded the default value (if any).}
+    \item{\code{expr}}{The R expression (if any) that yielded the default value.}
   }
 
   In addition, other fields included in the YAML may also be present
@@ -62,7 +62,7 @@ params:
 This second form is useful when you need to provide additional details
 about the parameter (e.g. a \code{label} field as describe above).
 
-You can use R code to yield the value of a parameter by prefacing the value
+You can also use R code to yield the value of a parameter by prefacing the value
 with \code{!r}, for example:
 
 \preformatted{

--- a/tests/testit/test-params.R
+++ b/tests/testit/test-params.R
@@ -125,3 +125,27 @@ assert(
   'y/Y/n/N are not converted to booleans',
   identical(unlist(lapply(params, `[[`, 'name')), c('x', 'y', 'z', 'n', 'Y', 'N'))
 )
+
+
+## test handling of expressions --------------------------------------------
+
+params <- read_params('
+---
+params:
+  today: !expr Sys.Date()
+  now: !expr Sys.time()
+  datevar: !date 2015-07-09
+---
+'
+)
+assert(params[[1]]$expr)
+assert(params[[1]]$type == "date")
+assert(params[[2]]$expr)
+assert(params[[2]]$type == "datetime")
+assert(!params[[3]]$expr)
+assert(params[[1]]$type == "date")
+
+
+
+
+

--- a/tests/testit/test-params.R
+++ b/tests/testit/test-params.R
@@ -24,7 +24,7 @@ assert(params[[2]]$value == 20)
 
 assert(identical(flatten_params(params), list(a = 10L, b = 20L)))
 
-## test date custom type ---------------------------------------------------
+## test date custom type (these deprecated and here for backwards compt) --
 
 params <- read_params('
 ---
@@ -35,25 +35,11 @@ params:
 '
 )
 assert(params[[1]]$name == 'start')
-assert(params[[1]]$type == 'date')
+assert('Date' %in% params[[1]]$class)
 assert(params[[1]]$value == as.Date("2015-01-01"))
 assert(params[[2]]$name == 'end')
-assert(params[[2]]$type == 'datetime')
+assert('POSIXct' %in% params[[2]]$class)
 assert(params[[2]]$value == as.POSIXct("2015-01-01 12:30:00", tz = "GMT"))
-
-
-## test file custom type ---------------------------------------------------
-
-params <- read_params('
----
-params:
-  file: !file data.csv
----
-'
-)
-assert(params[[1]]$name == 'file')
-assert(params[[1]]$type == 'file')
-assert(params[[1]]$value == 'data.csv')
 
 
 ## test specifying value in sub-object and type at object level ------------
@@ -62,18 +48,12 @@ params <- read_params('
 ---
 params:
   file1:
-    value: !file data1.csv
-  file2: !file
-    value: data2.csv
+    value: data1.csv
 ---
 '
 )
 assert(params[[1]]$name == 'file1')
-assert(params[[1]]$type == 'file')
 assert(params[[1]]$value == 'data1.csv')
-assert(params[[2]]$name == 'file2')
-assert(params[[2]]$type == 'file')
-assert(params[[2]]$value == 'data2.csv')
 
 
 ## test parameters with length(value) > 1 ----------------------------------
@@ -132,18 +112,18 @@ assert(
 params <- read_params('
 ---
 params:
-  today: !expr Sys.Date()
+  today: !r Sys.Date()
   now: !expr Sys.time()
-  datevar: !date 2015-07-09
+  x: 10
 ---
 '
 )
-assert(params[[1]]$expr)
-assert(params[[1]]$type == "date")
+assert(!is.null(params[[1]]$expr))
+assert('Date' %in% params[[1]]$class)
 assert(params[[2]]$expr)
-assert(params[[2]]$type == "datetime")
-assert(!params[[3]]$expr)
-assert(params[[1]]$type == "date")
+assert('POSIXct' %in% params[[2]]$class)
+assert(is.null(params[[3]]$expr))
+
 
 
 


### PR DESCRIPTION
- correct 'type' field for Date and POSIXct objects generated via !eval
- add 'expr' field to flag when a parameter's value was the result of an R expression)

@trestletech @aronatkins @jcheng5 
