### PR TITLE
knit2wp environment fix

### DIFF
--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -140,11 +140,11 @@ knit2html = function(input, output = NULL, ..., envir = parent.frame(), text = N
 #'   (especially when using Windows).
 #' @examples # see the reference
 knit2wp = function(
-  input, title = 'A post from knitr', ..., shortcode = FALSE,
+  input, title = 'A post from knitr', ..., envir = parent.frame(), shortcode = FALSE,
   action = c('newPost', 'editPost', 'newPage'), postid,
   encoding = getOption('encoding'), publish = TRUE
 ) {
-  out = knit(input, encoding = encoding); on.exit(unlink(out))
+  out = knit(input, encoding = encoding, envir = envir); on.exit(unlink(out))
   con = file(out, encoding = encoding); on.exit(close(con), add = TRUE)
   content = native_encode(readLines(con, warn = FALSE))
   content = paste(content, collapse = '\n')

--- a/man/chunk_hook.Rd
+++ b/man/chunk_hook.Rd
@@ -15,7 +15,7 @@ hook_plot_custom(before, options, envir)
 hook_purl(before, options, envir)
 }
 \arguments{
-\item{before, options, envir}{see references}
+\item{before,  options,  envir}{see references}
 }
 \description{
 Hook functions are called when the corresponding chunk options are not

--- a/man/knit2wp.Rd
+++ b/man/knit2wp.Rd
@@ -3,8 +3,8 @@
 \alias{knit2wp}
 \title{Knit an R Markdown document and post it to WordPress}
 \usage{
-knit2wp(input, title = "A post from knitr", ..., shortcode = FALSE, 
-    action = c("newPost", "editPost", "newPage"), postid, 
+knit2wp(input, title = "A post from knitr", ..., envir = parent.frame(), 
+    shortcode = FALSE, action = c("newPost", "editPost", "newPage"), postid, 
     encoding = getOption("encoding"), publish = TRUE)
 }
 \arguments{
@@ -14,6 +14,10 @@ knit2wp(input, title = "A post from knitr", ..., shortcode = FALSE,
 
 \item{...}{other meta information of the post, e.g. \code{categories = c('R',
 'Stats')} and \code{mt_keywords = c('knitr', 'wordpress')}, etc}
+
+\item{envir}{the environment in which the code chunks are to be evaluated
+(for example, \code{\link{parent.frame}()}, \code{\link{new.env}()}, or
+\code{\link{globalenv}()})}
 
 \item{shortcode}{a logical vector of length 2: whether to use the shortcode
 \samp{[sourcecode lang='lang']} which can be useful to WordPress.com users

--- a/man/read_chunk.Rd
+++ b/man/read_chunk.Rd
@@ -17,12 +17,12 @@ read_demo(topic, package = NULL, ...)
 
 \item{labels}{a character vector of chunk labels (default \code{NULL})}
 
-\item{from, to}{a numeric vector specifying the starting/ending line numbers
+\item{from,  to}{a numeric vector specifying the starting/ending line numbers
 of code chunks, or a character vector; see Details}
 
-\item{from.offset, to.offset}{an offset to be added to \code{from}/\code{to}}
+\item{from.offset,  to.offset}{an offset to be added to \code{from}/\code{to}}
 
-\item{topic, package}{name of the demo and the package see \code{\link[utils]{demo}}}
+\item{topic,  package}{name of the demo and the package see \code{\link[utils]{demo}}}
 
 \item{...}{arguments to be passed to \code{\link{read_chunk}}}
 }


### PR DESCRIPTION
Hi, Yihui,

The function `knit2wp()` did not pass the argument `envir = parent.frame()` to the `knit()` function (like the other `utils-conversion.R` functions do). That was causing problems because the `.rmd` file was being evaluated in the function environment.

So, for instance, if one had a `rm(list = ls())` in the `.rmd` file, it would remove all the function arguments and cause the function to break.

See this minimal example. 

Create a `bug.rmd` file with:



> <div> --- </div>
> title: "minimal"
> author: "Carlos Cinelli"
> date: "5 de março de 2016"
> output: html_document
> <div>---</div>
> 
> <div>```{r rm}</div>
> rm(list = ls())
> <div>```</div>
> 



Then try to `knit2wp()` the `bug.rmd` file. The function does not find the `encoding` argument.

I would write a test for this, but since it requires to provide a WordPress user and password, I could not think of a simple way to do it. 

Hope this helps, thanks!