### PR TITLE
Control display of package startup messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Added a new object `cache_engines` for other language engines to handle caching. See `?knitr::cache_engines` for details (thanks, @tmastny, #1518).
 
+- Add `package.startup.message` option to control display of the package startup message (thanks, @jimhester, #1583).
+
 ## BUG FIXES
 
 - `valign` in `kable_latex()` does not put the float alignment to the correct location (thanks, @haozhu233, #1487, #1519).

--- a/R/block.R
+++ b/R/block.R
@@ -178,6 +178,7 @@ block_exec = function(options) {
       code, envir = env, new_device = FALSE,
       keep_warning = !isFALSE(options$warning),
       keep_message = !isFALSE(options$message),
+      keep_package_startup_message = !isFALSE(options$package.startup.message),
       stop_on_error = if (options$error && options$include) 0L else 2L,
       output_handler = knit_handlers(options$render, options)
     )

--- a/R/defaults.R
+++ b/R/defaults.R
@@ -74,7 +74,7 @@ opts_chunk = new_defaults(list(
   fig.pos = '', out.width = NULL, out.height = NULL, out.extra = NULL, fig.retina = 1,
   external = TRUE, sanitize = FALSE, interval = 1, aniopts = 'controls,loop',
 
-  warning = TRUE, error = TRUE, message = TRUE,
+  warning = TRUE, error = TRUE, message = TRUE, package.startup.message = FALSE,
 
   render = NULL,
 


### PR DESCRIPTION
These are often unwanted in knitr output, so we default to not showing
them. Requires a corresponding change to evaluate
https://github.com/r-lib/evaluate/pull/86

Fixes #1583