### PR TITLE
Enable caching of Rcpp engine chunks

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -67,7 +67,9 @@ call_block = function(block) {
     }
     hash = paste(valid_path(params$cache.path, label), digest::digest(content), sep = '_')
     params$hash = hash
-    if (cache$exists(hash, params$cache.lazy) && isFALSE(params$cache.rebuild)) {
+    if (cache$exists(hash, params$cache.lazy) &&
+        isFALSE(params$cache.rebuild) &&
+        params$engine != 'Rcpp') {
       if (opts_knit$get('verbose')) message('  loading cache from ', hash)
       cache$load(hash, lazy = params$cache.lazy)
       if (!params$include) return('')

--- a/R/engine.R
+++ b/R/engine.R
@@ -157,30 +157,17 @@ eng_Rcpp = function(options) {
   opts = options$engine.opts
 
   # use custom cacheDir for sourceCpp if it's supported
-  cache <- options$cache && (packageVersion("Rcpp") >= "0.12.5.6")
+  cache <- options$cache && (packageVersion("Rcpp") >= "0.12.5.7")
   if (cache) {
     opts$cacheDir <- file.path(opts_chunk$get('cache.path'),
                                paste(options$label, "sourceCpp", sep = "_"))
-    if(!dir.exists(opts$cacheDir))
-      dir.create(opts$cacheDir, recursive = TRUE)
+    opts$cleanupCacheDir = TRUE
   }
 
   if (!is.environment(opts$env)) opts$env = knit_global() # default env is knit_global()
   if (options$eval) {
-    # build the library
     message('Building shared library for Rcpp code chunk...')
-    result <- do.call(getFromNamespace('sourceCpp', 'Rcpp'), c(list(code = code), opts))
-    # if we are using a cache then cleanup old entries
-    if (cache) {
-      cpp_source_path <- normalizePath(result$cppSourcePath)
-      build_directory <- normalizePath(result$buildDirectory)
-      cache_dir <- dirname(build_directory)
-      cache_files <- list.files(cache_dir, pattern = glob2rx("*.cpp"), recursive = FALSE, full.names = TRUE)
-      cache_files <- c(cache_files, list.dirs(cache_dir, recursive = FALSE, full.names = TRUE))
-      cache_files <- normalizePath(cache_files)
-      old_cache_files <- cache_files[!cache_files %in% c(cpp_source_path, build_directory)]
-      unlink(old_cache_files, recursive = TRUE)
-    }
+    do.call(getFromNamespace('sourceCpp', 'Rcpp'), c(list(code = code), opts))
   }
 
   options$engine = 'cpp' # wrap up source code in cpp syntax instead of Rcpp

--- a/R/engine.R
+++ b/R/engine.R
@@ -155,6 +155,11 @@ eng_Rcpp = function(options) {
   # engine.opts is a list of arguments to be passed to Rcpp function, e.g.
   # engine.opts=list(plugin='RcppArmadillo')
   opts = options$engine.opts
+
+  # use custom cacheDir for sourceCpp if it's supported
+  if (options$cache && (packageVersion("Rcpp") >= "0.12.5.5"))
+    opts$cacheDir <- file.path(opts_chunk$get('cache.path'))
+
   if (!is.environment(opts$env)) opts$env = knit_global() # default env is knit_global()
   if (options$eval) {
     message('Building shared library for Rcpp code chunk...')

--- a/R/engine.R
+++ b/R/engine.R
@@ -157,7 +157,7 @@ eng_Rcpp = function(options) {
   opts = options$engine.opts
 
   # use custom cacheDir for sourceCpp if it's supported
-  cache <- options$cache && (packageVersion("Rcpp") >= "0.12.5.5")
+  cache <- options$cache && (packageVersion("Rcpp") >= "0.12.5.6")
   if (cache) {
     opts$cacheDir <- file.path(opts_chunk$get('cache.path'),
                                paste(options$label, "sourceCpp", sep = "_"))
@@ -167,14 +167,19 @@ eng_Rcpp = function(options) {
 
   if (!is.environment(opts$env)) opts$env = knit_global() # default env is knit_global()
   if (options$eval) {
+    # build the library
     message('Building shared library for Rcpp code chunk...')
     result <- do.call(getFromNamespace('sourceCpp', 'Rcpp'), c(list(code = code), opts))
-    # remove old build directories from cache
+    # if we are using a cache then cleanup old entries
     if (cache) {
-      buildParent <- dirname(result$buildDirectory)
-      buildDirs <- list.dirs(path = buildParent, full.names = TRUE, recursive = FALSE)
-      oldBuildDirs <- buildDirs[buildDirs != result$buildDirectory]
-      unlink(oldBuildDirs, recursive = TRUE)
+      cpp_source_path <- normalizePath(result$cppSourcePath)
+      build_directory <- normalizePath(result$buildDirectory)
+      cache_dir <- dirname(build_directory)
+      cache_files <- list.files(cache_dir, pattern = glob2rx("*.cpp"), recursive = FALSE, full.names = TRUE)
+      cache_files <- c(cache_files, list.dirs(cache_dir, recursive = FALSE, full.names = TRUE))
+      cache_files <- normalizePath(cache_files)
+      old_cache_files <- cache_files[!cache_files %in% c(cpp_source_path, build_directory)]
+      unlink(old_cache_files, recursive = TRUE)
     }
   }
 

--- a/R/engine.R
+++ b/R/engine.R
@@ -169,7 +169,6 @@ eng_Rcpp = function(options) {
   if (options$eval) {
     message('Building shared library for Rcpp code chunk...')
     result <- do.call(getFromNamespace('sourceCpp', 'Rcpp'), c(list(code = code), opts))
-    print(result)
     # remove old build directories from cache
     if (cache) {
       buildParent <- dirname(result$buildDirectory)


### PR DESCRIPTION
This PR aims to enable support for caching of Rcpp engine chunks. Once completed this will resolve https://github.com/rstudio/bookdown/issues/113.

This also requires changes in Rcpp which can be found here: https://github.com/RcppCore/Rcpp/pull/504. To install this branch:

```r
devtools::install_github("RcppCore/Rcpp", ref = "feature/source-cpp-cache-dir")
```

The way Rcpp does caching of compilations isn't entirely compatible with the default codepath for knitr caching so we'll need some additional customized behavior for the Rcpp engine to get this fully working. 

Cross-session caching for the `sourceCpp` function can now be enabled by passing a `cacheDir` argument to `sourceCpp` (it normally defaults to `tempdir()`). This will cache the expensive part of the compilation (the R CMD SHLIB) however the code still needs to run in order to bind the R function that wraps the C++ function to the location of the (cached) shared library on disk.

So what we want is that for the Rcpp engine the `cache` option is passed through to the engine (so it can invoke `sourceCpp` with the `cacheDir` option) however knitr essentially ignores this option and always runs the chunk.

The more general notion here is that engines should be able to have their own caching strategies. I trawled around the knitr code for a while attempting to make this work but couldn't find a path. @yihui let me know your thoughts. 

