### PR TITLE
Accept numeric indices for fig.keep (#1265).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - added a new engine named `sql` that uses the **DBI** package to execute SQL queries, and optionally assign the result to a variable in the **knitr** session; see http://rmarkdown.rstudio.com/authoring_knitr_engines.html for details (#1241)
 
+- `fig.keep` now accepts numeric values to index low-level plots to keep (#1265)
+
 ## BUG FIXES
 
 - fixed #1211: `pandoc('foo.md')` generates foo_utf8.html instead of foo.html by default

--- a/R/block.R
+++ b/R/block.R
@@ -119,6 +119,11 @@ block_exec = function(options) {
   obj.before = ls(globalenv(), all.names = TRUE)  # global objects before chunk
 
   keep = options$fig.keep
+  keep.idx = NULL
+  if (is.numeric(keep)) {
+    keep.idx = keep
+    keep = "index"
+  }
   # open a device to record plots
   if (chunk_device(options$fig.width[1L], options$fig.height[1L], keep != 'none',
                    options$dev, options$dev.args, options$dpi, options)) {
@@ -220,6 +225,8 @@ block_exec = function(options) {
         if (keep %in% c('first', 'last')) {
           res = res[-(if (keep == 'last') head else tail)(which(figs), -1L)]
         } else {
+          # keep only selected
+          if (keep == 'index') res = res[which(figs)[keep.idx]]
           # merge low-level plotting changes
           if (keep == 'high') res = merge_low_plot(res, figs)
         }


### PR DESCRIPTION
As discussed in #1265. However, I had to create a new variable for the indices and manipulate `keep` to remain of length 1. Otherwise, passing a vector to `fig.keep` would crash the comparisons accessing `keep`.
