### PR TITLE
Add go engine

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Authors@R: c(
     person("Henrik", "Bengtsson", role = "ctb"),
     person("Hiroaki", "Yutani", role = "ctb"),
     person("Ian", "Lyttle", role = "ctb"),
+    person("Hodges", "Daniel", role = "ctb"),
     person("Jake", "Burkhead", role = "ctb"),
     person("James", "Manton", role = "ctb"),
     person("Jared", "Lander", role = "ctb"),


### PR DESCRIPTION
This engine allows for adding go code within a `{go}` block. It will attempt to run `go fmt` first on any code so that it is rendered in the standard go format. Also supports `eval` as long as the block contains an executable block of code.

