### PR TITLE
Add clarification to `read_chunk` doc regarding duplicated chunk labels

### DIFF
--- a/R/parser.R
+++ b/R/parser.R
@@ -252,8 +252,8 @@ print.inline = function(x, ...) {
 #'   comments from code chunks in addition to whitespace
 #' @return As a side effect, code chunks are read into the current session so
 #'   that future chunks can (re)use the code by chunk label references.
-#'   If an external chunk has the same name as a chunk in the current session,
-#'   chunk label references to that name by future chunks will refer to the
+#'   If an external chunk has the same label as a chunk in the current session,
+#'   chunk label references by future chunks will refer to the
 #'   external chunk.
 #' @references \url{https://yihui.name/knitr/demo/externalization/}
 #' @note This function can only be used in a chunk which is \emph{not} cached

--- a/R/parser.R
+++ b/R/parser.R
@@ -252,6 +252,9 @@ print.inline = function(x, ...) {
 #'   comments from code chunks in addition to whitespace
 #' @return As a side effect, code chunks are read into the current session so
 #'   that future chunks can (re)use the code by chunk label references.
+#'   If an external chunk has the same name as a chunk in the current session,
+#'   chunk label references to that name by future chunks will refer to the
+#'   external chunk.
 #' @references \url{https://yihui.name/knitr/demo/externalization/}
 #' @note This function can only be used in a chunk which is \emph{not} cached
 #'   (chunk option \code{cache = FALSE}), and the code is read and stored in the


### PR DESCRIPTION
Suppose we have an external R script with this external chunk code separator:
```
# script.R
## ---- generic_name ----
print('Conflict')
````
And we have a .Rmd that has the same chunk label:
````
.Rmd 1
```{r generic_name}
print('No conflict')
```
```{r}
knitr::read_chunk('script2.R')
```
```{r generic_name}
```
````
After calling `read_chunk`, the reference to `generic_name` now refers to the code chunk we've read into the session. We can verify this by knitting the file, or by calling `knitr:::knit_code$get()` in another chunk. 

I thought this situation warranted some clarification in the documentation, since you can't implicitly overwrite chunk labels by hand. For example, this new .Rmd doesn't compile:
````
.Rmd 2
```{r generic_name}
print('No conflict')
```

```{r generic_name}
print('what happens?')
```
````
```
Error in parse_block(g[-1], g[1], params.src) : 
  duplicate label 'generic_name'
```

I also thought about trying to append the path or file name to chunks with duplicated labels, but I'm not sure it is worth the effort. Another idea would be adding in a warning or an error when `read_chunks` sees duplicated labels. Thoughts?
