### PR TITLE
kable -- added a `label` argument that allows specifying a LaTeX refe…

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -16,19 +16,19 @@
 #' @param digits Maximum number of digits for numeric columns, passed to
 #'   \code{round()}. This can also be a vector of length \code{ncol(x)}, to set
 #'   the number of digits for individual columns.
-#' @param row.names Logical: whether to include row names. By
-#'   default, row names are included if \code{rownames(x)} is neither
-#'   \code{NULL} nor identical to \code{1:nrow(x)}.
+#' @param row.names Logical: whether to include row names. By default, row names
+#'   are included if \code{rownames(x)} is neither \code{NULL} nor identical to
+#'   \code{1:nrow(x)}.
 #' @param col.names A character vector of column names to be used in the table.
-#' @param align Column alignment: a character vector consisting of
-#'   \code{'l'} (left), \code{'c'} (center) and/or \code{'r'} (right). By
-#'   default or if \code{align = NULL}, numeric columns are right-aligned, and
-#'   other columns are left-aligned. If \code{length(align) == 1L}, the string will be
+#' @param align Column alignment: a character vector consisting of \code{'l'}
+#'   (left), \code{'c'} (center) and/or \code{'r'} (right). By default or if
+#'   \code{align = NULL}, numeric columns are right-aligned, and other columns
+#'   are left-aligned. If \code{length(align) == 1L}, the string will be
 #'   expanded to a vector of individual letters, e.g. \code{'clc'} becomes
-#'  \code{c('c', 'l', 'c')}, unless the output format is LaTeX.
+#'   \code{c('c', 'l', 'c')}, unless the output format is LaTeX.
 #' @param caption The table caption.
-#' @param label The table reference label. By default, the label is obtained from
-#' knitr:::opts_current. Only provide a label when using kable outside of RMarkdown.
+#' @param label The table reference label. By default, the label is obtained
+#'   from \code{knitr::\link{opts_current}$get('label')}.
 #' @param format.args A list of arguments to be passed to \code{\link{format}()}
 #'   to format table values, e.g. \code{list(big.mark = ',')}.
 #' @param escape Boolean; whether to escape special characters when producing
