### PR TITLE
Allow use of _ in engine names

### DIFF
--- a/R/parser.R
+++ b/R/parser.R
@@ -64,8 +64,8 @@ parse_block = function(code, header, params.src) {
   engine = 'r'
   # consider the syntax ```{engine, opt=val} for chunk headers
   if (out_format('markdown')) {
-    engine = sub('^([a-zA-Z0-9]+).*$', '\\1', params)
-    params = sub('^([a-zA-Z0-9]+)', '', params)
+    engine = sub('^([a-zA-Z0-9_]+).*$', '\\1', params)
+    params = sub('^([a-zA-Z0-9_]+)', '', params)
   }
   params = gsub('^\\s*,*|,*\\s*$', '', params) # rm empty options
   # turn ```{engine} into ```{r, engine="engine"}

--- a/R/pattern.R
+++ b/R/pattern.R
@@ -29,7 +29,7 @@ all_patterns = list(
     inline.code = '<!--\\s*rinline(.+?)-->', header.begin = '\\s*<head>'),
 
   `md` = list(
-    chunk.begin = '^[\t >]*```+\\s*\\{([a-zA-Z0-9]+.*)\\}\\s*$',
+    chunk.begin = '^[\t >]*```+\\s*\\{([a-zA-Z0-9_]+.*)\\}\\s*$',
     chunk.end = '^[\t >]*```+\\s*$',
     ref.chunk = '^\\s*<<(.+)>>\\s*$', inline.code = '(?<!(^|\n)``)`r[ #]([^`]+)\\s*`'),
 


### PR DESCRIPTION
I would like to define a `glue_sql` engine, which works fine with `{r engine = "glue_sql"}` but fails if you use `{glue_sql}`. In this PR I added support for `.` separators as well, which seems natural.