### PR TITLE
Adding styler support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -127,7 +127,8 @@ Suggests:
     httr,
     DBI (>= 0.4-1),
     showtext,
-    tibble
+    tibble,
+    styler
 License: GPL
 URL: https://yihui.name/knitr/
 BugReports: https://github.com/yihui/knitr/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,7 @@ Authors@R: c(
     person(c("Kevin", "K."), "Smith", role = "ctb"),
     person("Kirill", "Mueller", role = "ctb"),
     person("Kohske", "Takahashi", role = "ctb"),
+    person("Lorenz", "Walthert", role = "ctb"),
     person("Lucas", "Gallindo", role = "ctb"),
     person("Martin", "Modrák", role = "ctb"),
     person("Michael", "Chirico", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## NEW FEATURES
 
+- Added **styler** support: the chunk option `tidy = 'styler'`, the code will be reformatted using the **styler** package. The chunk option `tidy = TRUE` means `tidy = 'formatR'` and still uses `formatR::tidy_source()` to reformat the code. The chunk option `tidy` can also take a custom function to reformat the code. See the documentation for details: https://yihui.name/knitr/options/ (thanks, @lorenzwalthert, #1581).
+
 - Added a new object `cache_engines` for other language engines to handle caching. See `?knitr::cache_engines` for details (thanks, @tmastny, #1518).
 
 - Can now pass additional arguments to knitr vignette engines if needed (thanks, @jimhester, #1577).

--- a/R/block.R
+++ b/R/block.R
@@ -145,18 +145,17 @@ block_exec = function(options) {
 
   code = options$code
   echo = options$echo  # tidy code if echo
-  if (!isFALSE(echo) && options$tidy && length(code)) {
-    if (options$tidy.method == "formatR") {
-      res = try_silent(do.call(
+  if (!isFALSE(echo) && !identical(options$tidy, FALSE) && length(code)) {
+    tidy.method = if (isTRUE(options$tidy)) 'formatR' else options$tidy
+    res = switch(
+      tidy.method,
+      formatR = try_silent(do.call(
         formatR::tidy_source, c(list(text = code, output = FALSE), options$tidy.opts)
-      ))
-    } else if (options$tidy.method == "styler") {
-      bare = try_silent(do.call(
+      )),
+      styler = try_silent(list(text.tidy = do.call(
         styler::style_text, c(list(text = code), options$tidy.opts)
-      ))
-      res = list(text.tidy = unclass(bare), text.mask = unclass(bare))
-    } else {
-      stop('Invalid \'tidy.metod\'. Must be either \'formatR\' or \'styler\'')
+      ))),
+      stop("Invalid 'tidy.metod'. Must be either 'formatR' or 'styler'")
     }
 
     if (!inherits(res, 'try-error')) {

--- a/R/block.R
+++ b/R/block.R
@@ -145,7 +145,7 @@ block_exec = function(options) {
 
   code = options$code
   echo = options$echo  # tidy code if echo
-  if (!isFALSE(echo) && !identical(options$tidy, FALSE) && length(code)) {
+  if (!isFALSE(echo) && !isFALSE(options$tidy) && length(code)) {
     tidy.method = if (isTRUE(options$tidy)) 'formatR' else options$tidy
     if (is.character(tidy.method)) tidy.method = switch(
       tidy.method,

--- a/R/block.R
+++ b/R/block.R
@@ -161,7 +161,7 @@ block_exec = function(options) {
   # only evaluate certain lines
   if (is.numeric(ev <- options$eval)) {
     # group source code into syntactically complete expressions
-    if (!options$tidy) code = sapply(highr:::group_src(code), paste, collapse = '\n')
+    if (isFALSE(options$tidy)) code = sapply(highr:::group_src(code), paste, collapse = '\n')
     iss = seq_along(code)
     code = comment_out(code, '##', setdiff(iss, iss[ev]), newline = FALSE)
   }

--- a/R/block.R
+++ b/R/block.R
@@ -146,9 +146,19 @@ block_exec = function(options) {
   code = options$code
   echo = options$echo  # tidy code if echo
   if (!isFALSE(echo) && options$tidy && length(code)) {
-    res = try_silent(do.call(
-      formatR::tidy_source, c(list(text = code, output = FALSE), options$tidy.opts)
-    ))
+    if (options$tidy.method == "formatR") {
+      res = try_silent(do.call(
+        formatR::tidy_source, c(list(text = code, output = FALSE), options$tidy.opts)
+      ))
+    } else if (options$tidy.method == "styler") {
+      bare = try_silent(do.call(
+        styler::style_text, c(list(text = code), options$tidy.opts)
+      ))
+      res = list(text.tidy = unclass(bare), text.mask = unclass(bare))
+    } else {
+      stop('Invalid \'tidy.metod\'. Must be either \'formatR\' or \'styler\'')
+    }
+
     if (!inherits(res, 'try-error')) {
       code = res$text.tidy
     } else warning('failed to tidy R code in chunk <', options$label, '>\n',

--- a/R/defaults.R
+++ b/R/defaults.R
@@ -62,7 +62,7 @@ new_defaults = function(value = list()) {
 opts_chunk = new_defaults(list(
 
   eval = TRUE, echo = TRUE, results = 'markup',
-  tidy = FALSE, tidy.method = 'formatR', tidy.opts = NULL,
+  tidy = FALSE, tidy.opts = NULL,
   collapse = FALSE, prompt = FALSE, comment = '##', highlight = TRUE,
   strip.white = TRUE, size = 'normalsize', background = '#F7F7F7',
 

--- a/R/defaults.R
+++ b/R/defaults.R
@@ -61,7 +61,8 @@ new_defaults = function(value = list()) {
 #' @examples opts_chunk$get('prompt'); opts_chunk$get('fig.keep')
 opts_chunk = new_defaults(list(
 
-  eval = TRUE, echo = TRUE, results = 'markup', tidy = FALSE, tidy.opts = NULL,
+  eval = TRUE, echo = TRUE, results = 'markup',
+  tidy = FALSE, tidy.method = 'formatR', tidy.opts = NULL,
   collapse = FALSE, prompt = FALSE, comment = '##', highlight = TRUE,
   strip.white = TRUE, size = 'normalsize', background = '#F7F7F7',
 

--- a/R/defaults.R
+++ b/R/defaults.R
@@ -61,8 +61,7 @@ new_defaults = function(value = list()) {
 #' @examples opts_chunk$get('prompt'); opts_chunk$get('fig.keep')
 opts_chunk = new_defaults(list(
 
-  eval = TRUE, echo = TRUE, results = 'markup',
-  tidy = FALSE, tidy.opts = NULL,
+  eval = TRUE, echo = TRUE, results = 'markup', tidy = FALSE, tidy.opts = NULL,
   collapse = FALSE, prompt = FALSE, comment = '##', highlight = TRUE,
   strip.white = TRUE, size = 'normalsize', background = '#F7F7F7',
 

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -18,7 +18,7 @@ hilight_source = function(x, format, options) {
   } else if (options$prompt) {
     # if you did not reformat or evaluate the code, I have to figure out which
     # lines belong to one complete expression first (#779)
-    if (options$engine == 'R' && !options$tidy && isFALSE(options$eval))
+    if (options$engine == 'R' && isFALSE(options$tidy) && isFALSE(options$eval))
       x = vapply(highr:::group_src(x), paste, character(1), collapse = '\n')
     line_prompt(x)
   } else x


### PR DESCRIPTION
Finally, I got time to try to add styler support as suggested in #1516. I have the following questions: 

* As of now, there are two options `tidy` (defaults to  `FALSE`) and `tidy.method` (defaults to `"formatR"`). We could remove the `tidy` option. This would result in a backward-incompatible API change, which is probably not a good idea. I think it would make sense to simply issue a warning when someone sets `tidy.method = "styler"` and (either because of explicit specification or because of the default) `tidy = FALSE`, because he or she probably just wants `tidy = TRUE` and `tidy.method = styler`. I have not yet implemented that, so let me know if I should go ahead with that.
* I don't know what resources (e.g. documentation, cheat sheets etc.) need to be updated to reflect the API change, at least I could not find any help file where the `tidy` option was documented.
* Also, I wasn't sure about if and how I should add unit tests for this. 

Could you please advise on these points? Thanks.

cc: @krlmlr 