### PR TITLE
Cache the result of SQL chunk properly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - `engine.path` does not work for `engine = 'dot'` (thanks, @billy34, #1534).
 
+- `sql` engine now caches the result properly when `output.var` is specified (thanks, @yutannihilation, #1544).
+
 # CHANGES IN knitr VERSION 1.20
 
 ## NEW FEATURES

--- a/R/block.R
+++ b/R/block.R
@@ -111,7 +111,11 @@ block_exec = function(options) {
     output = knit_hooks$get('chunk')(output, options)
     if (options$cache) block_cache(
       options, output,
-      if (options$engine == 'stan') options$engine.opts$x else character(0)
+      switch(
+        options$engine,
+        'stan' = options$engine.opts$x, 'sql' = options$output.var,
+        character(0)
+      )
     )
     return(if (options$include) output else '')
   }


### PR DESCRIPTION
(The original author of this idea is @yihui: https://github.com/yihui/knitr/pull/1542#pullrequestreview-119148409)

fixes rstudio/rmarkdown#914

When the engine is not R and the result of R object exists, the object should be passed to `block_cache`; SQL chunk and Stan chunk are the cases. Currently, Stan chunk does the right thing. This PR also make the result of SQL chunk to be cached.