### PR TITLE
deals with xml2 >= 1.2.0 change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -120,7 +120,7 @@ Suggests:
     JuliaCall (>= 0.11.1),
     png,
     jpeg,
-    xml2,
+    xml2 (>= 1.2.0),
     httr,
     DBI (>= 0.4-1),
     showtext,

--- a/R/utils-upload.R
+++ b/R/utils-upload.R
@@ -35,7 +35,6 @@
 #' opts_knit$set(upload.fun = function(file) imgur_upload(file, key = 'your imgur key'))
 #' }
 imgur_upload = function(file, key = '9f3460e67f308f6') {
-
   if (!is.character(key)) stop('The Imgur API Key must be a character string!')
   resp = httr::POST(
     "https://api.imgur.com/3/image.xml",
@@ -44,6 +43,8 @@ imgur_upload = function(file, key = '9f3460e67f308f6') {
   )
   res = httr::content(resp, as = "raw")
   res = if (length(res)) xml2::as_list(xml2::read_xml(res))
-  if (is.null(res$data$link[[1]])) stop('failed to upload ', file)
-  structure(res$data$link[[1]], XML = res)
+  # Breaking change in xml2 1.2.0
+  if (packageVersion('xml2') >= '1.2.0') res <- res[[1L]]
+  if (is.null(res$link[[1]])) stop('failed to upload ', file)
+  structure(res$link[[1]], XML = res)
 }


### PR DESCRIPTION
In version xml2 1.2.0, there is a breaking change in the structure returned by as_list. The root node is now return that adds one more level on top.

This PR deals with that by

+ adding a minimal version to xml2 suggests
+ dealing with the breaking change if xml2 version is >= 1.2.0

this fixes #1523.

I did not had a bullet to NEWS for this small change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yihui/knitr/1525)
<!-- Reviewable:end -->
