### PR TITLE
Sanitise latex captions of kable() and figures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,6 +74,7 @@ Authors@R: c(
     person("Taiyun", "Wei", role = "ctb"),
     person("Thibaut", "Assus", role = "ctb"),
     person("Thibaut", "Lamadon", role = "ctb"),
+    person("Thierry", "Onkelinx", role = "ctb"),
     person("Thomas", "Leeper", role = "ctb"),
     person("Tom", "Torsney-Weir", role = "ctb"),
     person("Trevor", "Davis", role = "ctb"),

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -90,8 +90,8 @@ hook_plot_tex = function(x, options) {
     switch(a, left = '\\hfill{}\n\n', center = '\n\n}\n\n', right = '\n\n', '')
 
   # figure environment: caption, short caption, label
-  cap = options$fig.cap
-  scap = options$fig.scap
+  cap = escape_latex(options$fig.cap)
+  scap = escape_latex(options$fig.scap)
   fig1 = fig2 = ''
   mcap = fig.num > 1L && options$fig.show == 'asis' && !length(subcap)
   # initialize subfloat strings

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -91,8 +91,16 @@ hook_plot_tex = function(x, options) {
 
   # figure environment: caption, short caption, label
   if (out_format('latex')) {
-    cap = escape_latex(options$fig.cap)
-    scap = escape_latex(options$fig.scap)
+    if (is.null(options$fig.cap)) {
+      cap = NULL
+    } else {
+      cap = escape_latex(options$fig.cap)
+    }
+    if (is.null(options$fig.scap)) {
+      scap = NULL
+    } else {
+      scap = escape_latex(options$fig.scap)
+    }
   } else {
     cap = options$fig.cap
     scap = options$fig.scap

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -90,8 +90,13 @@ hook_plot_tex = function(x, options) {
     switch(a, left = '\\hfill{}\n\n', center = '\n\n}\n\n', right = '\n\n', '')
 
   # figure environment: caption, short caption, label
-  cap = escape_latex(options$fig.cap)
-  scap = escape_latex(options$fig.scap)
+  if (out_format('latex')) {
+    cap = escape_latex(options$fig.cap)
+    scap = escape_latex(options$fig.scap)
+  } else {
+    cap = options$fig.cap
+    scap = options$fig.scap
+  }
   fig1 = fig2 = ''
   mcap = fig.num > 1L && options$fig.show == 'asis' && !length(subcap)
   # initialize subfloat strings

--- a/R/table.R
+++ b/R/table.R
@@ -104,7 +104,7 @@ kable = function(
   # create a label for bookdown if applicable
   if (!is.null(caption) && !is.na(caption)) caption = paste0(
     create_label('tab:', opts_current$get('label'), latex = (format == 'latex')),
-                 caption
+    ifelse(escape && format == 'latex', escape_latex(caption), caption)
   )
   if (inherits(x, 'list')) {
     # if the output is for Pandoc and we want multiple tabular in one table, we

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -53,9 +53,12 @@ x & y\\\\
 assert(
   'kable() escapes LaTeX special characters by default',
   identical(
-    kable2(data.frame(x = c("10%", "5%"), col_name = c("3_8", "40_6")), 'latex'),
-    '
-\\begin{tabular}{l|l}
+    kable2(data.frame(x = c("10%", "5%"), col_name = c("3_8", "40_6")), 'latex', caption = "Test % and _"),
+    '\\begin{table}
+
+\\caption{\\label{tab:}Test \\% and \\_}
+\\centering
+\\begin{tabular}[t]{l|l}
 \\hline
 x & col\\_name\\\\
 \\hline
@@ -63,16 +66,20 @@ x & col\\_name\\\\
 \\hline
 5\\% & 40\\_6\\\\
 \\hline
-\\end{tabular}'
+\\end{tabular}
+\\end{table}'
   )
 )
 
 assert(
   'kable() doesn\'t escape LaTeX special characters when escape = FALSE',
   identical(
-    kable2(data.frame(x = c("10%", "5%"), col_name = c("3_8", "40_6")), 'latex', escape = FALSE),
-    '
-\\begin{tabular}{l|l}
+    kable2(data.frame(x = c("10%", "5%"), col_name = c("3_8", "40_6")), 'latex', caption = "Test % and _", escape = FALSE),
+    '\\begin{table}
+
+\\caption{\\label{tab:}Test % and _}
+\\centering
+\\begin{tabular}[t]{l|l}
 \\hline
 x & col_name\\\\
 \\hline
@@ -80,7 +87,8 @@ x & col_name\\\\
 \\hline
 5% & 40_6\\\\
 \\hline
-\\end{tabular}'
+\\end{tabular}
+\\end{table}'
   )
 )
 


### PR DESCRIPTION
Using `%` and `_` in captions with kable() or fig.cap were problematic when rendered to pdf. These are now sanitised with `escape_latex()`