### PR TITLE
Add svg output to tikz engine (use fig.ext="svg"). 

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -200,22 +200,47 @@ eng_tikz = function(options) {
   s = append(lines, options$code, i)  # insert tikz into tex-template
   writeLines(s, texf <- paste0(f <- tempfile('tikz', '.'), '.tex'))
   on.exit(unlink(texf), add = TRUE)
-  unlink(outf <- paste0(f, '.pdf'))
-  tools::texi2pdf(texf, clean = TRUE)
-  if (!file.exists(outf)) stop('failed to compile tikz; check the template: ', tmpl)
 
-  fig = fig_path('', options)
-  dir.create(dirname(fig), recursive = TRUE, showWarnings = FALSE)
-  file.rename(outf, paste0(fig, '.pdf'))
-  # convert to the desired output-format, calling `convert`
   ext = tolower(options$fig.ext %n% dev2ext(options$dev))
-  if (ext != 'pdf') {
-    conv = system2(options$engine.opts$convert %n% 'convert', c(
-      options$engine.opts$convert.opts, sprintf('%s.pdf %s.%s', fig, fig, ext)
-    ))
+
+  if (ext=="svg") {
+    unlink(outf <- paste0(f, '.dvi'))
+    tools::texi2dvi(texf, pdf=F, clean = T) #dvisvgm uses .dvi as input not pdf
+    if (!file.exists(outf)) stop('failed to compile tikz to dvi; check the template: ', tmpl)
+
+    fig = fig_path('', options)
+    dir.create(dirname(fig), recursive = TRUE, showWarnings = FALSE)
+    file.rename(outf, paste0(fig, '.dvi'))
+
+    # dvisvgm needs to be on the path
+    # dvisvgm for windows needs ghostscript bin dir on the path also
+    conv = system2("dvisvgm", sprintf("%s.dvi", fig))
     if (conv != 0 && !options$error)
-      stop('problems with `convert`; probably not installed?')
+      stop('problems with `dvisvgm`; check that dvisvgm and ghostscript are installed and on path.')
+
+    # copy the svg to figure-html subdir
+    file.rename(paste0(basename(fig),".svg"), paste0(fig,".svg"))
   }
+  else
+  {
+    unlink(outf <- paste0(f, '.pdf'))
+    tools::texi2pdf(texf, clean = TRUE)
+    if (!file.exists(outf)) stop('failed to compile tikz; check the template: ', tmpl)
+
+    fig = fig_path('', options)
+    dir.create(dirname(fig), recursive = TRUE, showWarnings = FALSE)
+    file.rename(outf, paste0(fig, '.pdf'))
+    # convert to the desired output-format, calling `convert`
+
+    if (ext != 'pdf') {
+      conv = system2(options$engine.opts$convert %n% 'convert', c(
+        options$engine.opts$convert.opts, sprintf('%s.pdf %s.%s', fig, fig, ext)
+      ))
+      if (conv != 0 && !options$error)
+        stop('problems with `convert`; probably not installed?')
+    }
+  }
+
   options$fig.num = 1L; options$fig.cur = 1L
   extra = knit_hooks$get('plot')(paste(fig, ext, sep = '.'), options)
   options$engine = 'tex'  # for output hooks to use the correct language class


### PR DESCRIPTION
As requested [here](https://github.com/yihui/knitr-examples/pull/45) this pull request allows the tikz engine to output svg files by the fig.ext option. eg

```
```{r tikz-ex, engine="tikz", fig.ext="svg"}
```

If you use fig.ext = "png" then tikz will use imagemagick to convert to a raster png
If you don't use the fig.ext option then tikz will output the default pdf.

Note: The fig.ext="svg" option requires that dvisvgm and ghostscript are installed and on path (ghostscript bin directory).
