### PR TITLE
various improvements to sql engine

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -410,27 +410,70 @@ eng_sql = function(options) {
     do.call(DBI::sqlInterpolate, c(list(conn, sql), args))
   }
 
+  # extract options
   conn = options$connection
   varname = options$output.var
-  limit = options$limit %n% 10  # fetch 10 records by default if varname not provided
-  if (is.na(limit)) limit = -1
-  max.display = options$max.display
+  max.print <- options$max.print %n% (opts_knit$get('sql.max.print') %n% 10)
+  if (is.na(max.print) || is.null(max.print))
+    max.print = -1
   sql = options$code
 
+  # execute query -- when we are printing with an enforced max.print we
+  # use dbFetch so as to only pull down the required number of records
   query = interpolate_from_env(conn, sql)
-  if (is.null(varname) && limit > 0) {
+  if (is.null(varname) && max.print > 0) {
     res = DBI::dbSendQuery(conn, query)
-    data = DBI::dbFetch(res, n = limit)
+    if (!DBI::dbHasCompleted(res))
+      data = DBI::dbFetch(res, n = max.print)
+    else
+      data = NULL
     DBI::dbClearResult(res)
-  } else data = DBI::dbGetQuery(conn, query)
-  output = if (!is.null(data) && ncol(data) > 0) capture.output(
-    if (loadable('tibble')) print(tibble::as_tibble(data)) else {
-      if (is.null(max.display)) print(data) else print(head(data, max.display))
+  } else {
+    data = DBI::dbGetQuery(conn, query)
+  }
+
+  # create output if needed (we have data and we aren't assigning it to a variable)
+  if (!is.null(data) && ncol(data) > 0 && is.null(varname)) output = capture.output({
+
+    # apply max.print to data
+    if (max.print == -1)
+      display_data <- data
+    else
+      display_data <- head(data, n = max.print)
+
+    # use kable for markdown
+    if (out_format('markdown')) {
+
+      # we are going to output raw markdown so set results = 'asis'
+      options$results <- 'asis'
+
+      # wrap html output in a div so special styling can be applied
+      if (is_html_output())
+        cat("<div class=\"knitsql-table\">\n")
+
+      # print using kable
+      print(kable(data))
+
+      # terminate div
+      if (is_html_output())
+        cat("\n</div>\n")
+
+    # otherwise use tibble if it's available
+    } else if (loadable('tibble')) {
+        print(tibble::as_tibble(display_data))
+
+    # fallback to standard print
+    } else
+        print(display_data)
     }
   )
+  else
+    output = NULL
 
+  # assign varname if requested
   if (!is.null(varname)) assign(varname, data, envir = knit_global())
 
+  # return output
   engine_output(options, options$code, output)
 }
 


### PR DESCRIPTION
A number of related improvements here:

1. Never display records when capturing to a variable (this is equivalent to an R assignment to a data frame which is invisible)

2. Use single `max.print` option (replaces `limit` and `max.display`) whose default is drawn from a knitr option (`sql.max.print`) that in turn defaults to 10.

3. Check `DBI::dbHasCompleted` before calling `DBI::dbFetch` to prevent warnings for queries that don't return records.

4. Print table using `kable` when emiting markdown output. For HTML output also add a div around the table with class "knitsql-table" to make it easier for page renderers to provide custom styling/behaviors (e.g. sticky table headers for larger numbers of records).