### PR TITLE
adds options class.output and class.source for html documents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Authors@R: c(
     person("Heewon", "Jeon", role = "ctb"),
     person("Henrik", "Bengtsson", role = "ctb"),
     person("Hiroaki", "Yutani", role = "ctb"),
+    person("Ian", "Lyttle", role = "ctb"),
     person("Jake", "Burkhead", role = "ctb"),
     person("James", "Manton", role = "ctb"),
     person("Jared", "Lander", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## NEW FEATURES
 
+- adds two new options, `class.output` and `class.source` to help you manage the appearance of output and source chunks. This can be useful in the context of `rmarkdown::render()` using `rmarkdown::html_document()` (@ijlyttle) # This note is aspirational for the moment - it's here so I can start a pull request.
+
 - added a new hook function `hook_pngquant()` that can call `pngquant` to optimize PNG images (thanks, @slowkow, #1320)
 
 ## BUG FIXES

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -107,6 +107,15 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
   set_html_dev()
   opts_knit$set(out.format = 'markdown')
   fence = paste(rep(fence_char, 3), collapse = '')
+  # helper function to manage classes
+  block_class = function(x){
+
+    classes = unlist(strsplit(x, split = ' '))
+    str_class = paste0('.', classes, collapse = ' ')
+    block_class = paste0('{', str_class, '}')
+
+    block_class
+  }
   # four spaces lead to <pre></pre>
   hook.t = function(x, options) {
     if (strict) {
@@ -122,10 +131,8 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
       paste0('\n\n', fence, x, fence, '\n\n')
     }
   }
-  # this feels a bit hacky, copy-pasting much of
-  # this code - maybe a better way will
-  # reveal itself
   hook.t.output = function(x, options) {
+    # this code-block is duplicated from hook.t()
     if (strict) {
       paste('\n', indent_block(x), '', sep = '\n')
     } else {
@@ -137,15 +144,12 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
         if (l >= 4) fence = paste(rep(fence_char, l), collapse = '')
       }
 
-      # this is the original bit
-      if (is.null(options$class.output)){
-        class_header = NULL
-      } else {
-        class = paste0('.', options$class.output, collapse = ' ')
-        class_header = paste0('{', class, '}')
+      # the rest is 'new'
+      class_header = NULL
+      if (!is.null(options$class.output)){
+        class_header = block_class(options$class.output)
       }
 
-      # this is new, too
       paste0('\n\n', fence, class_header, x, fence, '\n\n')
     }
   }
@@ -154,9 +158,7 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
     if (language == 'node') language = 'javascript'
     if (!options$highlight) language = 'text'
     if (!is.null(options$class.source)){
-      language_class =
-        paste0('.', c(language, options$class.source), collapse = ' ')
-      language = paste0('{', language_class, '}')
+      language = block_class(c(language, options$class.source))
     }
     paste0('\n\n', fence, language, '\n', x, fence, '\n\n')
   }

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -122,6 +122,31 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
       paste0('\n\n', fence, x, fence, '\n\n')
     }
   }
+  # this feels a bit hacky, copy-pasting much of
+  # this code - maybe a better way will
+  # reveal itself
+  hook.t.output = function(x, options) {
+    if (strict) {
+      paste('\n', indent_block(x), '', sep = '\n')
+    } else {
+      x = paste(c('', x), collapse = '\n')
+      r = paste0('\n', fence_char, '{3,}')
+      if (grepl(r, x)) {
+        l = attr(gregexpr(r, x)[[1]], 'match.length')
+        l = max(l)
+        if (l >= 4) fence = paste(rep(fence_char, l), collapse = '')
+      }
+
+      if (is.null(options$class.output)){
+        class_header = NULL
+      } else {
+        class = paste0('.', options$class.output, collapse = ' ')
+        class_header = paste0('{', class, '}')
+      }
+
+      paste0('\n\n', fence, class_header, x, fence, '\n\n')
+    }
+  }
   hook.r = function(x, options) {
     language = tolower(options$engine)
     if (language == 'node') language = 'javascript'
@@ -138,7 +163,7 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
       x = hilight_source(x, 'markdown', options)
       (if (strict) hook.t else hook.r)(paste(c(x, ''), collapse = '\n'), options)
     },
