### PR TITLE
Parse the text to detect doc comments and inlines properly in spin()

### DIFF
--- a/R/spin.R
+++ b/R/spin.R
@@ -68,7 +68,7 @@ spin = function(
   # turn ((expr)) into inline expressions, e.g. `r expr` or \Sexpr{expr}
   if (any(i <- grepl(inline, x))) x[i] = gsub(inline, p[4], x[i])
 
-  r = rle(grepl(doc, x) | i)  # inline expressions are treated as doc instead of code
+  r = rle(grepl_doc_comment(doc, x) | i)  # inline expressions are treated as doc instead of code
   n = length(r$lengths); txt = vector('list', n); idx = c(0L, cumsum(r$lengths))
   p1 = gsub('\\{', '\\\\{', paste0('^', p[1L], '.*', p[2L], '$'))
 
@@ -118,6 +118,12 @@ spin = function(
 
   if (!precious && !is.null(outsrc)) file.remove(outsrc)
   invisible(out)
+}
+
+grepl_doc_comment = function(doc, x) {
+  d = getParseData(parse(text = x))
+  doc_lines = d[d$col1 == 1 & d$token == "COMMENT" & grepl(doc, d$text), ]$line1
+  seq_along(x) %in% doc_lines
 }
 
 .fmt.pat = list(

--- a/R/spin.R
+++ b/R/spin.R
@@ -22,7 +22,7 @@
 #'   if you want to use \code{##} to denote documentation, you can use
 #'   \code{'^##\\\\s*'}.
 #' @param inline A regular expression to identify inline R expressions; by
-#'   default, code of the form \code{((code))} on its own line is treated as an
+#'   default, code of the form \code{\{\{code\}\}} on its own line is treated as an
 #'   inline expression.
 #' @param comment A pair of regular expressions for the start and end delimiters
 #'   of comments; the lines between a start and an end delimiter will be
@@ -65,7 +65,7 @@ spin = function(
   if (length(c1)) x = x[-unique(unlist(mapply(seq, c1, c2, SIMPLIFY = FALSE)))]
 
   p = .fmt.pat[[tolower(format)]]
-  # turn ((expr)) into inline expressions, e.g. `r expr` or \Sexpr{expr}
+  # turn {{expr}} into inline expressions, e.g. `r expr` or \Sexpr{expr}
   if (any(i <- grepl(inline, x))) x[i] = gsub(inline, p[4], x[i])
 
   r = rle(grepl_doc_comment(doc, x) | i)  # inline expressions are treated as doc instead of code

--- a/R/spin.R
+++ b/R/spin.R
@@ -64,15 +64,16 @@ spin = function(
   # remove comments
   if (length(c1)) x = x[-unique(unlist(mapply(seq, c1, c2, SIMPLIFY = FALSE)))]
 
-  # remove multiline string literals and symbols
+  # remove multiline string literals and symbols (note that this ignores lines with spaces at their
+  # beginnings, assuming doc and inline regex don't match these lines anyway)
   parsed_data = getParseData(parse(text = x))
-  is_complete = seq_along(x) %in% unique(parsed_data[parsed_data$col1 == 1, ]$line1)
+  is_matchable = seq_along(x) %in% unique(parsed_data[parsed_data$col1 == 1, ]$line1)
 
   p = .fmt.pat[[tolower(format)]]
   # turn {{expr}} into inline expressions, e.g. `r expr` or \Sexpr{expr}
-  if (any(i <- is_complete & grepl(inline, x))) x[i] = gsub(inline, p[4], x[i])
+  if (any(i <- is_matchable & grepl(inline, x))) x[i] = gsub(inline, p[4], x[i])
 
-  r = rle((is_complete & grepl(doc, x)) | i)  # inline expressions are treated as doc instead of code
+  r = rle((is_matchable & grepl(doc, x)) | i)  # inline expressions are treated as doc instead of code
   n = length(r$lengths); txt = vector('list', n); idx = c(0L, cumsum(r$lengths))
   p1 = gsub('\\{', '\\\\{', paste0('^', p[1L], '.*', p[2L], '$'))
 

--- a/R/spin.R
+++ b/R/spin.R
@@ -66,8 +66,8 @@ spin = function(
 
   # remove multiline string literals and symbols (note that this ignores lines with spaces at their
   # beginnings, assuming doc and inline regex don't match these lines anyway)
-  parsed_data = getParseData(parse(text = x))
-  is_matchable = seq_along(x) %in% unique(parsed_data[parsed_data$col1 == 1, ]$line1)
+  parsed_data = getParseData(parse(text = x, keep.source = TRUE))
+  is_matchable = seq_along(x) %in% unique(parsed_data[parsed_data$col1 == 1, 'line1'])
 
   p = .fmt.pat[[tolower(format)]]
   # turn {{expr}} into inline expressions, e.g. `r expr` or \Sexpr{expr}

--- a/R/spin.R
+++ b/R/spin.R
@@ -64,11 +64,15 @@ spin = function(
   # remove comments
   if (length(c1)) x = x[-unique(unlist(mapply(seq, c1, c2, SIMPLIFY = FALSE)))]
 
+  # remove multiline string literals and symbols
+  parsed_data = getParseData(parse(text = x))
+  is_complete = seq_along(x) %in% unique(parsed_data[parsed_data$col1 == 1, ]$line1)
+
   p = .fmt.pat[[tolower(format)]]
   # turn {{expr}} into inline expressions, e.g. `r expr` or \Sexpr{expr}
-  if (any(i <- grepl(inline, x))) x[i] = gsub(inline, p[4], x[i])
+  if (any(i <- is_complete & grepl(inline, x))) x[i] = gsub(inline, p[4], x[i])
 
-  r = rle(grepl_doc_comment(doc, x) | i)  # inline expressions are treated as doc instead of code
+  r = rle((is_complete & grepl(doc, x)) | i)  # inline expressions are treated as doc instead of code
   n = length(r$lengths); txt = vector('list', n); idx = c(0L, cumsum(r$lengths))
   p1 = gsub('\\{', '\\\\{', paste0('^', p[1L], '.*', p[2L], '$'))
 
@@ -118,12 +122,6 @@ spin = function(
 
   if (!precious && !is.null(outsrc)) file.remove(outsrc)
   invisible(out)
-}
-
-grepl_doc_comment = function(doc, x) {
-  d = getParseData(parse(text = x))
-  doc_lines = d[d$col1 == 1 & d$token == "COMMENT" & grepl(doc, d$text), ]$line1
-  seq_along(x) %in% doc_lines
 }
 
 .fmt.pat = list(

--- a/man/spin.Rd
+++ b/man/spin.Rd
@@ -4,10 +4,11 @@
 \alias{spin}
 \title{Spin goat's hair into wool}
 \usage{
-spin(hair, knit = TRUE, report = TRUE, text = NULL, envir = parent.frame(), 
-    format = c("Rmd", "Rnw", "Rhtml", "Rtex", "Rrst"), doc = "^#+'[ ]?", 
-    inline = "^[{][{](.+)[}][}][ ]*$", comment = c("^[# ]*/[*]", "^.*[*]/ *$"), 
-    precious = !knit && is.null(text))
+spin(hair, knit = TRUE, report = TRUE, text = NULL,
+  envir = parent.frame(), format = c("Rmd", "Rnw", "Rhtml", "Rtex",
+  "Rrst"), doc = "^#+'[ ]?", inline = "^[{][{](.+)[}][}][ ]*$",
+  comment = c("^[# ]*/[*]", "^.*[*]/ *$"), precious = !knit &&
+  is.null(text))
 }
 \arguments{
 \item{hair}{Path to the R script.}
@@ -31,7 +32,7 @@ if you want to use \code{##} to denote documentation, you can use
 \code{'^##\\\\s*'}.}
 
 \item{inline}{A regular expression to identify inline R expressions; by
-default, code of the form \code{((code))} on its own line is treated as an
+default, code of the form \code{\{\{code\}\}} on its own line is treated as an
 inline expression.}
 
 \item{comment}{A pair of regular expressions for the start and end delimiters

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -13,8 +13,14 @@ assert(
   'spin() detects lines for documentation',
   identical(spin_w_tempfile("#' test", "1 * 1", "#' test"),
             c("test", "", "```{r }", "1 * 1", "```", "", "test")),
+  # a multiline string literal contains the pattern of doc or inline
   identical(spin_w_tempfile("code <- \"", "#' test\""),
             c("", "```{r }", "code <- \"", "#' test\"", "```", "")),
   identical(spin_w_tempfile("code <- \"", "{{ 1 + 1 }}", "\""),
-            c("", "```{r }", "code <- \"", "{{ 1 + 1 }}", "\"", "```", ""))
+            c("", "```{r }", "code <- \"", "{{ 1 + 1 }}", "\"", "```", "")),
+  # a multiline symbol contains the pattern of doc or inline
+  identical(spin_w_tempfile("`", "#' test", "`"),
+            c("", "```{r }", "`", "#' test", "`", "```", "")),
+  identical(spin_w_tempfile("`", "{{ 1 + 1 }}", "`"),
+            c("", "```{r }", "`", "{{ 1 + 1 }}", "`", "```", ""))
 )

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -23,5 +23,7 @@ assert(
   identical(spin_w_tempfile("#' test", "1 * 1", "#' test"),
             c("test", "", "```{r }", "1 * 1", "```", "", "test")),
   identical(spin_w_tempfile("code <- \"", "#' test\""),
-            c("", "```{r }", "code <- \"", "#' test\"", "```", ""))
+            c("", "```{r }", "code <- \"", "#' test\"", "```", "")),
+  identical(spin_w_tempfile("code <- \"", "{{ 1 + 1 }}", "\""),
+            c("", "```{r }", "code <- \"", "{{ 1 + 1 }}", "\"", "```", ""))
 )

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -1,0 +1,27 @@
+library(testit)
+
+doc = formals(spin)$doc
+
+assert(
+  'is_doc_line() detects lines for documentation',
+  identical(grepl_doc_comment(doc, c("#' test", "1 * 1", "#' test")), c(TRUE, FALSE, TRUE)),
+  identical(grepl_doc_comment(doc, c("code <- \"", "#' test\"")), c(FALSE, FALSE)),
+  identical(grepl_doc_comment(doc, c("`code", "#' test` <- 1")), c(FALSE, FALSE))
+)
+
+spin_w_tempfile = function(...) {
+  tmp = tempfile(fileext = ".R")
+  writeLines(c(...), tmp)
+  spinned = spin(tmp, knit = FALSE)
+  result = readLines(spinned)
+  file.remove(c(tmp, spinned))
+  result
+}
+
+assert(
+  'spin() detects lines for documentation',
+  identical(spin_w_tempfile("#' test", "1 * 1", "#' test"),
+            c("test", "", "```{r }", "1 * 1", "```", "", "test")),
+  identical(spin_w_tempfile("code <- \"", "#' test\""),
+            c("", "```{r }", "code <- \"", "#' test\"", "```", ""))
+)

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -1,14 +1,5 @@
 library(testit)
 
-doc = formals(spin)$doc
-
-assert(
-  'is_doc_line() detects lines for documentation',
-  identical(grepl_doc_comment(doc, c("#' test", "1 * 1", "#' test")), c(TRUE, FALSE, TRUE)),
-  identical(grepl_doc_comment(doc, c("code <- \"", "#' test\"")), c(FALSE, FALSE)),
-  identical(grepl_doc_comment(doc, c("`code", "#' test` <- 1")), c(FALSE, FALSE))
-)
-
 spin_w_tempfile = function(...) {
   tmp = tempfile(fileext = ".R")
   writeLines(c(...), tmp)


### PR DESCRIPTION
## Problem

(originally reported at https://github.com/rstudio/rmarkdown/issues/1444)

Currently, `spin()` detects doc comments by checking if the `"^#+'[ ]?"` matches on a line-by-line basis. 

https://github.com/yihui/knitr/blob/01407a72c8d3497336487029b21189ad13bee498/R/spin.R#L71

Accordingly, it mistakenly detects string literals that contain `#' ` as doc comments in cases like this:

``` r
code <- "
#' hello, world!"
```

The same thing occurs on `inline` in the following case:

``` r
code <- "
{{ Sys.Date() }}
"
```

In addition to string literals, symbols can also be multi-line:

``` r
`
{{very_strange_var_name}}
` <- 1
```

## Fix

To identify the true comments and double-brackets correctly, we need to parse the whole code first and ignore string literals and symbols that are over multiple lines. To me, @yihui's suggestion of `utils::getParsedData()` at https://github.com/rstudio/rmarkdown/issues/1444#issuecomment-420751993 seems simpler and faster (benchmark: https://github.com/yihui/knitr/pull/1605#issuecomment-421572485), so I implemented as such.

The idea is simple; since multi-line `STR_CONST` or `SYMBOL` are tokenized as below, if the beginning of a line is contained by them, there are no `col1 = 1` token in the line. So, we can filter the parsed data by `col1 == 1` to see what lines are "complete".

``` r
codes <-
  c("{{ Sys.Date() }}",   # true inline
    '"',
    "{{ Sys.Date() }}\"", # false
    "`",
    "{{ Sys.Date() }}",   # false
    "`",
    "#' Hello world!",    # true doc comment
    '"',
    "#' Hello world!\"",  # false
    "`",
    "#' Hello world!",    # false
    "`")

d <- getParseData(parse(text = codes))
options(width = 400)
d
#>    line1 col1 line2 col2 id parent                token terminal                   text
#> 16     1    1     1   16 16      0                 expr    FALSE                       
#> 1      1    1     1    1  1     16                  '{'     TRUE                      {
#> 12     1    2     1   15 12     16                 expr    FALSE                       
#> 2      1    2     1    2  2     12                  '{'     TRUE                      {
#> 8      1    4     1   13  8     12                 expr    FALSE                       
#> 3      1    4     1   11  3      5 SYMBOL_FUNCTION_CALL     TRUE               Sys.Date
#> 5      1    4     1   11  5      8                 expr    FALSE                       
#> 4      1   12     1   12  4      8                  '('     TRUE                      (
#> 6      1   13     1   13  6      8                  ')'     TRUE                      )
#> 9      1   15     1   15  9     12                  '}'     TRUE                      }
#> 13     1   16     1   16 13     16                  '}'     TRUE                      }
#> 20     2    1     3   17 20     22            STR_CONST     TRUE   "\n{{ Sys.Date() }}"
#> 22     2    1     3   17 22      0                 expr    FALSE                       
#> 25     4    1     6    1 25     27               SYMBOL     TRUE `\n{{ Sys.Date() }}\n`
#> 27     4    1     6    1 27      0                 expr    FALSE                       
#> 30     7    1     7   15 30    -35              COMMENT     TRUE        #' Hello world!
#> 33     8    1     9   16 33     35            STR_CONST     TRUE    "\n#' Hello world!"
#> 35     8    1     9   16 35      0                 expr    FALSE                       
#> 38    10    1    12    1 38     40               SYMBOL     TRUE  `\n#' Hello world!\n`
#> 40    10    1    12    1 40      0                 expr    FALSE

complete_lines <- unique(d[d$col1 == 1, ]$line1)
complete_lines
#> [1]  1  2  4  7  8 10

# doc
grep("^#+'[ ]?", codes[complete_lines], value = TRUE)
#> [1] "#' Hello world!"

# inline
grep("^[{][{](.+)[}][}][ ]*$", codes[complete_lines], value = TRUE)
#> [1] "{{ Sys.Date() }}"
```

Created on 2018-09-16 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).
