### PR TITLE
Allow YAML header to end with ...

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -10,7 +10,7 @@
 #' @param evaluate If TRUE, expression values embedded within the YAML will be
 #' evaluated. This is the default. When FALSE, parameters defined by an
 #' expression will have the parsed expression in its \code{value} field.
-#'
+#' 
 #' @return List of objects of class \code{knit_param} that correspond to the
 #'   parameters declared in the \code{params} section of the YAML front matter.
 #'   These objects have the following fields:
@@ -98,7 +98,7 @@ knit_params = function(text, evaluate = TRUE) {
 #' \code{\link{knit_params}} for a full description of these objects.
 #'
 #' @seealso \code{\link{knit_params}}
-#'
+#' 
 #' @export
 knit_params_yaml = function(yaml, evaluate = TRUE) {
   # parse the yaml using our handlers

--- a/R/params.R
+++ b/R/params.R
@@ -10,7 +10,7 @@
 #' @param evaluate If TRUE, expression values embedded within the YAML will be
 #' evaluated. This is the default. When FALSE, parameters defined by an
 #' expression will have the parsed expression in its \code{value} field.
-#' 
+#'
 #' @return List of objects of class \code{knit_param} that correspond to the
 #'   parameters declared in the \code{params} section of the YAML front matter.
 #'   These objects have the following fields:
@@ -98,7 +98,7 @@ knit_params = function(text, evaluate = TRUE) {
 #' \code{\link{knit_params}} for a full description of these objects.
 #'
 #' @seealso \code{\link{knit_params}}
-#' 
+#'
 #' @export
 knit_params_yaml = function(yaml, evaluate = TRUE) {
   # parse the yaml using our handlers
@@ -143,11 +143,12 @@ yaml_front_matter = function(lines) {
   # by other content
   has_front_matter = function(delimiters) {
     length(delimiters) >= 2 && (delimiters[2] - delimiters[1] > 1) &&
-      (delimiters[1] == 1 || is_blank(head(lines, delimiters[1] - 1)))
+      (delimiters[1] == 1 || is_blank(head(lines, delimiters[1] - 1))) &&
+      grepl("^---\\s*$", lines[delimiters[1]])
   }
 
   # find delimiters in the document
-  delimiters = grep("^---\\s*$", lines)
+  delimiters = grep("^(---|\\.\\.\\.)\\s*$", lines)
 
   # if it's valid then return front matter as a text block suitable for passing
   # to yaml::load


### PR DESCRIPTION
See https://github.com/rstudio/rmarkdown/pull/485

I ran `make check`, and got the following error, which appears unrelated as I get it when I run it without these changes:

```
* checking examples ... ERROR
Running examples in ‘knitr-Ex.R’ failed
The error most likely occurred in:

> base::assign(".ptime", proc.time(), pos = "CheckExEnv")
> ### Name: hook_pdfcrop
> ### Title: Built-in chunk hooks to extend knitr
> ### Aliases: hook_optipng hook_pdfcrop hook_plot_custom hook_purl
>
> ### ** Examples
>
> if (require("rgl")) knit_hooks$set(rgl = hook_rgl)
Loading required package: rgl
Error in knit_hooks$set(rgl = hook_rgl) : object 'hook_rgl' not found
Execution halted
```