@@ -84,7 +84,7 @@
 #' # can also set options(knitr.table.format = 'html') so that the output is HTML
 kable = function(
   x, format, digits = getOption('digits'), row.names = NA, col.names = NA,
-  align, caption = NULL, label=NULL, format.args = list(), escape = TRUE, ...
+  align, caption = NULL, label = NULL, format.args = list(), escape = TRUE, ...
 ) {
 
   # determine the table format
@@ -106,18 +106,9 @@ kable = function(
     align = strsplit(align, '')[[1]]
 
   # create a label for bookdown if applicable
-
-  #no label from markdown, no explicit label provided
-  if(is.null(knitr::opts_current$get('label')) & is.null(label)) label = 'unlabeled'
-
-  #label from markdown, explicit labels will be ignored
-  if(!is.null(knitr::opts_current$get('label'))) label = knitr::opts_current$get('label')
-
-
-  #include label in caption
+  if (is.null(label)) label = opts_current$get('label')
   if (!is.null(caption) && !is.na(caption)) caption = paste0(
-    create_label('tab:', label, latex = (format == 'latex')),
-                 caption
+    create_label('tab:', label, latex = (format == 'latex')), caption
   )
   if (inherits(x, 'list')) {
     # if the output is for Pandoc and we want multiple tabular in one table, we

--- a/R/table.R
+++ b/R/table.R
@@ -27,6 +27,8 @@
 #'   expanded to a vector of individual letters, e.g. \code{'clc'} becomes
 #'  \code{c('c', 'l', 'c')}, unless the output format is LaTeX.
 #' @param caption The table caption.
+#' @param label The table reference label. By default, the label is obtained from
+#' knitr:::opts_current. Only provide a label when using kable outside of RMarkdown.
 #' @param format.args A list of arguments to be passed to \code{\link{format}()}
 #'   to format table values, e.g. \code{list(big.mark = ',')}.
 #' @param escape Boolean; whether to escape special characters when producing
@@ -82,7 +84,7 @@
 #' # can also set options(knitr.table.format = 'html') so that the output is HTML
 kable = function(
   x, format, digits = getOption('digits'), row.names = NA, col.names = NA,
-  align, caption = NULL, format.args = list(), escape = TRUE, ...
+  align, caption = NULL, label=NULL, format.args = list(), escape = TRUE, ...
 ) {
 
   # determine the table format
@@ -104,8 +106,17 @@ kable = function(
     align = strsplit(align, '')[[1]]
 
   # create a label for bookdown if applicable
+
+  #no label from markdown, no explicit label provided
+  if(is.null(knitr::opts_current$get('label')) & is.null(label)) label = 'unlabeled'
+
+  #label from markdown, explicit labels will be ignored
+  if(!is.null(knitr::opts_current$get('label'))) label = knitr::opts_current$get('label')
+
+
+  #include label in caption
   if (!is.null(caption) && !is.na(caption)) caption = paste0(
-    create_label('tab:', opts_current$get('label'), latex = (format == 'latex')),
+    create_label('tab:', label, latex = (format == 'latex')),
                  caption
   )
   if (inherits(x, 'list')) {

--- a/man/kable.Rd
+++ b/man/kable.Rd
@@ -20,23 +20,23 @@ can also be set in the global option \code{knitr.table.format}. If
 \code{round()}. This can also be a vector of length \code{ncol(x)}, to set
 the number of digits for individual columns.}
 
-\item{row.names}{Logical: whether to include row names. By
-default, row names are included if \code{rownames(x)} is neither
-\code{NULL} nor identical to \code{1:nrow(x)}.}
+\item{row.names}{Logical: whether to include row names. By default, row names
+are included if \code{rownames(x)} is neither \code{NULL} nor identical to
+\code{1:nrow(x)}.}
 
 \item{col.names}{A character vector of column names to be used in the table.}
 
-\item{align}{Column alignment: a character vector consisting of
- \code{'l'} (left), \code{'c'} (center) and/or \code{'r'} (right). By
- default or if \code{align = NULL}, numeric columns are right-aligned, and
- other columns are left-aligned. If \code{length(align) == 1L}, the string will be
- expanded to a vector of individual letters, e.g. \code{'clc'} becomes
+\item{align}{Column alignment: a character vector consisting of \code{'l'}
+(left), \code{'c'} (center) and/or \code{'r'} (right). By default or if
+\code{align = NULL}, numeric columns are right-aligned, and other columns
+are left-aligned. If \code{length(align) == 1L}, the string will be
+expanded to a vector of individual letters, e.g. \code{'clc'} becomes
 \code{c('c', 'l', 'c')}, unless the output format is LaTeX.}
 
 \item{caption}{The table caption.}
 
-\item{label}{The table reference label. By default, the label is obtained from
-knitr:::opts_current. Only provide a label when using kable outside of RMarkdown.}
+\item{label}{The table reference label. By default, the label is obtained
+from \code{knitr::\link{opts_current}$get('label')}.}
 
 \item{format.args}{A list of arguments to be passed to \code{\link{format}()}
 to format table values, e.g. \code{list(big.mark = ',')}.}

--- a/man/kable.Rd
+++ b/man/kable.Rd
@@ -5,7 +5,7 @@
 \title{Create tables in LaTeX, HTML, Markdown and reStructuredText}
 \usage{
 kable(x, format, digits = getOption("digits"), row.names = NA, col.names = NA, align, 
-    caption = NULL, format.args = list(), escape = TRUE, ...)
+    caption = NULL, label = NULL, format.args = list(), escape = TRUE, ...)
 }
 \arguments{
 \item{x}{An R object, typically a matrix or data frame.}
@@ -34,6 +34,9 @@ default, row names are included if \code{rownames(x)} is neither
 \code{c('c', 'l', 'c')}, unless the output format is LaTeX.}
 
 \item{caption}{The table caption.}
+
+\item{label}{The table reference label. By default, the label is obtained from
+knitr:::opts_current. Only provide a label when using kable outside of RMarkdown.}
 
 \item{format.args}{A list of arguments to be passed to \code{\link{format}()}
 to format table values, e.g. \code{list(big.mark = ',')}.}


### PR DESCRIPTION
`kable` -- added a label argument that allows specifying a tex reference label for standalone use. Argument is ignored if used within RMarkdown.