### PR TITLE
adds fig.ncol for latex output

### DIFF
--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -69,10 +69,11 @@ hook_plot_tex = function(x, options) {
   fig.cur = options$fig.cur %n% 1L
   fig.num = options$fig.num %n% 1L
   animate = options$fig.show == 'animate'
-  ncol = abs(options$fig.ncol %n% fig.num)
-  sep = options$fig.sep %n% c(rep('', ncol - 1), '\\newline')
-  ncol = length(sep)
-  col.cur = fig.cur - floor((fig.cur - 1)/ncol)*ncol
+  fig.ncol = options$fig.ncol %n% fig.num
+  if (is.null(sep <- options$fig.sep)) {
+    sep = character(fig.num)
+    if (fig.ncol < fig.num) sep[seq(fig.ncol, fig.num - 1L, fig.ncol)] = '\\newline'
+  }
   sep.cur = NULL
 
   # If this is a non-tikz animation, skip to the last fig.
@@ -115,10 +116,7 @@ hook_plot_tex = function(x, options) {
     if (usesub) {
       sub1 = sprintf('\\subfloat[%s%s]{', subcap, create_label(lab, fig.cur, latex = TRUE))
       sub2 = '}'
-      # Add separator command for floats if not last in set
-      # Add separator command for floats if not last in set
-      # Add separator command for floats if not last in set
-      if (!plot2) sep.cur = sep[col.cur]
+      sep.cur = sep[fig.cur]
     }
 
     # If pic is standalone/last in set:

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -69,7 +69,11 @@ hook_plot_tex = function(x, options) {
   fig.cur = options$fig.cur %n% 1L
   fig.num = options$fig.num %n% 1L
   animate = options$fig.show == 'animate'
-  ncol = options$fig.ncol %n% .Machine$integer.max
+  ncol = abs(options$fig.ncol %n% fig.num)
+  sep = options$fig.sep %n% c(rep('', ncol - 1), '\\newline')
+  ncol = length(sep)
+  col.cur = fig.cur - floor((fig.cur - 1)/ncol)*ncol
+  sep.cur = NULL
 
   # If this is a non-tikz animation, skip to the last fig.
   if (!tikz && animate && fig.cur < fig.num) return('')
@@ -82,8 +86,6 @@ hook_plot_tex = function(x, options) {
   plot1 = ai || fig.cur <= 1L
   # TRUE if this picture is standalone or last in set
   plot2 = ai || fig.cur == fig.num
-  # TRUE if this picture is not standalone, nor last in set and is at the last column
-  plot3 = !plot2 && (fig.cur %% ncol == 0)
 
   # open align code if this picture is standalone/first in set
   align1 = if (plot1)
@@ -91,9 +93,6 @@ hook_plot_tex = function(x, options) {
   # close align code if this picture is standalone/last in set
   align2 = if (plot2)
     switch(a, left = '\\hfill{}\n\n', center = '\n\n}\n\n', right = '\n\n', '')
-
-  # initialize newline
-  newline = NULL
 
   # figure environment: caption, short caption, label
   cap = options$fig.cap
@@ -116,8 +115,10 @@ hook_plot_tex = function(x, options) {
     if (usesub) {
       sub1 = sprintf('\\subfloat[%s%s]{', subcap, create_label(lab, fig.cur, latex = TRUE))
       sub2 = '}'
-      # Add newline command for floats
-      if (plot3) newline = '\\newline'
+      # Add separator command for floats if not last in set
+      # Add separator command for floats if not last in set
+      # Add separator command for floats if not last in set
+      sep.cur = sep[col.cur]
     }
 
     # If pic is standalone/last in set:
@@ -166,7 +167,7 @@ hook_plot_tex = function(x, options) {
       if (is.null(lnk) || is.na(lnk)) res else sprintf('\\href{%s}{%s}', lnk, res)
     },
 
-    resize2, sub2, align2, newline, fig2
+    resize2, sub2, sep.cur, align2, fig2
   )
 }
 

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -69,7 +69,7 @@ hook_plot_tex = function(x, options) {
   fig.cur = options$fig.cur %n% 1L
   fig.num = options$fig.num %n% 1L
   animate = options$fig.show == 'animate'
-  ncol = options$fig.ncol %n% 1L
+  ncol = options$fig.ncol %n% .Machine$integer.max
 
   # If this is a non-tikz animation, skip to the last fig.
   if (!tikz && animate && fig.cur < fig.num) return('')
@@ -93,7 +93,7 @@ hook_plot_tex = function(x, options) {
     switch(a, left = '\\hfill{}\n\n', center = '\n\n}\n\n', right = '\n\n', '')
 
   # initialize newline
-  newline = ''
+  newline = NULL
 
   # figure environment: caption, short caption, label
   cap = options$fig.cap

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -70,9 +70,9 @@ hook_plot_tex = function(x, options) {
   fig.num = options$fig.num %n% 1L
   animate = options$fig.show == 'animate'
   fig.ncol = options$fig.ncol %n% fig.num
-  if (is.null(sep <- options$fig.sep)) {
-    sep = character(fig.num)
-    if (fig.ncol < fig.num) sep[seq(fig.ncol, fig.num - 1L, fig.ncol)] = '\\newline'
+  if (is.null(fig.sep <- options$fig.sep)) {
+    fig.sep = character(fig.num)
+    if (fig.ncol < fig.num) fig.sep[seq(fig.ncol, fig.num - 1L, fig.ncol)] = '\\newline'
   }
   sep.cur = NULL
 
@@ -116,7 +116,7 @@ hook_plot_tex = function(x, options) {
     if (usesub) {
       sub1 = sprintf('\\subfloat[%s%s]{', subcap, create_label(lab, fig.cur, latex = TRUE))
       sub2 = '}'
-      sep.cur = sep[fig.cur]
+      sep.cur = fig.sep[fig.cur]; if (is.na(sep.cur)) sep.cur = NULL
     }
 
     # If pic is standalone/last in set:

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -118,7 +118,7 @@ hook_plot_tex = function(x, options) {
       # Add separator command for floats if not last in set
       # Add separator command for floats if not last in set
       # Add separator command for floats if not last in set
-      sep.cur = sep[col.cur]
+      if (!plot2) sep.cur = sep[col.cur]
     }
 
     # If pic is standalone/last in set:

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -82,8 +82,8 @@ hook_plot_tex = function(x, options) {
   plot1 = ai || fig.cur <= 1L
   # TRUE if this picture is standalone or last in set
   plot2 = ai || fig.cur == fig.num
-  # TRUE if this picture is not standalone and is at the last column
-  plot3 = !ai && (fig.cur %% ncol == 0)
+  # TRUE if this picture is not standalone, nor last in set and is at the last column
+  plot3 = !plot2 && (fig.cur %% ncol == 0)
 
   # open align code if this picture is standalone/first in set
   align1 = if (plot1)

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -69,6 +69,7 @@ hook_plot_tex = function(x, options) {
   fig.cur = options$fig.cur %n% 1L
   fig.num = options$fig.num %n% 1L
   animate = options$fig.show == 'animate'
+  ncol = options$fig.ncol %n% 1L
 
   # If this is a non-tikz animation, skip to the last fig.
   if (!tikz && animate && fig.cur < fig.num) return('')
@@ -81,6 +82,8 @@ hook_plot_tex = function(x, options) {
   plot1 = ai || fig.cur <= 1L
   # TRUE if this picture is standalone or last in set
   plot2 = ai || fig.cur == fig.num
+  # TRUE if this picture is not standalone and is at the last column
+  plot3 = !ai && (fig.cur %% ncol == 0)
 
   # open align code if this picture is standalone/first in set
   align1 = if (plot1)
@@ -88,6 +91,9 @@ hook_plot_tex = function(x, options) {
   # close align code if this picture is standalone/last in set
   align2 = if (plot2)
     switch(a, left = '\\hfill{}\n\n', center = '\n\n}\n\n', right = '\n\n', '')
+
+  # initialize newline
+  newline = ''
 
   # figure environment: caption, short caption, label
   cap = options$fig.cap
@@ -110,6 +116,8 @@ hook_plot_tex = function(x, options) {
     if (usesub) {
       sub1 = sprintf('\\subfloat[%s%s]{', subcap, create_label(lab, fig.cur, latex = TRUE))
       sub2 = '}'
+      # Add newline command for floats
+      if (plot3) newline = '\\newline'
     }
 
     # If pic is standalone/last in set:
@@ -158,7 +166,7 @@ hook_plot_tex = function(x, options) {
       if (is.null(lnk) || is.na(lnk)) res else sprintf('\\href{%s}{%s}', lnk, res)
     },
 
-    resize2, sub2, align2, fig2
+    resize2, sub2, align2, newline, fig2
   )
 }
 


### PR DESCRIPTION
Adds new chunk option `fig.ncol` that controls the number of columns when using subfigures. (fixes #1327 )

Example and some tests: https://gist.github.com/eliocamp/7609fae98632b5af9a05d37262337bb9

![example](https://i.imgur.com/WIzehzq.png)