### PR TITLE
Added engine for Fortran95

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -134,7 +134,7 @@ eng_interpreted = function(options) {
 
 ## C and Fortran (via R CMD SHLIB)
 eng_shlib = function(options) {
-  n = switch(options$engine, c = 'c', fortran = 'f')
+  n = switch(options$engine, c = 'c', fortran = 'f', fortran95 = 'f95')
   f = basename(tempfile(n, '.', paste0('.', n)))
   writeLines(options$code, f)
   on.exit(unlink(c(f, sub_ext(f, c('o', 'so', 'dll')))))
@@ -517,7 +517,7 @@ local({
 # additional engines
 knit_engines$set(
   highlight = eng_highlight, Rcpp = eng_Rcpp, tikz = eng_tikz, dot = eng_dot,
-  c = eng_shlib, fortran = eng_shlib, asy = eng_dot, cat = eng_cat,
+  c = eng_shlib, fortran = eng_shlib, fortran95 = eng_shlib, asy = eng_dot, cat = eng_cat,
   asis = eng_asis, stan = eng_stan, block = eng_block, js = eng_js, css = eng_css,
   sql = eng_sql
 )


### PR DESCRIPTION
The default behaviour for the Fortran engine is to produce a temporary xxx.f file which causes SHLIB to interpret it as Fortran 77 (https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Using-F95-code).  Fortran 77 is different from Fortran 90/95.
I will not divulge into the problems of using Fortran 95 (as indicated in the link), I just want to compile Fortran 95 code; the SHLIB mechanism apparently switches to a Fortran 95 compiler (if available) when the file extension is .f95.