### PR TITLE
Add flags to ffmpeg mp4 hook for Safari support

### DIFF
--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -95,6 +95,9 @@ hook_ffmpeg = function(x, options, format = 'webm') {
 
   extra = if (format == 'webm') {
     paste('-b:v', options$ffmpeg.bitrate %n% '1M', '-crf 10')
+  } else if (format == 'mp4') {
+    # enables Safari support of .mp4
+    paste('-pix_fmt yuv420p')
   }
   ffmpeg.cmd = paste(
     'ffmpeg', '-y', '-r', 1 / options$interval, '-i', fig.fname, extra, mov.fname


### PR DESCRIPTION
With the current ffmpeg mp4 converter setup in knitr in-line
animation, I was not able to have my animations show up in
Safari. After adding the flags in this commit, it worked.

https://apple.stackexchange.com/questions/166553/why-wont-video-from-ffmpeg-show-in-quicktime-imovie-or-quick-preview

I found the Safari viewability to be sensitive to exactly where
the flags were placed. For instance, running

ffmpeg -y -r 1 -pix_fmt yuv420p -i foo-%d.png foo.mp4

did not work, otherwise I would consider aliasing my ffmpeg
command. It turned out to be necessary to include the -i flag
first, as so:

ffmpeg -y -r 1 -i foo-%d.png -pix_fmt yuv420p foo.mp4