### PR TITLE
Set STATA log file explicitly

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -130,10 +130,14 @@ eng_interpreted = function(options) {
       stata = {
         logf = sub('[.]do$', '.log', f)
         on.exit(unlink(c(logf)), add = TRUE)
-        paste(switch(
-          Sys.info()[['sysname']], Windows = '/q /e do', Darwin = '-q -e do',
-          Linux = '-q -b do', '-q -b do'
-        ), shQuote(normalizePath(f)))
+        switch(
+          Sys.info()[['sysname']], 
+          Windows = paste('/q /e do', shQuote(normalizePath(f))),
+          Darwin = paste('-q <', shQuote(normalizePath(f)), ">", 
+            shQuote(sub('[.]do$', '.log', normalizePath(f)))),
+          Linux = paste('-q -e do', shQuote(normalizePath(f))), 
+          '-q -b do'
+         ) 
       },
       f
     )


### PR DESCRIPTION
STATA batch mode is unable to create a logfile when the do file path contains certain symbols. For example, the following command will no generate the log file in the correct place when run on Mac:

/Applications/Stata/StataSE.app/Contents/MacOS/stata-se -q -b "/Users/abc/Working/main (1)/test.do"

The log file will appear as main.log in the folder "/Users/abc/Working" instead of as test.log in "/Users/abc/Working/main (1)". 

One workaround is to specify the log file directory/log file name explicitly: 

/Applications/Stata/StataSE.app/Contents/MacOS/stata-se -q < "/Users/abc/Working/main (1)/test.do" > "/Users/abc/Working/main (1)/test.log" 

Arguable, you shouldn't construct folder names with symbols like "()", but unfortunately for people with multiple Dropbox accounts, the Dropbox folder name always takes the form "Dropbox (account-name)". 

When running knitr with the STATA engine, I relies on the first version of the syntax to run the chunks and breaks when run on files in folders with a path like the one above. I modified knitr:::engine.R such that it uses the alternative syntax. 

