### PR TITLE
New imgur_upload with xml2 and httr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -109,6 +109,8 @@ Suggests:
     png,
     jpeg,
     XML,
+    xml2,
+    httr,
     RCurl,
     DBI (>= 0.4-1),
     tibble

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Authors@R: c(
     person("Ben", "Baumer", role = "ctb"),
     person("Brian", "Diggs", role = "ctb"),
     person("Cassio", "Pereira", role = "ctb"),
+    person("Christophe", "Dervieux", role = "ctb"),
     person("David", "Robinson", role = "ctb"),
     person("Donald", "Arseneau", role = c("ctb", "cph"), comment = "the framed package at inst/misc/framed.sty"),
     person("Doug", "Hemken", role = "ctb"),

--- a/R/utils-upload.R
+++ b/R/utils-upload.R
@@ -35,6 +35,12 @@
 #' opts_knit$set(upload.fun = function(file) imgur_upload(file, key = 'your imgur key'))
 #' }
 imgur_upload = function(file, key = '9f3460e67f308f6') {
+
+  if (!requireNamespace("xml2", quietly = TRUE) || !requireNamespace("httr", quietly = TRUE)) {
+    stop("Pkg xml2 and httr needed for uploading file to imgur. Please install them or do not upload files.",
+         call. = FALSE)
+  }
+
   if (!is.character(key)) stop('The Imgur API Key must be a character string!')
   resp <- httr::POST(url = "https://api.imgur.com/3/image.xml",
                      config = httr::add_headers(Authorization = paste("Client-ID", key)),

--- a/R/utils-upload.R
+++ b/R/utils-upload.R
@@ -43,13 +43,8 @@ imgur_upload = function(file, key = '9f3460e67f308f6') {
   httr::stop_for_status(resp, task = "Fail to upload")
   info_media <- httr::parse_media(resp$headers[["Content-Type"]])
   if (info_media$complete != "text/xml") stop("Fail to upload; response is not XML")
-  if (is.null(encoding <- info_media$params$charset)) {
-    message("No encoding in response : defaulting to UTF-8")
-    encoding <- "utf-8"
-  }
   res <- xml2::as_list(
-    xml2::read_xml(x = httr::content(resp, as = "raw"),
-                   encoding = encoding)
+    xml2::read_xml(x = httr::content(resp, as = "raw"))
   )
   if (is.null(res$link[[1]])) stop('failed to upload ', file)
   structure(res$link[[1]], XML = res)

--- a/R/utils-upload.R
+++ b/R/utils-upload.R
@@ -36,7 +36,7 @@
 #' }
 imgur_upload = function(file, key = '9f3460e67f308f6') {
 
-  if (!requireNamespace("xml2", quietly = TRUE) || !requireNamespace("httr", quietly = TRUE)) {
+  if (!has_package("xml2") || !has_package("httr")) {
     stop("Pkg xml2 and httr needed for uploading file to imgur. Please install them or do not upload files.",
          call. = FALSE)
   }

--- a/R/utils-upload.R
+++ b/R/utils-upload.R
@@ -36,11 +36,6 @@
 #' }
 imgur_upload = function(file, key = '9f3460e67f308f6') {
 
-  if (!has_package("xml2") || !has_package("httr")) {
-    stop("Pkg xml2 and httr needed for uploading file to imgur. Please install them or do not upload files.",
-         call. = FALSE)
-  }
-
   if (!is.character(key)) stop('The Imgur API Key must be a character string!')
   resp <- httr::POST(url = "https://api.imgur.com/3/image.xml",
                      config = httr::add_headers(Authorization = paste("Client-ID", key)),

--- a/man/imgur_upload.Rd
+++ b/man/imgur_upload.Rd
@@ -18,8 +18,8 @@ A character string of the link to the image; this string carries an
   file; see Imgur API in the references.
 }
 \description{
-This function uses the \pkg{httr} package to upload a image to
-\url{imgur.com}, and parses the XML response to a list with \pkg{xml2} which
+This function uses the \pkg{RCurl} package to upload a image to
+\url{imgur.com}, and parses the XML response to a list with \pkg{XML} which
 contains information about the image in the Imgur website.
 }
 \details{
@@ -36,16 +36,19 @@ Please register your own Imgur application to get your client id; you
 }
 \examples{
 \dontrun{
-f = tempfile(fileext = '.png')
-png(f); plot(rnorm(100), main = R.version.string); dev.off()
+f = tempfile(fileext = ".png")
+png(f)
+plot(rnorm(100), main = R.version.string)
+dev.off()
 
 res = imgur_upload(f)
 res  # link to original URL of the image
-attr(res, 'XML')  # all information
-if (interactive()) browseURL(res)
+attr(res, "XML")  # all information
+if (interactive()) 
+    browseURL(res)
 
 # to use your own key
-opts_knit$set(upload.fun = function(file) imgur_upload(file, key = 'your imgur key'))
+opts_knit$set(upload.fun = function(file) imgur_upload(file, key = "your imgur key"))
 }
 }
 \references{

--- a/man/imgur_upload.Rd
+++ b/man/imgur_upload.Rd
@@ -18,8 +18,8 @@ A character string of the link to the image; this string carries an
   file; see Imgur API in the references.
 }
 \description{
-This function uses the \pkg{RCurl} package to upload a image to
-\url{imgur.com}, and parses the XML response to a list with \pkg{XML} which
+This function uses the \pkg{httr} package to upload a image to
+\url{imgur.com}, and parses the XML response to a list with \pkg{xml2} which
 contains information about the image in the Imgur website.
 }
 \details{
@@ -36,19 +36,16 @@ Please register your own Imgur application to get your client id; you
 }
 \examples{
 \dontrun{
-f = tempfile(fileext = ".png")
-png(f)
-plot(rnorm(100), main = R.version.string)
-dev.off()
+f = tempfile(fileext = '.png')
+png(f); plot(rnorm(100), main = R.version.string); dev.off()
 
 res = imgur_upload(f)
 res  # link to original URL of the image
-attr(res, "XML")  # all information
-if (interactive()) 
-    browseURL(res)
+attr(res, 'XML')  # all information
+if (interactive()) browseURL(res)
 
 # to use your own key
-opts_knit$set(upload.fun = function(file) imgur_upload(file, key = "your imgur key"))
+opts_knit$set(upload.fun = function(file) imgur_upload(file, key = 'your imgur key'))
 }
 }
 \references{


### PR DESCRIPTION
Hi @yihui, 

Following a _PS_ call in your recent [blog post](https://yihui.name/en/2017/09/knitr-imgur-upload/), I modified `imgur_upload` to use `httr` and `xml2` instead of `RCurl` and `XML`

Note that `RCurl` is also used in `knitr::image_uri2` for `RCurl::base64Encode`. `httr` has a `base64url` but not exported. What should we do to remove `RCurl` suggest dependency to RCurl ? 

`XML` package is used is called `inst/examples/knitr-themes.Rnw`. I think we can remove the _suggests_ dependency but not sure.

One thing: There is a [imguR](https://github.com/cloudyr/imguR) package with a `upload_imgur` function. I do not know if it is better to have a `imgur_upload` function specific to `knitr` or if it may be a good idea to use a dependency toward `imguR` package and import the `imgur_upload`. 

What do you think of all this ? 
Does it help ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yihui/knitr/1433)
<!-- Reviewable:end -->
