### PR TITLE
add example for table.envir param

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -57,6 +57,8 @@
 #' kable(mtcars, format = 'latex', booktabs = TRUE)
 #' # use the longtable package
 #' kable(matrix(1000, ncol=5), format = 'latex', digits = 2, longtable = TRUE)
+#' # change LaTeX default table environment
+#' kable(head(iris), format = "latex", caption = "mytable", table.envir='table1')
 #' # add some table attributes
 #' kable(head(iris), format = 'html', table.attr = 'id="mytable"')
 #' # reST output

--- a/R/table.R
+++ b/R/table.R
@@ -58,7 +58,7 @@
 #' # use the longtable package
 #' kable(matrix(1000, ncol=5), format = 'latex', digits = 2, longtable = TRUE)
 #' # change LaTeX default table environment
-#' kable(head(iris), format = "latex", caption = "mytable", table.envir='table1')
+#' kable(head(iris), format = "latex", caption = "My table", table.envir='table*')
 #' # add some table attributes
 #' kable(head(iris), format = 'html', table.attr = 'id="mytable"')
 #' # reST output


### PR DESCRIPTION
following discussion in #1585 to show that `table.envir=` can be used in `kable`. I did not rebuilt the documentation thinking you'd prefer to do it yourself. Tell me if not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yihui/knitr/1588)
<!-- Reviewable:end -->
