### PR TITLE
New function to build rst vignettes with pandoc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -114,7 +114,7 @@ URL: http://yihui.name/knitr/
 BugReports: https://github.com/yihui/knitr/issues
 VignetteBuilder: knitr
 SystemRequirements: Package vignettes based on R Markdown v2 or reStructuredText require Pandoc (http://pandoc.org). 
-    The function rst2pdf() reStructuredText require rst2pdf (https://github.com/rst2pdf/rst2pdf).
+    The function rst2pdf() require rst2pdf (https://github.com/rst2pdf/rst2pdf).
 Collate:
     'block.R'
     'cache.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -113,9 +113,8 @@ License: GPL
 URL: http://yihui.name/knitr/
 BugReports: https://github.com/yihui/knitr/issues
 VignetteBuilder: knitr
-SystemRequirements: Package vignettes based on R Markdown v2 require Pandoc
-    (http://pandoc.org). The function rst2pdf() and vignettes based on
-    reStructuredText require rst2pdf (https://github.com/rst2pdf/rst2pdf).
+SystemRequirements: Package vignettes based on R Markdown v2 or reStructuredText require Pandoc (http://pandoc.org). 
+    The function rst2pdf() reStructuredText require rst2pdf (https://github.com/rst2pdf/rst2pdf).
 Collate:
     'block.R'
     'cache.R'

--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -19,6 +19,35 @@ rst2pdf = function(input, command = 'rst2pdf', options = '') {
   if (file.exists(out)) out else stop('conversion by rst2pdf failed!')
 }
 
+#' Convert various input files to various output files using knit and pandoc
+#'
+#' Knits the input file and compiles to an output format using pandoc.
+#' @inheritParams knit
+#' @param to Character string describing output format to use
+#' @param pandoc_wrapper R function used to call pandoc.  By default if rmarkdown installed uses pandoc_convert else pandoc.
+#' @param ... options to be passed to the pandoc_wrapper function
+#' @author Trevor L. Davis
+#' @return Returns the output of the pandoc_wrapper function
+#' @export
+#' @seealso \code{\link{knit}}, \code{\link{pandoc}},
+#'      \code{\link[rmarkdown]{pandoc_convert}}, \code{\link{rst2pdf}}
+knit2pandoc <- function(input, output = NULL, tangle = FALSE, text = NULL,
+                           quiet = FALSE, envir=parent.frame(), encoding=getOption("encoding"),
+                           to = "html", pandoc_wrapper = NULL, ...) {
+    knit_output <- knit(input, output, tangle, text, quiet, envir, encoding)
+    if(is.null(pandoc_wrapper)) {
+        has_r_markdown <- "rmarkdown" %in% rownames(installed.packages())
+        if(has_r_markdown) {
+            output <- gsub(paste0(file_ext(knit_output), "$"), to, knit_output)
+            rmarkdown::pandoc_convert(knit_output, to, output=output, ...)
+        } else {
+            pandoc(knit_output, to, ...)
+        }
+    } else {
+        pandoc_wrapper(knit_output, to, ...)
+    }
+}
+
 #' Convert Rnw or Rrst files to PDF using knit() and texi2pdf() or rst2pdf()
 #'
 #' Knit the input Rnw or Rrst document, and compile to PDF using \code{texi2pdf}

--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -37,7 +37,7 @@ vweave = function(file, driver, syntax, encoding = 'UTF-8', quiet = FALSE, ...) 
   }
   opts_chunk$set(error = FALSE)  # should not hide errors
   knit_hooks$set(purl = hook_purl)  # write out code while weaving
-  (if (grepl('\\.[Rr]md$', file)) knit2html_v1 else if (grepl('\\.[Rr]rst$', file)) knit2pdf else knit)(
+  (if (grepl('\\.[Rr]md$', file)) knit2html_v1 else if (grepl('\\.[Rr]rst$', file)) knit2pandoc else knit)(
     file, encoding = encoding, quiet = quiet, envir = globalenv()
   )
 }


### PR DESCRIPTION
Should close (#1341). Added one new function ``knit2pandoc`` which is fairly general so a user could theoretically use it to convert from many formats to other formats (i.e. Rhtml to pdf) but selected a default output html so one could also directly use it as an rst vignette builder (theoretically could use it as a vignette builder for other formats as well like asciidoc?).

Didn't seem to break your unit tests and my rst vignette in optparse package seems to build fine with this modified although doesn't seem any of pandoc's pretty code coloring options were enabled.

This update will cause any packages with an Rrst vignette to switch vignette builidng from rst2pdf to pandoc.  Seems a little uglier but pandoc seems a less painful dependency to install for CRAN etc.  Not sure if any users besides me would be affected by such a change.