### PR TITLE
support folding of rendering output when on Travis 

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -264,7 +264,7 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
   progress = opts_knit$get('progress')
   if (on_travis()) {
     cat(sprintf('travis_fold:start:%s\r', input))
-    cat("processing file: %s", input)
+    cat(sprintf("processing file: %s\r", input))
   }
   if (in.file && !quiet) message(ifelse(progress, '\n\n', ''), 'processing file: ', input)
   res = process_file(text, output)

--- a/R/output.R
+++ b/R/output.R
@@ -279,8 +279,8 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
     concord_gen(input, output)
     if (!quiet) message('output file: ', output, ifelse(progress, '\n', ''))
   }
-  output %n% res
   travis_fold("end", input)
+  output %n% res
 }
 #' @rdname knit
 #' @param documentation An integer specifying the level of documentation to add to

--- a/R/output.R
+++ b/R/output.R
@@ -279,8 +279,8 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
     concord_gen(input, output)
     if (!quiet) message('output file: ', output, ifelse(progress, '\n', ''))
   }
-  travis_fold("end", input)
   output %n% res
+  travis_fold("end", input)
 }
 #' @rdname knit
 #' @param documentation An integer specifying the level of documentation to add to

--- a/R/output.R
+++ b/R/output.R
@@ -262,10 +262,7 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
   }
 
   progress = opts_knit$get('progress')
-  if (on_travis()) {
-    cat(sprintf('travis_fold:start:%s\r', input))
-    cat(sprintf("processing file: %s\r", input))
-  }
+  travis_fold("start", input, sprintf("processing file: %s\r", input))
   if (in.file && !quiet) message(ifelse(progress, '\n\n', ''), 'processing file: ', input)
   res = process_file(text, output)
   res = paste(knit_hooks$get('document')(res), collapse = '\n')
@@ -282,9 +279,7 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
     concord_gen(input, output)
     if (!quiet) message('output file: ', output, ifelse(progress, '\n', ''))
   }
-  if (on_travis()) {
-    cat(sprintf('travis_fold:end:%s\r', input))
-  }
+  travis_fold("end", input)
   output %n% res
 }
 #' @rdname knit

--- a/R/output.R
+++ b/R/output.R
@@ -262,7 +262,7 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
   }
 
   progress = opts_knit$get('progress')
-  travis_fold("start", input, sprintf("processing file: %s\r", input))
+  travis_fold("start", input, sprintf("processing file: %s", input))
   if (in.file && !quiet) message(ifelse(progress, '\n\n', ''), 'processing file: ', input)
   res = process_file(text, output)
   res = paste(knit_hooks$get('document')(res), collapse = '\n')

--- a/R/output.R
+++ b/R/output.R
@@ -262,6 +262,10 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
   }
 
   progress = opts_knit$get('progress')
+  if (on_travis()) {
+    cat(sprintf('travis_fold:start:%s\r', input))
+    cat("processing file: %s", input)
+  }
   if (in.file && !quiet) message(ifelse(progress, '\n\n', ''), 'processing file: ', input)
   res = process_file(text, output)
   res = paste(knit_hooks$get('document')(res), collapse = '\n')
@@ -278,7 +282,9 @@ knit = function(input, output = NULL, tangle = FALSE, text = NULL, quiet = FALSE
     concord_gen(input, output)
     if (!quiet) message('output file: ', output, ifelse(progress, '\n', ''))
   }
-
+  if (on_travis()) {
+    cat(sprintf('travis_fold:end:%s\r', input))
+  }
   output %n% res
 }
 #' @rdname knit

--- a/R/utils.R
+++ b/R/utils.R
@@ -964,3 +964,7 @@ digest3 = function(x) {
   close(s)
   unname(tools::md5sum(f))
 }
+
+on_travis <- function() {
+  Sys.getenv('TRAVIS') == 'true'
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -965,6 +965,12 @@ digest3 = function(x) {
   unname(tools::md5sum(f))
 }
 
-on_travis <- function() {
-  Sys.getenv('TRAVIS') == 'true'
+# if document is knit on travis, add the folding tags.
+# from functions in https://github.com/yihui/crandalf
+travis_fold <- function(type = c("start", "end"), job, msg = NULL) {
+  type = match.arg(type)
+  if (Sys.getenv('TRAVIS') == 'true') {
+    cat(sprintf('travis_fold:%s:%s\r', type, job))
+    if (!is.null(msg)) cat(msg, '\n')
+  }
 }


### PR DESCRIPTION
This is a proposition to implement folding to close #1654 

The travis folding feature is not very well documented but I found the crandalf 📦 that implement it so it helped a lot reproduce it. 

Instead of taking the code as is, it just use the part that put the folding part, only if on TRAVIS (`Sys.getenv("TRAVIS") == 'true'`)

Also, crandalf implemented the timer feature to time each folding part. I did not reuse that part, put could be if interested.

This is working (see [example](https://travis-ci.com/cderv/adv-r/jobs/171850729)), however it is really slow to render in the page. Not sure adding timing will be a good idea.

Don't know if something could be done.

Still WIP but you may have thoughts on this one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yihui/knitr/1661)
<!-- Reviewable:end -->
