### PR TITLE
Added a newline before the closing DIV tag before EndKnitrBlock

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -425,7 +425,7 @@ eng_block2 = function(options) {
   h6 = options$html.after2 %n% ''
 
   sprintf(
-    '\\BeginKnitrBlock{%s}%s%s<%s class="%s">%s%s%s</%s>%s\\EndKnitrBlock{%s}',
+    '\\BeginKnitrBlock{%s}%s%s<%s class="%s">%s%s%s\n</%s>%s\\EndKnitrBlock{%s}',
     type, l1, h3, h2, type, h5, code, h6, h2, h4, type
   )
 }


### PR DESCRIPTION
This change corrects a common issue in bookdown.

Before the change, a minimal book with the following content won't render into PDF by bookdown:
````
---
title: "A Book"
author: "Frida Gomam"
site: bookdown::bookdown_site
output:
  bookdown::latex
documentclass: book
---

# Test footnote

```{example}
This will fail to render to PDF.

1. One
2. Two
3. Three
```
````
One can see why the render fails in the intermediate TeX file generated for the knitr block:
```
\BeginKnitrBlock{example}
\protect\hypertarget{exm:unnamed-chunk-1}{}{\label{exm:unnamed-chunk-1}
}This will fail to render to PDF.

\begin{enumerate}
\def\labelenumi{\arabic{enumi}.}
\tightlist
\item
  One
\item
  Two
\item
  Three

  \EndKnitrBlock{example}
\end{enumerate}
```
The line`\EndKnitrBlock{example}` should occur *after* `\end{enumerate}`.  With the change, the TeX file contains instead:
```
\BeginKnitrBlock{example}
\protect\hypertarget{exm:unnamed-chunk-1}{}{\label{exm:unnamed-chunk-1}
}This will fail to render to PDF.

\begin{enumerate}
\def\labelenumi{\arabic{enumi}.}
\tightlist
\item
  One
\item
  Two
\item
  Three
\end{enumerate}
\EndKnitrBlock{example}
```
