### PR TITLE
Added conversion of percent height to LaTex unit.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -290,8 +290,8 @@ fix_options = function(options) {
 
   # turn x% to x/100\linewidth
   if (is_latex_output())
-    options['out.width'] = list(percent_latex_width(options[['out.width']]))
-    options['out.height'] = list(percent_latex_height(options[['out.height']]))
+    options['out.width'] = list(percent_latex_width_height('out.width', options))
+    options['out.height'] = list(percent_latex_width_height('out.height', options))
 
   # deal with aliases: a1 is real option; a0 is alias
   if (length(a1 <- opts_knit$get('aliases')) && length(a0 <- names(a1))) {
@@ -345,14 +345,21 @@ is_html_output = function(fmt = pandoc_to(), excludes = NULL) {
 }
 
 
-# turn percent width to LaTeX unit, e.g. out.width = 30% -> .3\linewidth
-percent_latex_width = function(x) {
+# turn percent width or height to LaTeX unit
+#  e.g. out.width = 30% -> .3\linewidth
+#  e.g. out.height = 80% -> .8\textheight
+percent_latex_width_height = function(width.height, options) {
+  x = options[[width.height]]
   if (!is.character(x)) return(x)
   i = grep('^[0-9.]+%$', x)
   if (length(i) == 0) return(x)
   xi = as.numeric(sub('%$', '', x[i]))
   if (any(is.na(xi))) return(x)
-  x[i] = paste0(xi / 100, '\\linewidth')
+  xi = xi / 100
+  if (width.height == 'out.width')
+    x[i] = paste0(xi, '\\linewidth')
+  else if (width.height == 'out.height')
+    x[i] = paste0(xi, '\\textheight')
   x
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -291,6 +291,7 @@ fix_options = function(options) {
   # turn x% to x/100\linewidth
   if (is_latex_output())
     options['out.width'] = list(percent_latex_width(options[['out.width']]))
+    options['out.height'] = list(percent_latex_height(options[['out.height']]))
 
   # deal with aliases: a1 is real option; a0 is alias
   if (length(a1 <- opts_knit$get('aliases')) && length(a0 <- names(a1))) {
@@ -352,6 +353,17 @@ percent_latex_width = function(x) {
   xi = as.numeric(sub('%$', '', x[i]))
   if (any(is.na(xi))) return(x)
   x[i] = paste0(xi / 100, '\\linewidth')
+  x
+}
+
+# turn percent height to LaTeX unit, e.g. out.height = 30% -> .3\textheight
+percent_latex_height = function(x) {
+  if (!is.character(x)) return(x)
+  i = grep('^[0-9.]+%$', x)
+  if (length(i) == 0) return(x)
+  xi = as.numeric(sub('%$', '', x[i]))
+  if (any(is.na(xi))) return(x)
+  x[i] = paste0(xi / 100, '\\textheight')
   x
 }
 


### PR DESCRIPTION
Before this patch, `out.height` for figures when specified as a percent leads to the percent sign get passed into pandoc causing parsing problems.  The patch translates the percent to the equivalent fraction of `\textheight`

Fixes https://github.com/rstudio/bookdown/issues/501