### PR TITLE
Sweave2knitr left a connection open, the next gc() triggered a warning

### DIFF
--- a/R/utils-sweave.R
+++ b/R/utils-sweave.R
@@ -63,12 +63,12 @@
 #' knit('Sweave-test-knitr.Rnw') # or knit2pdf() directly
 Sweave2knitr = function(file, output = gsub('[.]([^.]+)$', '-knitr.\\1', file),
                         encoding = getOption('encoding'), text = NULL) {
-  if (is.null(text)) {
-    f <- file(file, encoding = encoding)
-    x <- readLines(f, warn = FALSE)
+  x = text
+  if (is.null(x)) {
+    f = file(file, encoding = encoding)
+    x = readLines(f, warn = FALSE)
     close(f)
-  } else
-    x <- text
+  }
   x = native_encode(x)
   x = gsub_msg('removing \\usepackage{Sweave}',
                '^\\s*\\\\usepackage(\\[.*\\])?\\{Sweave\\}', '', x)

--- a/R/utils-sweave.R
+++ b/R/utils-sweave.R
@@ -63,7 +63,12 @@
 #' knit('Sweave-test-knitr.Rnw') # or knit2pdf() directly
 Sweave2knitr = function(file, output = gsub('[.]([^.]+)$', '-knitr.\\1', file),
                         encoding = getOption('encoding'), text = NULL) {
-  x = if (is.null(text)) readLines(file(file, encoding = encoding), warn = FALSE) else text
+  if (is.null(text)) {
+    f <- file(file, encoding = encoding)
+    x <- readLines(f, warn = FALSE)
+    close(f)
+  } else
+    x <- text
   x = native_encode(x)
   x = gsub_msg('removing \\usepackage{Sweave}',
                '^\\s*\\\\usepackage(\\[.*\\])?\\{Sweave\\}', '', x)


### PR DESCRIPTION
This was discussed on Stackoverflow here:  https://stackoverflow.com/questions/46236619/r-sweave-writes-connection-closed-warning-message-on-pdf-output.  In that case, Sweave2knitr was being called many times automatically, and the warning was showing up in the document output sometimes.

The PR explicitly closes the leaked connection.