### PR TITLE
For wrapped code, set `tidy=TRUE`

### DIFF
--- a/inst/examples/knitr-twocolumn.Rnw
+++ b/inst/examples/knitr-twocolumn.Rnw
@@ -46,7 +46,7 @@ figures can span over two columns. Because the output hooks use the
 environment, we can either modify the output hooks or use other packages
 like \textbf{listings}. For example,
 
-<<chunk-hook, echo=2, tidy.opts=list(width.cutoff=30)>>=
+<<chunk-hook, echo=2, tidy=TRUE, tidy.opts=list(width.cutoff=30)>>=
 <<setup>>
 @
 


### PR DESCRIPTION
This now needs to be done explicitly, either where I've made the edit or above that in `opt_chunk$set()`  (which will result in slightly different output for the pdf's first listing).