### PR TITLE
cleanup expr handling

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -234,7 +234,7 @@ resolve_params = function(params, evaluate = TRUE) {
     # get the parameter
     param = params[[name]]
 
-    if ("knit_param_expr" %in% class(param)) {
+    if (inherits(param, "knit_param_expr")) {
       # We have a key: !r expr
       param = list(
           expr = param$expr,
@@ -243,7 +243,7 @@ resolve_params = function(params, evaluate = TRUE) {
       if ("value" %in% names(param)) {
         # This looks like a complex parameter configuration.
         value = param$value
-        if ("knit_param_expr" %in% class(value)) {
+        if (inherits(value, "knit_param_expr")) {
           # We have a key: { value: !r expr }
           param$expr  = value$expr
           param$value = value$value

--- a/tests/testit/test-params.R
+++ b/tests/testit/test-params.R
@@ -146,11 +146,14 @@ params <- read_params_yaml('
 params:
   x: 1
   today: !r Sys.Date()
+  posixlt: !r strptime("2015-01-01", format = "%Y-%m-%d")
 ')
 assert(params$x$value == 1)
 assert(identical(class(params$x$value), "integer"))
 assert(identical(params$today$expr, "Sys.Date()"))
 assert('Date' %in% class(params$today$value))
+assert(identical(params$posixlt$expr, 'strptime("2015-01-01", format = "%Y-%m-%d")'))
+assert('POSIXlt' %in% class(params$posixlt$value))
 
 ## test handling of unevaluated yaml parameters --------------------------------------------
 

--- a/tests/testit/test-params.R
+++ b/tests/testit/test-params.R
@@ -147,7 +147,11 @@ params:
   x: 1
   today: !r Sys.Date()
   posixlt: !r strptime("2015-01-01", format = "%Y-%m-%d")
+  list: [1,2,3]
+#  map: { a: 1, b: 2 }
+  map: { value: { a: 1, b: 2 } }
 ')
+# The direct map value is not supported; an explicit value field is necessary
 assert(params$x$value == 1)
 assert(identical(class(params$x$value), "integer"))
 assert(identical(params$today$expr, "Sys.Date()"))


### PR DESCRIPTION
This fixes a problem where we were incorrectly calling `unlist` on values produced by expressions.

Here is the old behavior:

```
> y <- yaml::yaml.load('k: !r strptime("2015-01-01", format = "%Y-%m-%d")\n', handlers = knitr:::knit_params_handlers(evaluate = TRUE))
> r <- knitr:::resolve_params(y)
> r$k$value
   sec    min   hour   mday    mon   year   wday   yday  isdst   zone gmtoff 
   "0"    "0"    "0"    "1"    "0"  "115"    "4"    "0"    "0"  "EST"     NA 
> class(r$k$value)
[1] "character"
```

And the new:

```
> y <- yaml::yaml.load('k: !r strptime("2015-01-01", format = "%Y-%m-%d")\n', handlers = knitr:::knit_params_handlers(evaluate = TRUE))
> r <- knitr:::resolve_params(y)
> r$k$value
[1] "2015-01-01 EST"
> class(r$k$value)
[1] "POSIXlt" "POSIXt" 
```