### PR TITLE
Allow setting only convert.opts for tikz engine

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -308,7 +308,7 @@ eng_tikz = function(options) {
     # convert to the desired output-format, calling `convert`
     conv = 0
     if (ext != 'pdf') {
-      conv = system2(options$engine.opts$convert %n% 'convert', c(
+      conv = system2(options$engine.opts[['convert']] %n% 'convert', c(
         options$engine.opts$convert.opts, sprintf('%s %s', fig, fig2)
       ))
     }


### PR DESCRIPTION
The *convert.opts* field could not be given as the only field
to *engine.opts* when using the tikz engine. The default value
for *convert* was not chosen if *convert.opts* was set, as R used
partial matching for `engine.opts$convert`. Using the `[[` extractor to
select the list element fixes this.