### PR TITLE
Cache fix for non-R engine chunks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,6 +73,7 @@ Authors@R: c(
     person("Miller", "Patrick", role = "ctb"),
     person("Nacho", "Caballero", role = "ctb"),
     person("Nick", "Salkowski", role = "ctb"),
+    person("Niels Richard", "Hansen", role = "ctb"),
     person("Noam", "Ross", role = "ctb"),
     person("Obada", "Mahdi", role = "ctb"),
     person("Qiang", "Li", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 - Added the unit `px` to the chunk option `out.width` if its value is numeric (thanks, @chendaniely, #1761).
 
+- The chunk option `dependson` did not work for non-R engines (thanks, @nielsrhansen, #1601).
+
 # CHANGES IN knitr VERSION 1.24
 
 ## MAJOR CHANGES

--- a/R/block.R
+++ b/R/block.R
@@ -111,7 +111,7 @@ block_exec = function(options) {
     output = knit_hooks$get('chunk')(output, options)
     if (options$cache) {
       cache.exists = cache$exists(options$hash, options$cache.lazy)
-      if(options$cache.rebuild || !cache.exists) block_cache(options, output, switch(
+      if (options$cache.rebuild || !cache.exists) block_cache(options, output, switch(
         options$engine,
         'stan' = options$output.var, 'sql' = options$output.var, character(0)
         ))

--- a/R/block.R
+++ b/R/block.R
@@ -109,10 +109,13 @@ block_exec = function(options) {
     res.after = run_hooks(before = FALSE, options)
     output = paste(c(res.before, output, res.after), collapse = '')
     output = knit_hooks$get('chunk')(output, options)
-    if (options$cache) block_cache(options, output, switch(
-      options$engine,
-      'stan' = options$output.var, 'sql' = options$output.var, character(0)
-    ))
+    if (options$cache) {
+      cache.exists = cache$exists(options$hash, options$cache.lazy)
+      if(options$cache.rebuild || !cache.exists) block_cache(options, output, switch(
+        options$engine,
+        'stan' = options$output.var, 'sql' = options$output.var, character(0)
+        ))
+      }
     return(if (options$include) output else '')
   }
 


### PR DESCRIPTION
I noticed that even though I cached an Rcpp chunk (and no recompilation was done), chunks that were dependent on the Rcpp chunk via the 'dependson' argument were evaluated every time disregarding the caching option. 

The cause, I believe, is in 'block_exec' where the call of 'block_cache' whenever the engine is not R always triggers deletion of the cache for all dependent chunks via 'purge_cache'. 

I have modified the code to check if it's actually necessary to rewrite the cache via a call to 'block_cache' in exactly the same way as it is done further down in the function anyway. This appears to work correctly on the document I am working on with cached Rcpp chunks. I don't know if this will break something for other non-R engines, but I don't see any argument why Rcpp chunks that have not changed should trigger recomputation of dependent chunks.