### PR TITLE
add js and css engines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 - for the `tikz` engine, if `fig.ext = 'svg'`, `dvisvgm` will be called to convert the DVI output of TikZ to SVG; you need to install `dvisvgm`, and Windows users have to install GhostScript as well (thanks, @dkilfoyle, #1177)
 
+- new `js` and `css` engines which surround their content with `<script>` and `<style>` tags respecitvely, and print no output when not in an HTML document
+
 ## BUG FIXES
 
 - when the chunk option `cache.rebuild = TRUE`, the cache database should be rewritten (thanks, Oleg Mayba)

--- a/R/engine.R
+++ b/R/engine.R
@@ -350,6 +350,23 @@ eng_block = function(options) {
   )
 }
 
+# helper to create engines the wrap embedded html assets (e.g. css,js)
+eng_html_asset <- function(prefix, postfix) {
+  function(options) {
+    if (options$eval && is_html_output(allow_markdown = FALSE)) {
+      code <- c(prefix, options$code, postfix)
+      paste(code, collapse = '\n')
+    }
+  }
+}
+
+## include js in a script tag (ignore if not html output)
+eng_js = eng_html_asset('<script type="text/javascript">', '</script>')
+
+## include css in a style tag (ignore if not html output)
+eng_css = eng_html_asset('<style type="text/css">', '</style>')
+
+
 # set engines for interpreted languages
 local({
   for (i in c(
@@ -363,7 +380,7 @@ local({
 knit_engines$set(
   highlight = eng_highlight, Rcpp = eng_Rcpp, tikz = eng_tikz, dot = eng_dot,
   c = eng_shlib, fortran = eng_shlib, asy = eng_dot, cat = eng_cat,
-  asis = eng_asis, stan = eng_stan, block = eng_block
+  asis = eng_asis, stan = eng_stan, block = eng_block, js = eng_js, css = eng_css
 )
 
 get_engine = function(name) {

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -21,9 +21,9 @@ hook_plot_md = function(x, options) {
   hook_plot_md_base(x, options)
 }
 
-is_html_output = function(fmt = pandoc_to()) {
+is_html_output = function(fmt = pandoc_to(), allow_markdown = TRUE) {
   if (length(fmt) == 0) return(FALSE)
-  grepl('^markdown', fmt) ||
+  (allow_markdown && grepl('^markdown', fmt)) ||
     fmt %in% c('epub', 'epub3', 'html', 'html5', 'revealjs', 's5', 'slideous', 'slidy')
 }
 


### PR DESCRIPTION
The engines are quite straightforward, the just surround their content with `<script>` and `<style>` tags respectively, and print no output when not in an HTML document.

This is of course already possible by direct embedding of `<script>` and `<style>` tags, the main motivation for making them engines is to enable use of the RStudio js and css modes for editing, to better demark them as executable code within documents, and enable use of both of the above with chunk options like eval = FALSE, etc.

@jcheng5