### PR TITLE
Is it possible to use evaluate::evaluate for inline blocks?

### DIFF
--- a/R/hooks.R
+++ b/R/hooks.R
@@ -11,7 +11,7 @@
   message = .out.hook, error = .out.hook, plot = .plot.hook,
   inline = .inline.hook, chunk = .out.hook, text = identity,
   evaluate.inline = function(code, envir = knit_global()) {
-    v = withVisible(eval(parse_only(code), envir = envir))
+    v = withVisible(evaluate::evaluate(parse_only(code), envir = envir))
     if (v$visible) knit_print(v$value, inline = TRUE, options = opts_chunk$get())
   },
   evaluate = function(...) evaluate::evaluate(...), document = identity


### PR DESCRIPTION
Is there a reason why this is `eval` instead of `evaluate::evaluate`? I ask because the current implementation means that inline blocks do not respect the `error=TRUE` chunk option. That is, if `knitr::opts_chunk$set(error=T)` is set, then one would expect that errors in R code will not stop rendering. In fact this works for inline blocks:

<pre>
```{r}
knitr::opts_chunk$set(error=T)
stop('Expect: This error does not stop execution')
```
</pre>
The above code will not stop execution. However, an inline block like this will stop execution:

<pre>
```{r}
knitr::opts_chunk$set(error=T)
```

`r stop('Expect: This error does not stop execution')`
</pre>