### PR TITLE
Add expand Option to SQL Engine

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,7 +76,8 @@ Authors@R: c(
     person("Viktoras", "Veitas", role = "ctb"),
     person("Weicheng", "Zhu", role = "ctb"),
     person("Wush", "Wu", role = "ctb"),
-    person("Zachary", "Foster", role = "ctb")
+    person("Zachary", "Foster", role = "ctb"),
+    person("Forest", "Fang", role = "ctb")
     )
 Maintainer: Yihui Xie <xie@yihui.name>
 Description: Provides a general-purpose tool for dynamic report generation in R

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - added a `go` engine (thanks, @hodgesds, #1330)
 
+- added a `sql.show_interpolated` chunk option for `sql` engine. For `{sql, sql.show_interpolated=TRUE}`, interpolated SQL query will be dispalyed in the renderred document instead (thanks, @saurfang, #1357)
+
 ## MAJOR CHANGES
 
 - a warning will be emitted when the chunk option `fig.show='hold'` and the output format is Word (https://github.com/rstudio/bookdown/issues/249); `fig.show='hold'` will be changed to `'asis'` at the same time


### PR DESCRIPTION
SQL chunk is an awesome way to showcase SQL queries in syntax highlighted fashion. The support of interpolation is also great to allow further flexibility. While most the time I like showing uninterpolated SQL which is simple and easy to reason, sometimes I wish I can show interpolated SQL instead. This allows me to construct more complex SQL programmatically but show readers the end results.

This PR adds a new option `expand` for SQL engine, which would show interpolated SQL query in the code chunk.

I am open to any suggestion for a better name. Let me know if you can think of a better idea. Thank you!

Putting a space between ` so code block works correctly.

```
` ``{r}
x <- 1
` ``

` ``{sql, connection=db}
SELECT ?x
` ``

` ``{sql, connection=db, expand=TRUE}
SELECT ?x
` ``
```

![image](https://cloud.githubusercontent.com/assets/4317392/22755025/51064762-edf6-11e6-9830-72aaaa38c1e0.png)

