### PR TITLE
Repeat the header row on every page when longtable is used

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,10 @@
 
 - the `auto_pdf` argument of `include_graphics()` defaults to `FALSE` now; you can set `options(knitr.graphics.auto_pdf = TRUE)` to change the default to `TRUE` (thanks, @mebden, #1456)
 
+## MINOR CHANGES
+
+- On LaTeX output with `longtable=TRUE`, `kable()` repeats the table header on every additional page (@zeehio, )
+
 ## BUG FIXES
 
 - fixed #1446: **knitr** may fail to parse code chunks in blockquotes in Markdown (thanks, @rgaiacs)

--- a/R/table.R
+++ b/R/table.R
@@ -212,7 +212,9 @@ kable_latex = function(
   vline = getOption('knitr.table.vline', if (booktabs) '' else '|'),
   toprule = getOption('knitr.table.toprule', if (booktabs) '\\toprule' else '\\hline'),
   bottomrule = getOption('knitr.table.bottomrule', if (booktabs) '\\bottomrule' else '\\hline'),
-  midrule = getOption('knitr.table.midrule', if (booktabs) '\\midrule' else '\\hline'),
+  midrule = getOption('knitr.table.midrule', paste0(c(if (booktabs) "\\midrule" else "\\hline",
+                                                      if (longtable) "\\endhead" else NULL),
+                                                    collapse = "\n")),
   linesep = if (booktabs) c('', '', '', '', '\\addlinespace') else '\\hline',
   caption = NULL, caption.short = '', table.envir = if (!is.null(caption)) 'table',
   escape = TRUE

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -51,6 +51,24 @@ x & y\\\\
 )
 
 assert(
+  'kable() adds endhead to repeat the header row on new pages when longtable is used',
+  identical(
+    kable2(data.frame(x = c(1.2, 4.87), y = c('fooooo', 'bar')), 'latex', longtable = TRUE),
+    '
+\\begin{longtable}{r|l}
+\\hline
+x & y\\\\
+\\hline
+\\endhead
+1.20 & fooooo\\\\
+\\hline
+4.87 & bar\\\\
+\\hline
+\\end{longtable}'
+  )
+)
+
+assert(
   'kable() escapes LaTeX special characters by default',
   identical(
     kable2(data.frame(x = c("10%", "5%"), col_name = c("3_8", "40_6")), 'latex'),


### PR DESCRIPTION
`kable()` allows to generate tables in LaTeX using the `longtable` package. The longtable package has advantages with respect to the `tabular` environment as it allows to easily split tables across multiple pages.

A "nice to have" feature for multipage tables is to print the column names at the beginning of each page. This pull request adds the `\endhead` command after the header.  According to the [longtable documentation](https://ctan.org/pkg/longtable), this command tells longtable to repeat the header of the table on each page. Currently I am manually setting this option on each of my tables, feel free to merge if you feel it is a more sensible default (and feel free to close this if you prefer how things are right now :smiley:).

Minimal example:

    ---
    title: "Untitled"
    author: "Sergio Oller"
    date: "2017-11-21"
    output:
      pdf_document
    header-includes:
      - \usepackage{booktabs}
      - \usepackage{longtable}
    ---
    
    ```{r}
    data(iris)
    knitr::kable(iris, format = "latex", booktabs = TRUE, longtable = TRUE)
    ```

See the presence of a column header in the second page in the images below:

Before this PR there is no header on the second page:
![imatge](https://user-images.githubusercontent.com/75441/33092462-7c525204-cefa-11e7-843f-ce309e7718f3.png)

After this PR we have a header :smiley:
![imatge](https://user-images.githubusercontent.com/75441/33092408-5e449196-cefa-11e7-89cb-12aea62417ce.png)
