### PR TITLE
Add per engine engine.opts for eng_interpreted

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.20.21
+Version: 1.20.22
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Adam", "Vogt", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - When `options(knitr.include_graphics.ext = TRUE)` is set, the full filename will be used in `\includegraphics{}` (e.g., `\includegraphics{foo.pdf}`) instead of the (default) base filename (e.g., `\includegraphics{foo}`) if a plot is embedded in the LaTeX output. This will avoid the ambiguity for LaTeX to choose the correct file (#1587).
 
+- The chunk option `engine.opts` can also take a list now, so that users can specify different options for different language engines (thanks, @kiwiroy, #1632).
+
 ## BUG FIXES
 
 - `valign` in `kable_latex()` does not put the float alignment to the correct location (thanks, @haozhu233, #1487, #1519).

--- a/R/engine.R
+++ b/R/engine.R
@@ -148,7 +148,8 @@ eng_interpreted = function(options) {
 
   # FIXME: for these engines, the correct order is options + code + file
   code = if (engine %in% c('awk', 'gawk', 'sed', 'sas'))
-    paste(code, options$engine.opts) else paste(options$engine.opts, code)
+    paste(code, get_engine_opts(options$engine.opts, engine)) else
+      paste(get_engine_opts(options$engine.opts, engine), code)
   cmd = get_engine_path(options$engine.path, engine)
   out = if (options$eval) {
     message('running: ', cmd, ' ', code)
@@ -172,6 +173,11 @@ eng_interpreted = function(options) {
 get_engine_path = function(path, engine) {
   if (is.list(path)) path = path[[engine]]
   path %n% engine
+}
+
+get_engine_opts = function(opts, engine) {
+  if (is.list(opts)) opts = opts[[engine]]
+  opts %n% ""
 }
 
 ## C and Fortran (via R CMD SHLIB)

--- a/R/engine.R
+++ b/R/engine.R
@@ -150,7 +150,7 @@ eng_interpreted = function(options) {
   # FIXME: for these engines, the correct order is options + code + file
   code = if (engine %in% c('awk', 'gawk', 'sed', 'sas'))
     paste(code, opts) else paste(opts, code)
-  cmd = get_engine_opts(options$engine.path, engine, engine)
+  cmd = get_engine_path(options$engine.path, engine)
   out = if (options$eval) {
     message('running: ', cmd, ' ', code)
     tryCatch(
@@ -175,6 +175,8 @@ get_engine_opts = function(opts, engine, fallback = '') {
   if (is.list(opts)) opts = opts[[engine]]
   opts %n% fallback
 }
+
+get_engine_path = function(path, engine) get_engine_opts(path, engine, engine)
 
 ## C and Fortran (via R CMD SHLIB)
 eng_shlib = function(options) {

--- a/R/engine.R
+++ b/R/engine.R
@@ -146,11 +146,11 @@ eng_interpreted = function(options) {
     python = '-c', ruby = '-e', scala = '-e', sh = '-c', zsh = '-c', NULL
   ), shQuote(paste(options$code, collapse = '\n')))
 
+  opts = get_engine_opts(options$engine.opts, engine)
   # FIXME: for these engines, the correct order is options + code + file
   code = if (engine %in% c('awk', 'gawk', 'sed', 'sas'))
-    paste(code, get_engine_opts(options$engine.opts, engine)) else
-      paste(get_engine_opts(options$engine.opts, engine), code)
-  cmd = get_engine_path(options$engine.path, engine)
+    paste(code, opts) else paste(opts, code)
+  cmd = get_engine_opts(options$engine.path, engine, engine)
   out = if (options$eval) {
     message('running: ', cmd, ' ', code)
     tryCatch(
@@ -169,15 +169,11 @@ eng_interpreted = function(options) {
   engine_output(options, options$code, out)
 }
 
-# options$engine.path can be list(name1 = path1, name2 = path2, ...)
-get_engine_path = function(path, engine) {
-  if (is.list(path)) path = path[[engine]]
-  path %n% engine
-}
-
-get_engine_opts = function(opts, engine) {
+# options$engine.path can be list(name1 = path1, name2 = path2, ...); similarly,
+# options$engine.opts can be list(name1 = opts1, ...)
+get_engine_opts = function(opts, engine, fallback = '') {
   if (is.list(opts)) opts = opts[[engine]]
-  opts %n% ""
+  opts %n% fallback
 }
 
 ## C and Fortran (via R CMD SHLIB)


### PR DESCRIPTION
Currently setting a per engine path is quite simple with 

```R
knitr::opts_chunk$set(engine.path = list(perl = "/opt/local/bin/perl"))
```

It would be nice to be able to do the same for `engine.opts`, for example

```R
knitr::opts_chunk$set(
  engine.opts = list(perl = "-Mstrict -Mwarnings -Mfeature=say",
                     bash = "-o errexit -o nounset")
)
```

The current behaviour results in the options being passed to each of the `eng_interpreted` implemented engines leading to errors.

    running: bash -Mstrict -Mwarnings -Mfeature=say -c "something=\$SOMETHING
    somethingelse=\"\$something + Bash\"
    echo \"'\$something' is now '\$somethingelse'\""
    Quitting from lines 62-65 (106-polyglot.Rmd) 
    Error in engine(options) : bash: -/: invalid option
    Usage:	bash [GNU long option] [option] ...
    	bash [GNU long option] [option] script-file ...

This resolves this issue, by using the same style that discerns `engine.path` for these `engine`s.