### PR TITLE
Detect other CIs than travis in remind_sweave

### DIFF
--- a/R/utils-sweave.R
+++ b/R/utils-sweave.R
@@ -171,7 +171,7 @@ remind_sweave = function(file, sweave_lines) {
                 paste(sweave_lines, collapse = ', '), file)
   # throw a normal warning when R CMD check or tcltk not available
   warning(msg)
-  if (!is_R_CMD_check() && Sys.getenv('TRAVIS') != 'true' && tcltk_available()) {
+  if (!is_R_CMD_check() && Sys.getenv('CI') != 'true' && tcltk_available()) {
     do.call(
       getFromNamespace('tkmessageBox', 'tcltk'),
       list(title = 'Sweave Noweb syntax?', icon = 'info', message = msg)


### PR DESCRIPTION
Switch system environment variable from TRAVIS to CI to correctly detect other CIs like e.g. semaphore.