### PR TITLE
engine cat honors options echo and eval

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -382,16 +382,13 @@ eng_cat = function(options) {
     # do not write to stdout like the default behavior of cat()
     if (!identical(file, '')) cat(..., file = file)
   }
-  if (options$eval == TRUE)
+  if (options$eval)
     do.call(cat2, c(list(options$code, sep = '\n'), options$engine.opts))
 
   if (is.null(lang <- options$engine.opts$lang) && is.null(lang <- options$class.source))
-    lang = NULL
+    return('')
   options$engine = lang
-  if (options$echo == TRUE || ! is.null(lang))
-    engine_output(options, options$code, NULL)
-  else
-    return(NULL)
+  engine_output(options, options$code, NULL)
 }
 
 ## output the code without processing it

--- a/R/engine.R
+++ b/R/engine.R
@@ -382,11 +382,15 @@ eng_cat = function(options) {
     # do not write to stdout like the default behavior of cat()
     if (!identical(file, '')) cat(..., file = file)
   }
-  do.call(cat2, c(list(options$code, sep = '\n'), options$engine.opts))
+  if (options$eval == TRUE)
+    do.call(cat2, c(list(options$code, sep = '\n'), options$engine.opts))
   if (is.null(lang <- options$engine.opts$lang) && is.null(lang <- options$class.source))
-    return('')
+    lang = NULL
   options$engine = lang
-  engine_output(options, options$code, NULL)
+  if (options$echo == TRUE || ! is.null(lang))
+    engine_output(options, options$code, NULL)
+  else
+    return(NULL)
 }
 
 ## output the code without processing it

--- a/R/engine.R
+++ b/R/engine.R
@@ -308,7 +308,7 @@ eng_tikz = function(options) {
     # convert to the desired output-format, calling `convert`
     conv = 0
     if (ext != 'pdf') {
-      conv = system2(options$engine.opts$convert %n% 'convert', c(
+      conv = system2(options$engine.opts[['convert']] %n% 'convert', c(
         options$engine.opts$convert.opts, sprintf('%s %s', fig, fig2)
       ))
     }


### PR DESCRIPTION
I think it would be nice if the `cat` engine would honor the general chunk options `echo` and `eval` .  The use of  `lang`  is not clear to me, but a chunk will now be `echo`-ed when `lang` is present or `echo == TRUE`