-    output = hook.t, warning = hook.t, error = hook.t, message = hook.t,
+    output = hook.t.output, warning = hook.t, error = hook.t, message = hook.t,
     inline = function(x) {
       fmt = pandoc_to()
       fmt = if (length(fmt) == 1L) 'latex' else 'html'

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -137,6 +137,7 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
         if (l >= 4) fence = paste(rep(fence_char, l), collapse = '')
       }
 
+      # this is the original bit
       if (is.null(options$class.output)){
         class_header = NULL
       } else {
@@ -144,6 +145,7 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
         class_header = paste0('{', class, '}')
       }
 
+      # this is new, too
       paste0('\n\n', fence, class_header, x, fence, '\n\n')
     }
   }

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -126,13 +126,19 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
     language = tolower(options$engine)
     if (language == 'node') language = 'javascript'
     if (!options$highlight) language = 'text'
+    if (!is.null(options$class.source)){
+      language_class =
+        paste0('.', c(language, options$class.source), collapse = ' ')
+      language = paste0('{', language_class, '}')
+    }
     paste0('\n\n', fence, language, '\n', x, fence, '\n\n')
   }
   knit_hooks$set(
     source = function(x, options) {
       x = hilight_source(x, 'markdown', options)
       (if (strict) hook.t else hook.r)(paste(c(x, ''), collapse = '\n'), options)
-    }, output = hook.t, warning = hook.t, error = hook.t, message = hook.t,
+    },
+    output = hook.t, warning = hook.t, error = hook.t, message = hook.t,
     inline = function(x) {
       fmt = pandoc_to()
       fmt = if (length(fmt) == 1L) 'latex' else 'html'

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -132,7 +132,7 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
     }
   }
   hook.t.output = function(x, options) {
-    # this code-block is duplicated from hook.t()
+    # this code-block duplicated from hook.t()
     if (strict) {
       paste('\n', indent_block(x), '', sep = '\n')
     } else {

--- a/docs/options/index.md
+++ b/docs/options/index.md
@@ -110,6 +110,8 @@ Below is a list of chunk options in **knitr**. Note the options `background` and
   changing it will not invalidate the cache
 - `strip.white`: (`TRUE`; logical) whether to remove the white lines in the
   beginning or end of a source chunk in the output
+- `class.output`: (NULL; character) useful for HTML output, appends classes that
+  can be used in conjunction with css, so you can apply custom formatting.
 
 ### Code Decoration
 
@@ -121,6 +123,8 @@ Below is a list of chunk options in **knitr**. Note the options `background` and
 - `highlight`: (`TRUE`; logical) whether to highlight the source code (it is `FALSE` by default if the output is Sweave or listings)
 - `size`: (`'normalsize'`; character) font size for the default LaTeX output (see `?highlight` in the **highlight** package for a list of possible values)
 - `background`: (`'#F7F7F7'`; character or numeric) background color of chunks in LaTeX output (passed to the LaTeX package **framed**); the color model is `rgb`; it can be either a numeric vector of length 3, with each element between 0 and 1 to denote red, green and blue, or any built-in color in R like `red` or `springgreen3` (see `colors()` for a full list), or a hex string like `#FFFF00`, or an integer (all these colors will be converted to the RGB model; see `?col2rgb` for details)
+- `class.source`: (NULL; character) useful for HTML output, appends classes that
+  can be used in conjunction with css, so you can apply custom formatting.
 
 There is a hidden option `indent` which stores the possible leading white spaces of the chunk, e.g. for the chunk below, `indent` is a character string of two spaces:
 


### PR DESCRIPTION
Addresses #1333

This work is just beginning - I am opening the PR now so that @yihui and @AmeliaMN can pull me back towards the right path should I go the wrong way.

- [x] code
  -  [x] adapt `render_markdown()` in `hooks-md.R`
     - [x] `class.source`
     - [x] `class.output`
     - [x] clean out extraneous comments in `hooks.t.output`
- [x] documentation
  - [x] make PR to [knitr-examples](https://github.com/yihui/knitr-examples)
  - [x] docs (docs/options/index.md)
- [x] add a name to DESCRIPTION/Contributors

If you prefer to keep all the feedback until the whole PR is "done", I'll send a signal when I think I am there.

FWIW, here's a [gist](https://gist.github.com/ijlyttle/000efb922103ff7bd55625443187e774) with the Rmd file I've been using to test things.