### PR TITLE
Bug fix for pandoc - paragraph handling

### DIFF
--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -87,7 +87,7 @@ hook_ffmpeg = function(x, options, format = '.webm') {
     sprintf('width="%s"', options$out.width),
     sprintf('height="%s"', options$out.height), opts
   )
-  sprintf('<video %s><source src="%s" />video of chunk %s</video>',
+  sprintf('<video %s><source src="%s" /><p>video of chunk %s</p></video>',
           opts, paste0(opts_knit$get('base.url'), mov.fname), options$label)
 }
 


### PR DESCRIPTION
Pandoc creates disordered paragraph tags in the inner html for
video/source.
Closes yihui/knitr#1067