### PR TITLE
Fix `current_input` with absolute input file path

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -703,8 +703,7 @@ current_input = function(dir = FALSE) {
   if (dir) {
       if (substr(input, 1, 1) %in% c('/', '~')) {
           input
-      }
-      else {
+      } else {
           file.path(outwd, input)
       }
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -700,7 +700,16 @@ current_input = function(dir = FALSE) {
       dir = FALSE
     }
   }
-  if (dir) file.path(outwd, input) else input
+  if (dir) {
+      if (substr(input, 1, 1) %in% c('/', '~')) {
+          input
+      }
+      else {
+          file.path(outwd, input)
+      }
+  } else {
+      basename(input)
+  }
 }
 
 # import output handlers from evaluate

--- a/R/utils.R
+++ b/R/utils.R
@@ -701,7 +701,7 @@ current_input = function(dir = FALSE) {
     }
   }
   if (dir) {
-      if (substr(input, 1, 1) %in% c('/', '~')) {
+      if (is_abs_path(input)) {
           input
       } else {
           file.path(outwd, input)


### PR DESCRIPTION
With an absolute input file path passed to `knit`, `current_input` yields wrong output:

* When `dir = FALSE` is specified, an absolute path is given, not just
  the filename, contrary to the function’s documentation.
* When `dir = TRUE` is specified, the current working directory path is
  prepended to the absolute file path, yielding an incorrect path.

This situation (absolute input path) arises in particular when wrapping calls to knitr by using [‹ezknitr›](https://github.com/daattali/ezknitr), but it’s in principle an independent bug.

### Here’s an MWE:

    ```{r echo=FALSE}
    message(knitr::current_input())
    message(knitr::current_input(TRUE))
    ```

Run via

```bash
Rscript -e "knitr::knit('$(pwd)/test.rmd')"
```

#### Expected output:
    
    ```
    ## test.rmd
    ```
    
    ```
    ## /Users/konrad/tmp/knitr_after/test.rmd
    ```

#### Actual output:
    
    ```
    ## /Users/konrad/tmp/knitr_after/test.rmd
    ```
    
    ```
    ## /Users/konrad/tmp/knitr//Users/konrad/tmp/knitr/test.rmd
    ```
