### PR TITLE
avoid using dbFetch in sql chunks for update queries

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -379,6 +379,19 @@ eng_js = eng_html_asset('<script type="text/javascript">', '</script>')
 # include css in a style tag (ignore if not html output)
 eng_css = eng_html_asset('<style type="text/css">', '</style>')
 
+# perform basic sql parsing to determine if a sql query is an update query
+is_sql_update_query = function(query) {
+  # remove line comments
+  query <- gsub("^\\s*--.*\n", "", query)
+
+  # remove multi-line comments
+  if (grepl("^\\s*\\/\\*.*", query)) {
+    query <- gsub(".*\\*\\/", "", query)
+  }
+
+  grepl("^\\s*(INSERT|UPDATE|DELETE|CREATE).*", query)
+}
+
 # sql engine
 eng_sql = function(options) {
   # Return char vector of sql interpolation param names
@@ -424,10 +437,9 @@ eng_sql = function(options) {
   # execute query -- when we are printing with an enforced max.print we
   # use dbFetch so as to only pull down the required number of records
   query = interpolate_from_env(conn, sql)
-  if (is.null(varname) && max.print > 0) {
+  if (is.null(varname) && max.print > 0 && !is_sql_update_query(query)) {
     res = DBI::dbSendQuery(conn, query)
-    data = if (!DBI::dbHasCompleted(res) || (DBI::dbGetRowCount(res) > 0))
-              DBI::dbFetch(res, n = max.print)
+    data = DBI::dbFetch(res, n = max.print)
     DBI::dbClearResult(res)
   } else {
     data = DBI::dbGetQuery(conn, query)

--- a/R/engine.R
+++ b/R/engine.R
@@ -389,7 +389,7 @@ is_sql_update_query = function(query) {
     query <- gsub(".*\\*\\/", "", query)
   }
 
-  grepl("^\\s*(INSERT|UPDATE|DELETE|CREATE).*", query)
+  grepl("^\\s*(INSERT|UPDATE|DELETE|CREATE).*", query, ignore.case = TRUE)
 }
 
 # sql engine

--- a/tests/testit/test-sql.R
+++ b/tests/testit/test-sql.R
@@ -1,0 +1,51 @@
+library(testit)
+
+assert(identical(is_sql_update_query("SELECT 1"), FALSE))
+assert(identical(is_sql_update_query("SELECT * FROM foo"), FALSE))
+assert(identical(is_sql_update_query(" SELECT 1"), FALSE))
+assert(identical(is_sql_update_query("\nSELECT 1"), FALSE))
+assert(identical(is_sql_update_query("\tSELECT 1"), FALSE))
+
+assert(identical(is_sql_update_query(paste(
+  "-- Some SQL",
+  "SELECT 1",
+  sep = "\n")), FALSE))
+
+assert(identical(is_sql_update_query(paste(
+  "/* ",
+  "   Some SQL",
+  "*/",
+  "SELECT 1",
+  sep = "\n")), FALSE))
+
+assert(identical(is_sql_update_query(paste(
+  "   /* ",
+  "      Some SQL",
+  "   */",
+  "SELECT 1",
+  sep = "\n")), FALSE))
+
+assert(identical(is_sql_update_query("UPDATE foo SET a=1"), TRUE))
+assert(identical(is_sql_update_query(" UPDATE foo SET a=1"), TRUE))
+assert(identical(is_sql_update_query("\n\nUPDATE foo SET a=1"), TRUE))
+assert(identical(is_sql_update_query("\tUPDATE foo SET a=1"), TRUE))
+assert(identical(is_sql_update_query("DELETE FROM foo"), TRUE))
+assert(identical(is_sql_update_query("INSERT INTO foo values(1)"), TRUE))
+
+assert(identical(is_sql_update_query(paste(
+  "-- SELECT 1",
+  "INSERT INTO foo values(1)",
+  sep = "\n")), TRUE))
+
+assert(identical(is_sql_update_query(paste(
+  "/*SELECT 1*/",
+  "   INSERT INTO foo values(1)",
+  sep = "\n")), TRUE))
+
+assert(identical(is_sql_update_query(paste(
+  "/*",
+  "   Insert records into table",
+  "*/",
+  "",
+  "   INSERT INTO foo values(1)",
+  sep = "\n")), TRUE))

--- a/tests/testit/test-sql.R
+++ b/tests/testit/test-sql.R
@@ -49,3 +49,7 @@ assert(identical(is_sql_update_query(paste(
   "",
   "   INSERT INTO foo values(1)",
   sep = "\n")), TRUE))
+
+assert(identical(is_sql_update_query("update foo set a=1"), TRUE))
+assert(identical(is_sql_update_query("delete from foo"), TRUE))
+assert(identical(is_sql_update_query("insert into foo values(1)"), TRUE))


### PR DESCRIPTION
SQL chunks currently don't work with `RJDBC` since `RJDBC` does not support `DBI::dbGetRowCount(res)`. However, implementing `DBI::dbGetRowCount(res)` in `RJDBC` is not ideal since it is supposed to represent "the number of rows fetched so far" (http://rstats-db.github.io/DBI/dbGetRowCount.html), which for `RJDBC`s implementation is still zero before executing `dbFetch` since `dbSendQuery` won't prefetch fata. Some backends return useful information in `dbGetRowCount` before calling `dbFetch` but this is not necessarily true for all of them.

This PR fixed this by using`dbFetch` only for select queries. I believe this is desirable since with `DBI 0.5` a `dbExecute` function is introduced which is designed for update queries, more over, this is already supported in `RJDBC` through `dbSendUpdate`. Porting `knitr` to `DBI 0.5` is not being addressed in this PR; however, something we should consider doing at some point.

This PR is to resolve https://github.com/yihui/knitr/issues/1271