### PR TITLE
Updated required version for evaluate package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -80,7 +80,7 @@ Description: Provides a general-purpose tool for dynamic report generation in R
 Depends:
     R (>= 3.1.0)
 Imports:
-    evaluate (>= 0.8),
+    evaluate (>= 0.10),
     digest,
     highr,
     markdown,


### PR DESCRIPTION
evaluate version 0.10 added the include_timing argument.  When knitting documents, this argument was being passed to the evaluate function, which did not recognize it and raised an error.