### PR TITLE
Gobble longest common whitespace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,6 +69,7 @@ Authors@R: c(
     person("Sebastian", "Meyer", role = "ctb"),
     person("Sietse", "Brouwer", role = "ctb"),
     person(c("Simon", "de"), "Bernard", role = "ctb"),
+    person("Sylvain", "Rousseau", role = "ctb"),
     person("Taiyun", "Wei", role = "ctb"),
     person("Thibaut", "Assus", role = "ctb"),
     person("Thibaut", "Lamadon", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - added a wrapper function `knit2pandoc()`, and reStructuredText vignettes will be compiled through Pandoc instead of rst2pdf (thanks, @trevorld, #1386)
 
+- longest common whitespace prefix in code chunks is now stripped off along with the eventual prefix (see #1391)
+
 ## MAJOR CHANGES
 
 - a warning will be emitted when the chunk option `fig.show='hold'` and the output format is Word (https://github.com/rstudio/bookdown/issues/249); `fig.show='hold'` will be changed to `'asis'` at the same time

--- a/R/parser.R
+++ b/R/parser.R
@@ -46,7 +46,11 @@ knit_code = new_defaults()
 
 # strip the pattern in code
 strip_block = function(x, prefix = NULL) {
-  if (!is.null(prefix) && (length(x) > 1)) x[-1L] = sub(prefix, '', x[-1L])
+  if (!is.null(prefix) && (length(x) > 1)) {
+    x[-1L] = sub(prefix, '', x[-1L])
+    spaces = min(attr(regexpr("^ *", x[-1L]), "match.length"))
+    if (spaces > 0) x[-1L] = substring(x[-1L], spaces + 1)
+  }
   x
 }
 


### PR DESCRIPTION
Hi,

I often write
    % blah <- 1
instead of
    %blah <- 1
in my Rtex files as I find it more readable. The problem is that it inserts a spurious space in the output or in the tangled file. This pull request fixes this by removing the longest common whitespace.