### PR TITLE
Expand spin code block pattern

### DIFF
--- a/R/spin.R
+++ b/R/spin.R
@@ -3,7 +3,8 @@
 #' This function takes a specially formatted R script and converts it to a
 #' literate programming document. By default normal text (documentation) should
 #' be written after the roxygen comment (\code{#'}) and code chunk options are
-#' written after \code{#+} or \code{#-} or \code{# ----}.
+#' written after \code{#+} or \code{#-} or \code{# ----} or any of these
+#' combinations replacing \code{#} with \code{--}.
 #'
 #' Obviously the goat's hair is the original R script, and the wool is the
 #' literate programming document (ready to be knitted).
@@ -100,8 +101,8 @@ spin = function(
       # R code; #+/- indicates chunk options
       block = strip_white(block) # rm white lines in beginning and end
       if (!length(block)) next
-      if (length(opt <- grep('^#+(\\+|-| ----+| @knitr)', block))) {
-        block[opt] = paste0(p[1L], gsub('^#+(\\+|-| ----+| @knitr)\\s*|-*\\s*$', '', block[opt]), p[2L])
+      if (length(opt <- grep('^(#|--)+(\\+|-| ----+| @knitr)', block))) {
+        block[opt] = paste0(p[1L], gsub('^(#|--)+(\\+|-| ----+| @knitr)\\s*|-*\\s*$', '', block[opt]), p[2L])
       }
       if (!grepl(p1, block[1L])) {
         block = c(paste0(p[1L], p[2L]), block)


### PR DESCRIPTION
Copies behaviour implemented in #1455 from `read_chunks` to `spin`

Allows for code chunks in Haskell and SQL files to be used in `spin`.

```r
knitr::spin(..., doc = "^(#|--)+'[ ]?")
```

**example.sql**
```sql
--' Custom documentation lines as specified with
--' the `doc` parameter passed to `knitr::spin`

-- ---- sql_chunk_name, engine='sql'
CREATE OR REPLACE FUNCTION ...
```