### PR TITLE
Pass ... to vignette engines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Added a new object `cache_engines` for other language engines to handle caching. See `?knitr::cache_engines` for details (thanks, @tmastny, #1518).
 
+- Can now pass additional arguments to knitr vignette engines if needed (@jimhester).
+
 ## BUG FIXES
 
 - `valign` in `kable_latex()` does not put the float alignment to the correct location (thanks, @haozhu233, #1487, #1519).

--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -38,7 +38,7 @@ vweave = function(file, driver, syntax, encoding = 'UTF-8', quiet = FALSE, ...) 
   opts_chunk$set(error = FALSE)  # should not hide errors
   knit_hooks$set(purl = hook_purl)  # write out code while weaving
   (if (grepl('\\.[Rr]md$', file)) knit2html_v1 else if (grepl('\\.[Rr]rst$', file)) knit2pandoc else knit)(
-    file, encoding = encoding, quiet = quiet, envir = globalenv()
+    file, encoding = encoding, quiet = quiet, envir = globalenv(), ...
   )
 }
 
@@ -48,23 +48,24 @@ vtangle = function(file, ..., encoding = 'UTF-8', quiet = FALSE) {
     file.create(file)
     return(file)
   }
-  purl(file, encoding = encoding, quiet = quiet)
+  purl(file, encoding = encoding, quiet = quiet, ...)
 }
 
 vweave_docco_linear = vweave
 body(vweave_docco_linear)[5L] = expression(knit2html(
   file, encoding = encoding, quiet = quiet, envir = globalenv(),
-  template = system.file('misc', 'docco-template.html', package = 'knitr')
+  template = system.file('misc', 'docco-template.html', package = 'knitr'),
+  ...
 ))
 
 vweave_docco_classic = vweave
 body(vweave_docco_classic)[5L] = expression(rocco(
-  file, encoding = encoding, quiet = quiet, envir = globalenv()
+  file, encoding = encoding, quiet = quiet, envir = globalenv(), ...
 ))
 
 vweave_rmarkdown = vweave
 body(vweave_rmarkdown)[5L] = expression(rmarkdown::render(
-  file, encoding = encoding, quiet = quiet, envir = globalenv()
+  file, encoding = encoding, quiet = quiet, envir = globalenv(), ...
 ))
 
 # do not tangle R code from vignettes


### PR DESCRIPTION
This allows you to pass additional arguments to vignette engines if desired. This can be used in the `...` argument to `tools::buildVignette()` or by explicitly retrieving the vignette engine, e.g.

```r
vignetteEngine("knitr::rmarkdown")$weave("file.Rmd", clean = TRUE)
```

We would use this in devtools so we could save the intermediate md files when building Rmd vignettes with `devtools::build_vignettes()`