### PR TITLE
version qualify DBI dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,7 +101,7 @@ Suggests:
     jpeg,
     XML,
     RCurl,
-    DBI,
+    DBI (>= 0.4-1),
     tibble
 License: GPL
 URL: http://yihui.name/knitr/


### PR DESCRIPTION
We need 0.4-1 for the parameter binding feature to work.