### PR TITLE
Fix long example lines

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -74,11 +74,14 @@ cache_engines = new_defaults()
 #'   the appropriate output hooks.
 #' @export
 #' @examples library(knitr)
-#' engine_output(opts_chunk$merge(list(engine = 'Rscript')), code = '1 + 1', out = '[1] 2')
-#' engine_output(opts_chunk$merge(list(echo = FALSE, engine = 'Rscript')), code = '1 + 1', out = '[1] 2')
+#' engine_output(opts_chunk$merge(list(engine = 'Rscript')),
+#'               code = '1 + 1', out = '[1] 2')
+#' engine_output(opts_chunk$merge(list(echo = FALSE, engine = 'Rscript')),
+#'               code = '1 + 1', out = '[1] 2')
 #'
 #' # expert use only
-#' engine_output(opts_chunk$merge(list(engine = 'python')), out = list(structure(list(src = '1 + 1'), class = 'source'), '2'))
+#' engine_output(opts_chunk$merge(list(engine = 'python')),
+#'               out = list(structure(list(src = '1 + 1'), class = 'source'), '2'))
 engine_output = function(options, code, out, extra = NULL) {
   if (missing(code) && is.list(out)) return(unlist(wrap(out, options)))
   if (!is.logical(options$echo)) code = code[options$echo]

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -34,7 +34,8 @@
 #' # <<foo, dev='pdf', fig.show='animate', interval=.1>>=
 #'
 #' # 5 plots are generated in this chunk
-#' hook_plot_tex('foo5.pdf', opts_chunk$merge(list(fig.show='animate',interval=.1,fig.cur=5, fig.num=5)))
+#' hook_plot_tex('foo5.pdf', opts_chunk$merge(list(fig.show='animate',
+#'               interval=.1, fig.cur=5, fig.num=5)))
 hook_plot_tex = function(x, options) {
   # This function produces the image inclusion code for LaTeX.
   # optionally wrapped in code that resizes it, aligns it, handles it

--- a/R/parser.R
+++ b/R/parser.R
@@ -278,7 +278,8 @@ print.inline = function(x, ...) {
 #' # automatically figure out 'to'
 #' read_chunk(lines = code, labels = c('foo', 'bar'), from = c(1, 4))
 #' read_chunk(lines = code, labels = c('foo', 'bar'), from = "^#@@a", to = "^#@@b")
-#' read_chunk(lines = code, labels = c('foo', 'bar'), from = "^#@@a", to = "^#@@b", from.offset = 1, to.offset = -1)
+#' read_chunk(lines = code, labels = c('foo', 'bar'), from = "^#@@a",
+#'            to = "^#@@b", from.offset = 1, to.offset = -1)
 #'
 #' ## later you can use, e.g., <<foo>>=
 #' knitr:::knit_code$get() # use this to check chunks in the current session


### PR DESCRIPTION
This is a minor edit that fixes an R CMD check notes of the type

```
checking Rd line widths ... NOTE
Rd file 'engine_output.Rd':
  \examples lines wider than 100 characters:
     engine_output(opts_chunk$merge(list(echo = FALSE, engine = 'Rscript')), code = '1 + 1', out = '[1] 2')
     engine_output(opts_chunk$merge(list(engine = 'python')), out = list(structure(list(src = '1 + 1'), class = 'source'), '2'))

These lines will be truncated in the PDF manual.
```