### PR TITLE
Support sql engine character connection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
 
 - `purl()` can now also retrieve the code from inline expressions; it is disabled by default for compatibility, and can be enabled via `options(knitr.purl.inline = TRUE)` (thanks, @kforner, #1345)
 
+## BUG FIXES
+
+- `opts_chunk$set` supports referencing a sql connection by variable name.
+
 # CHANGES IN knitr VERSION 1.15.1
 
 ## NEW FEATURES

--- a/R/engine.R
+++ b/R/engine.R
@@ -464,6 +464,8 @@ eng_sql = function(options) {
 
   # extract options
   conn = options$connection
+  if (is.character(conn))
+    conn <- get(conn, envir = globalenv())
   if (is.null(conn)) stop2(
     "The 'connection' option (DBI connection) is required for sql chunks."
   )

--- a/R/engine.R
+++ b/R/engine.R
@@ -465,7 +465,7 @@ eng_sql = function(options) {
   # extract options
   conn = options$connection
   if (is.character(conn))
-    conn <- get(conn, envir = globalenv())
+    conn <- get(conn, envir = knit_global())
   if (is.null(conn)) stop2(
     "The 'connection' option (DBI connection) is required for sql chunks."
   )


### PR DESCRIPTION
The following document renders a SQL chunk by setting the connection based on a character string, as in, `knitr::opts_chunk$set(connection = "db")`. This is supported in RStudio notebooks but not in `knitr`, this PR matches functionality.

    ```{r}
    ---
    title: "R Notebook"
    output:
      html_document: default
      html_notebook: default
    ---

    ```{r setup}
    library(DBI)
    db <- dbConnect(RSQLite::SQLite(), dbname = "sql.sqlite")
    knitr::opts_chunk$set(connection = "db")
    ```

    ```{sql}
    SELECT 1
    ```