### PR TITLE
Lines starting with three backticks are not inline code chunks (#655)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Authors@R: c(
     person("Fitch", "Simeon", role = "ctb"),
     person("Forest", "Fang", role = "ctb"),
     person(c("Frank", "E", "Harrell", "Jr"), role = "ctb", comment = "the Sweavel package at inst/misc/Sweavel.sty"),
+    person("Garrick", "Aden-Buie", role = "ctb"),
     person("Gregoire", "Detrez", role = "ctb"),
     person("Hadley", "Wickham", role = "ctb"),
     person("Heewon", "Jeon", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 - `hook_optipng()` does not work correctly when a code chunk does not contain any R-generated plots (thanks, @@zevross-spatial, #1404)
 
+- markdown lines starting with three backticks won't be considered inline code chunks (thanks, @gadenbuie, #1416)
+
 # CHANGES IN knitr VERSION 1.16
 
 ## NEW FEATURES

--- a/R/pattern.R
+++ b/R/pattern.R
@@ -31,7 +31,7 @@ all_patterns = list(
   `md` = list(
     chunk.begin = '^[\t >]*```+\\s*\\{([a-zA-Z0-9]+.*)\\}\\s*$',
     chunk.end = '^[\t >]*```+\\s*$',
-    ref.chunk = '^\\s*<<(.+)>>\\s*$', inline.code = '`r[ #]([^`]+)\\s*`'),
+    ref.chunk = '^\\s*<<(.+)>>\\s*$', inline.code = '(?<!(^|\n)``)`r[ #]([^`]+)\\s*`'),
 
   `rst` = list(
     chunk.begin = '^\\s*[.][.]\\s+\\{r(.*)\\}\\s*$',


### PR DESCRIPTION
Adds negative lookback to md inline code pattern so that the parser does not flag code chunks as inline when a line starts with three backticks.

I ran into this when migrating a Jekyll blog to blogdown, where I had an extension that allowed attributes to be included in the same line as the ` ``` ` code fence, but the space after ` ```r ` matched the inline code pattern.

### These things will knit:

    ``` {r} 
       #{r}_^ line ends
    summary(cars)
    ```
    
    Inline with newline before backtick:
    `r nrow(cars)`
    rows knits to 50.

    Inline with line break inside code: `r nrow(
    cars
    )` 
    rows also knits to 50.

    Three backticks, but inline: ```r nrow(
    cars)``` rows knits to ``50``.

### These things will not knit:

    ```r 
      #r_^ line ends
    summary(cars)
    ```

    ``` r 
      #_r_^ line ends
    summary(cars)
    ```
    
    ```r something
    summary(cars)
    ```
    
    Inline with newline after backtick r: `r
    nrow(cars)` 
    rows.