### PR TITLE
seealso kableExtra

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -33,7 +33,7 @@
 #' @param escape escape special characters when producing HTML or LaTeX tables
 #' @param ... other arguments (see examples)
 #' @return A character vector of the table source code.
-#' @seealso Other R packages such as \pkg{huxtable}, \pkg{xtable}, and
+#' @seealso Other R packages such as \pkg{huxtable}, \pkg{xtable}, \pkg{kableExtra}, and
 #'   \pkg{tables} for HTML and LaTeX tables, and \pkg{ascii} and \pkg{pander}
 #'   for different flavors of markdown output and some advanced features and
 #'   table styles.


### PR DESCRIPTION
@yihui, I'm adding [kableExtra](https://CRAN.R-project.org/package=kableExtra) to the 'seealso' section.  

@haozhu233's package makes it easy to start with normal kable tables, and escalate the cosmetic complexity at the last second (and not have to remove any of the kable code).  If I make a mistake with kableExtra CSS (or the incoming data.frame has changed), it's nice that I can just comment out the kableExtra suffixes, and return to the base kable output.

I've used it most of my recent reports, and I think there will be some other kable users who will appreciate knowing about it from your documentation.