### PR TITLE
Better Stata support for OS X

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -98,7 +98,7 @@ eng_interpreted = function(options) {
       stata = {
         logf = sub('[.]do$', '.log', f)
         on.exit(unlink(c(logf)), add = TRUE)
-        paste(ifelse(.Platform$OS.type == 'windows', '/q /e do', '-q -b do'), f)
+        paste(switch(Sys.info()[['sysname']], Windows='/q /e do', Darwin='-q -e do', Linux='-q -b do', '-q -b do'), f)
       },
       f
     )


### PR DESCRIPTION
This adds slightly better functioning for Stata under OS X:  I've been working with a users from Duke University who is a Mac user.  The improvement is that Stata shuts down automatically, rather than waiting for the user to exit manually.