### PR TITLE
Add a bitrate option to control the quality of webm videos.

### DIFF
--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -75,9 +75,16 @@ hook_ffmpeg = function(x, options, format = '.webm') {
   # set up the ffmpeg run
   fig.fname = paste0(sub(paste0(fig.num, '$'), '%d', x[1]), '.', x[2])
   mov.fname = paste0(sub(paste(fig.num, '$', sep = ''), '', x[1]), format)
-
-  ffmpeg.cmd = paste('ffmpeg', '-y', '-r', 1 / options$interval,
+  
+  if (format == '.webm') {
+    mov.bitrate = ifelse(is.null(options$bitrate), "1M", options$bitrate)
+    ffmpeg.cmd = paste('ffmpeg', '-y', '-r', 1 / options$interval,
+                     '-i', fig.fname, '-b:v', mov.bitrate, '-crf 10', mov.fname)  
+  } else {
+    ffmpeg.cmd = paste('ffmpeg', '-y', '-r', 1 / options$interval,
                      '-i', fig.fname, mov.fname)
+  }
+  
   message('executing: ', ffmpeg.cmd)
   system(ffmpeg.cmd, ignore.stdout = TRUE)
 


### PR DESCRIPTION
Greetings and Salutations. I hope you're having a great day.

First off, thank you very much for this awesome package. I started working with it 5 days ago and it's making my life a lot better.

I was making some animations of ggplot2 plots yesterday (super neat feature), but the quality of the resulting webm video was low (there was blockiness and blurriness in spots). 

As you call out in the documentation and from the R Markdown output the command line call for ffmpeg is something like this...

```
ffmpeg -y -r {fps} -i {working-dir}/figure-html/{chunk-name}-%d.png {working-dir}/figure-html/{chunk-name}-.webm
```

From the [ffmpeg documentation on VP8 encoding](https://trac.ffmpeg.org/wiki/Encode/VP8)..

> **Important**: If neither -b:v nor -crf are set, the encoder will use a low default bitrate and your result will probably look very bad. Always supply one of these options—ideally both.

To that end, this pull request changes the ffmpeg hook to read `bitrate` from the chunk options and pass it through to ffmpeg, or pass a default of 1Mbps through. It also adds the recommended default `-crf` value of 10.

Thanks again!