### PR TITLE
Added clarifying note about fig.path behavior

### DIFF
--- a/options/index.md
+++ b/options/index.md
@@ -186,7 +186,7 @@ leading white spaces have special meanings in markdown.
 
 ### Plots
 
-- `fig.path`: (`'figure/'`; character) prefix to be used for figure filenames (`fig.path` and chunk labels are concatenated to make filenames); it may contain a directory like `figure/prefix-` (will be created if it does not exist); this path is relative to the current working directory
+- `fig.path`: (`'figure/'`; character) prefix to be used for figure filenames (`fig.path` and chunk labels are concatenated to make filenames); it may contain a directory like `figure/prefix-` (will be created if it does not exist); this path is relative to the current working directory; if the prefix ends in a trailing slash, e.g. `output/figures/`, figures will be saved in the specified directory without any changes to filename prefix, thus providing a relative filepath alternative to the package-level option `base.dir`
 - `fig.keep`: (`'high'`; character) how plots in chunks should be kept; it takes five possible character values or a numeric vector (see the end of this section for an example)
   - `high`: only keep high-level plots (merge low-level changes into high-level plots);
   - `none`: discard all plots;


### PR DESCRIPTION
Added a note which should help clarify the behavior of the `fig.path` chunk option and should help make it easier to see how to change the figure output directory to a relative location. In particular, it is useful to indicate that 'output/dir' and 'output/dir/' will behave very differently when passed to `fig.path`. (e.g. see http://stackoverflow.com/questions/21582402/knitr-how-to-set-a-figure-path-in-knit2html-without-using-setwd)