### PR TITLE
Ensure data is a data.frame that contains more than 0 columns in eng_sql

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -493,7 +493,7 @@ is_sql_update_query = function(query) {
   query = gsub('^\\s*--.*\n', '', query)
   # remove multi-line comments
   if (grepl('^\\s*\\/\\*.*', query)) query = gsub('.*\\*\\/', '', query)
-  grepl('^\\s*(INSERT|UPDATE|DELETE|CREATE).*', query, ignore.case = TRUE)
+  grepl('^\\s*(INSERT|UPDATE|DELETE|CREATE|DROP).*', query, ignore.case = TRUE)
 }
 
 # sql engine

--- a/R/engine.R
+++ b/R/engine.R
@@ -561,7 +561,7 @@ eng_sql = function(options) {
   }
 
   # create output if needed (we have data and we aren't assigning it to a variable)
-  output = if (length(dim(data)) == 2 && is.null(varname)) capture.output({
+  output = if (length(dim(data)) == 2 && ncol(data) > 0 && is.null(varname)) capture.output({
 
     # apply max.print to data
     display_data = if (max.print == -1) data else head(data, n = max.print)


### PR DESCRIPTION
Currently, Travis is failing because `is_sql_update_query()` fails to handle DROP statements;
when `dbFetch()` is used for a SQL that returns no result set, `data` is 0-column data.frame,
so this line raises an error:

https://github.com/yihui/knitr/blob/3d4cacfc9b80fa3c42f792d687f66c29bda05e54/R/engine.R#L582

We can fix this paticular issue easily by adding `DROP` to the regex in `is_sql_update_query()`.
But, considering there are many SQL-variants, it's impossible to detect update queries perfectly,
so we need to make the code more robust to handle 0-column data.frames.

I think there are two possible fixes:

1. Re-add the check of `ncol(data) > 0` to reject 0-column data.frames.
2. Modify the code in `capture.output()` to accept 0-column data.frames.

I feel 1. is safer.