### PR TITLE
fix #1181, paste seperator must be platform specific!

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -138,7 +138,7 @@ plot2dev = function(plot, name, dev, device, path, width, height, options) {
     owd = setwd(dirname(path))
     # add old wd to TEXINPUTS (see #188)
     oti = Sys.getenv('TEXINPUTS'); on.exit(Sys.setenv(TEXINPUTS = oti))
-    Sys.setenv(TEXINPUTS = paste(owd, oti, sep = ':'))
+    Sys.setenv(TEXINPUTS = paste(owd, oti, sep = .Platform$path.sep))
     latex = switch(
       getOption('tikzDefaultEngine'),
       pdftex = getOption('tikzLatex'),


### PR DESCRIPTION
Hey, 

it seems that I might have found the issue for solving https://github.com/yihui/knitr/issues/1181,
works on Win 10 with texlive 2017 for me. The seperator in paste() was hard-coded to ":" instead of using the OS agnostic .Platform$path.sep.

Hope it works!