### PR TITLE
Local chunk options supersede opts_template() options

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -15,15 +15,16 @@ call_block = function(block) {
   # now try eval all options except those in eval.after and their aliases
   af = opts_knit$get('eval.after'); al = opts_knit$get('aliases')
   if (!is.null(al) && !is.null(af)) af = c(af, names(al[af %in% al]))
+
+  # expand parameters defined via template
+  if (!is.null(block$params$opts.label)) {
+    block$params <- merge_list(opts_template$get(block$params$opts.label), block$params)
+  }
+
   params = opts_chunk$merge(block$params)
   opts_current$restore(params)
   for (o in setdiff(names(params), af)) params[o] = list(eval_lang(params[[o]]))
-
   params = fix_options(params)  # for compatibility
-
-  # expand parameters defined via template
-  if (!is.null(params$opts.label))
-    params = merge_list(params, opts_template$get(params$opts.label))
 
   label = ref.label = params$label
   if (!is.null(params$ref.label)) ref.label = sc_split(params$ref.label)
@@ -403,4 +404,3 @@ label_code = function(code, label) {
 as.source <- function(code) {
   list(structure(list(src = code), class = 'source'))
 }
-

--- a/tests/testit/test-output.R
+++ b/tests/testit/test-output.R
@@ -39,6 +39,34 @@ assert(
   )
 )
 
+assert(
+  'opts_template options are used',
+  identical(
+    "\n[1] 2\n",
+    knit(
+      text = c(
+        "<<include=FALSE>>=","opts_template$set(quiet = list(echo=FALSE))", "@",
+        "<<results='asis', opts.label='quiet'>>=", "1+1", "@"
+      ),
+      quiet = TRUE
+    )
+  )
+)
+
+assert(
+  'local chunk options override opts_template',
+  identical(
+    "\n\\begin{kframe}\n\\begin{alltt}\n\\hlnum{1}\\hlopt{+}\\hlnum{1}\n\\end{alltt}\n\\end{kframe}[1] 2\n",
+    knit(
+      text = c(
+        "<<include=FALSE>>=","opts_template$set(quiet = list(echo=FALSE))", "@",
+        "<<results='asis', opts.label='quiet', echo=TRUE>>=", "1+1", "@"
+      ),
+      quiet = TRUE
+    )
+  )
+)
+
 # a shortcut
 k = function(text) {
   on.exit(opts_chunk$restore())


### PR DESCRIPTION
Love the `opts_template()` feature but occasionally want to override a specific template parameter. This PR just alters the order in which params are processed so local chunk options override any redundant options specified within an options template.

For example:

    ```{r setup}
	knitr::opts_template$set(quiet = list(echo=FALSE))
	```

	```{r template, opts.label='quiet'}
	print("This is hidden")
	```

	```{r override, echo=TRUE, opts.label='quiet'}
	print("This is visible")
	```

    