### PR TITLE
Implement sass / scss engines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Authors@R: c(
     person("Doug", "Hemken", role = "ctb"),
     person("Duncan", "Murdoch", role = "ctb"),
     person("Elio", "Campitelli", role = "ctb"),
+    person("Emily", "Riederer", role = "ctb"),
     person("Fabian", "Hirschmann", role = "ctb"),
     person("Fitch", "Simeon", role = "ctb"),
     person("Forest", "Fang", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.21.7
+Version: 1.21.8
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Adam", "Vogt", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN knitr VERSION 1.22
 
+## NEW FEATURES 
+
+- Added a new engine `sass`/`scss` to convert Sass/SCSS to CSS using either the `sass` [R package](https://github.com/rstudio/sass) (LibSass) or a Dart Sass [executable](https://sass-lang.com/install) (when R package not found or chunk option `sass.package = FALSE`). After conversion, resulting CSS is treated as in the CSS engine (#1666).
+
 ## BUG FIXES
 
 - The output path should be quoted in `pandoc()` (thanks, @antoine-sachet, #1644).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES 
 
-- Added a new engine `sass`/`scss` to convert Sass/SCSS to CSS using either the `sass` [R package](https://github.com/rstudio/sass) (LibSass) or a Dart Sass [executable](https://sass-lang.com/install) (when R package not found or chunk option `sass.package = FALSE`). After conversion, resulting CSS is treated as in the CSS engine (#1666).
+- Added a new engine `sass`/`scss` to convert Sass/SCSS to CSS using either the `sass` [R package](https://github.com/rstudio/sass) (LibSass) or Dart Sass [executable](https://sass-lang.com/install) (when R package not found, engine option `package = FALSE`, or `engine.path` to executable is provided). After conversion, resulting CSS is treated as in the CSS engine (#1666).
 
 ## BUG FIXES
 

--- a/R/engine.R
+++ b/R/engine.R
@@ -659,10 +659,18 @@ eng_go = function(options) {
 }
 
 # SASS / SCSS engine
-## converts SASS / SCSS -> CSS (with same treatments as CSS engine) using either:
-## LibSass sass R package (https://github.com/rstudio/sass) if installed and not sass.package = FALSE, or
-## dart-sass standalone executable (https://sass-lang.com/install)
-## CSS output is compressed by default. Pass "expanded" to engine.opts for more readable output.
+#
+# Converts SASS / SCSS -> CSS (with same treatments as CSS engine) using either:
+# LibSass sass R package (https://github.com/rstudio/sass) when
+#   + the package is installed
+#   + engine.opts does not set package = FALSE (e.g. engine.opts = list(package = FALSE))
+#   + an explicit path to the executable is not provided through engine.path, or
+# dart-sass standalone executable (https://sass-lang.com/install) otherwise
+#
+# CSS output is compressed by default but formatting can be set through style in engine.opts
+#  For the sass R package, valid styles are "compressed","expanded", "nested", and "compact"
+#  For the executable, valid styles are "compressed" and "expanded"
+#  Please refer to respective package / executable documentation for more details
 eng_sxss = function(options) {
 
   # early exit if evaluated output not requested

--- a/R/engine.R
+++ b/R/engine.R
@@ -669,9 +669,9 @@ eng_sxss = function(options) {
   }
 
   # create temporary file with input code
-  f = tempfile( pattern = 'code', tmpdir = '.', fileext = paste0(".",options$engine) )
-  writeLines( options$code , f )
-  on.exit( unlink(f), add = TRUE )
+  f = tempfile(pattern = 'code', tmpdir = '.', fileext = paste0(".",options$engine))
+  writeLines(options$code , f)
+  on.exit(unlink(f), add = TRUE)
 
   # convert sass/sxss -> css
   if( loadable("sass") & !isFALSE(options$r.sass) ){
@@ -680,16 +680,16 @@ eng_sxss = function(options) {
       sass::sass( sass::sass_file(f) ),
       error = function(e) {
        if (!options$error) stop(e)
-       message( paste('Error in converting to CSS using sass R package:', e, sep = "\n") )
+       message(paste('Error in converting to CSS using sass R package:', e, sep = "\n"))
       }
     )
   }
   else{
     cmd = get_engine_path(options$engine.path, options$engine)
     out = tryCatch(
-      paste( system2( command = cmd, args = f, stdout = TRUE) , collapse = "\n"),
+      paste(system2(command = cmd, args = f, stdout = TRUE), collapse = "\n"),
       error = function(e) {
-        if(!openions$error) stop(e)
+        if(!options$error) stop(e)
         message( paste('Error in converting to CSS using executable:', e, sep = "\n") )
       }
     )

--- a/R/engine.R
+++ b/R/engine.R
@@ -660,7 +660,7 @@ eng_go = function(options) {
 
 # SASS / SCSS engine
 ## converts SASS / SCSS -> CSS (with same treatments as CSS engine) using either:
-## LibSass sass R package (https://github.com/rstudio/sass) if installed, or
+## LibSass sass R package (https://github.com/rstudio/sass) if installed and not sass.package = FALSE, or
 ## dart-sass standalone executable (https://sass-lang.com/install)
 eng_sxss = function(options) {
 
@@ -674,8 +674,8 @@ eng_sxss = function(options) {
   on.exit(unlink(f), add = TRUE)
 
   # convert sass/sxss -> css
-  if( loadable("sass") & !isFALSE(options$r.sass) ){
-    message("Converting sass with R package. For executable, set chunk option r.sass = FALSE")
+  if( loadable("sass") & !isFALSE(options$sass.package) ){
+    message("Converting sass with R package. For executable, set chunk option sass.package = FALSE")
     out = tryCatch(
       sass::sass( sass::sass_file(f) ),
       error = function(e) {
@@ -690,7 +690,7 @@ eng_sxss = function(options) {
       paste(system2(command = cmd, args = f, stdout = TRUE), collapse = "\n"),
       error = function(e) {
         if(!options$error) stop(e)
-        message( paste('Error in converting to CSS using executable:', e, sep = "\n") )
+        message(paste('Error in converting to CSS using executable:', e, sep = "\n"))
       }
     )
   }

--- a/R/engine.R
+++ b/R/engine.R
@@ -664,12 +664,12 @@ eng_go = function(options) {
 ## dart-sass standalone executable (https://sass-lang.com/install)
 eng_sxss = function(options) {
 
-  if (!options$eval) {
-    return(engine_output(options, options$code, ''))
-  }
+  # early exit if evaluated output not requested
+  options$results = 'asis'
+  if (!options$eval) return(engine_output(options, options$code, ''))
 
   # create temporary file with input code
-  f = tempfile(pattern = 'code', tmpdir = '.', fileext = paste0(".",options$engine))
+  f = tempfile(pattern = 'code', tmpdir = '.', fileext = paste0(".", options$engine))
   writeLines(options$code , f)
   on.exit(unlink(f), add = TRUE)
 

--- a/R/engine.R
+++ b/R/engine.R
@@ -682,19 +682,25 @@ eng_sxss = function(options) {
     # add sass to Suggests
     sass = get("sass", asNamespace("sass"))
     sass_file = get("sass_file", asNamespace("sass"))
+    sass_options = get("sass_options", asNamespace("sass"))
+
+    style = if(isFALSE(options$sass.compressed)) "expanded" else "compressed"
 
     out = tryCatch(
-      sass( sass_file(f) ),
+      sass(sass_file(f), options = sass_options(output_style = style)),
       error = function(e) {
-       if (!options$error) stop(e)
-       message(paste('Error in converting to CSS using sass R package:', e, sep = "\n"))
+        if (!options$error) stop(e)
+        message(paste('Error in converting to CSS using sass R package:', e, sep = "\n") )
       }
     )
   }
   else{
-    cmd = get_engine_path(options$engine.path, options$engine)
+    message("Converting sass with executable.")
+    cmd = get_engine_path(options$engine.path, "sass")
+    style = if(isFALSE(options$sass.compressed)) "" else "--style=compressed"
+
     out = tryCatch(
-      paste(system2( command = cmd, args = f, stdout = TRUE) , collapse = "\n"),
+      paste(system2( command = cmd, args = c(f, style), stdout = TRUE) , collapse = "\n"),
       warning = function(w) {
         if(!options$error && !is.null(xfun::attr(w, "status"))) stop(paste(w, collapse = "\n"))
         message(paste('Error in converting to CSS using executable:', w, sep = "\n"))

--- a/R/engine.R
+++ b/R/engine.R
@@ -674,10 +674,17 @@ eng_sxss = function(options) {
   on.exit(unlink(f), add = TRUE)
 
   # convert sass/sxss -> css
-  if( loadable("sass") & !isFALSE(options$sass.package) ){
+  if(loadable("sass") && !isFALSE(options$sass.package)){
     message("Converting sass with R package. For executable, set chunk option sass.package = FALSE")
+
+    # TODO: after sass R package (https://github.com/rstudio/sass) is released on CRAN
+    # delete calls to get and replace sass, sass_file, sass_options with sass::function_name()
+    # add sass to Suggests
+    sass = get("sass", asNamespace("sass"))
+    sass_file = get("sass_file", asNamespace("sass"))
+
     out = tryCatch(
-      sass::sass( sass::sass_file(f) ),
+      sass( sass_file(f) ),
       error = function(e) {
        if (!options$error) stop(e)
        message(paste('Error in converting to CSS using sass R package:', e, sep = "\n"))

--- a/R/engine.R
+++ b/R/engine.R
@@ -689,7 +689,7 @@ eng_sxss = function(options) {
 
   # validate provided engine options
   if (!is.logical(package)) {
-    if (!options$error) stop(paste("package option must be either TRUE or FALSE"))
+    if (!options$error) stop2(paste("package option must be either TRUE or FALSE"))
     package = TRUE
     warning2("package option must be either TRUE or FALSE. Defaulting to TRUE.")
   }
@@ -702,7 +702,7 @@ eng_sxss = function(options) {
   }
   if (!style %in% valid_styles) {
     if (!options$error) {
-      stop(paste("style must be one of:",
+      stop2(paste("style must be one of:",
                  paste(valid_styles, collapse = ", "), sep = "\n"))
     } else {
       style = "compressed"
@@ -741,7 +741,7 @@ eng_sxss = function(options) {
     out = tryCatch(
       system2(command = cmd, args = c(f, style), stdout = TRUE, stderr = TRUE),
       error = function(e) {
-        if (!options$error) stop(e)
+        if (!options$error) stop2(e)
         warning2(paste('Error in converting to CSS using executable:', e, sep = "\n"))
         return(NULL)
       }
@@ -749,7 +749,7 @@ eng_sxss = function(options) {
 
     # handle execution errors (status codes) or otherwise reformat valid output
     if (!is.null(attr(out, 'status'))) {
-      if (!options$error) stop(paste(out, collapse = '\n'))
+      if (!options$error) stop2(paste(out, collapse = '\n'))
       out = NULL
     } else if (!is.null(out)) {
       out = paste(out, collapse = "\n")
@@ -758,7 +758,7 @@ eng_sxss = function(options) {
 
   # wrap final output for correct rendering
   final_out = if (!is.null(out) && is_html_output(excludes = 'markdown')) {
-    out_tagged = paste(c('<style type="text/css">', out, '</style>'), collapse = "\n")
+    paste(c('<style type="text/css">', out, '</style>'), collapse = "\n")
   } else {
     ""
   }

--- a/R/engine.R
+++ b/R/engine.R
@@ -687,21 +687,25 @@ eng_sxss = function(options) {
   else{
     cmd = get_engine_path(options$engine.path, options$engine)
     out = tryCatch(
-      paste(system2(command = cmd, args = f, stdout = TRUE), collapse = "\n"),
+      paste(system2( command = cmd, args = f, stdout = TRUE) , collapse = "\n"),
+      warning = function(w) {
+        if(!options$error && !is.null(xfun::attr(w, "status"))) stop(paste(w, collapse = "\n"))
+        message(paste('Error in converting to CSS using executable:', w, sep = "\n"))
+      },
       error = function(e) {
-        if(!options$error) stop(e)
+        if(!options$error) stop(paste(e, collapse = "\n"))
         message(paste('Error in converting to CSS using executable:', e, sep = "\n"))
       }
     )
   }
 
   # wrap final output for correct rendering
-  final_out = if (options$eval && is_html_output(excludes = 'markdown')) {
-    out_tagged = c('<style type="text/css">', out, '</style>')
-    paste(out_tagged, collapse = '\n')
-  }
+  final_out =
+    if (!is.null(out) && is_html_output(excludes = 'markdown')) {
+      out_tagged = paste(c('<style type="text/css">', out, '</style>'), collapse = "\n")
+    }
+  else ""
 
-  options$results = 'asis'
   engine_output(options, options$code, final_out)
 
 }

--- a/R/engine.R
+++ b/R/engine.R
@@ -688,28 +688,31 @@ eng_sxss = function(options) {
   cmd = get_engine_path(options$engine.path, "sass")
 
   # validate provided engine options
-  if(!is.logical(package)) {
-    if(!options$error) stop(paste("package option must be either TRUE or FALSE"))
+  if (!is.logical(package)) {
+    if (!options$error) stop(paste("package option must be either TRUE or FALSE"))
     package = TRUE
     warning2("package option must be either TRUE or FALSE. Defaulting to TRUE.")
   }
   use_package = loadable("sass") && package && cmd == "sass"
 
-  valid_styles =
-    if(use_package) c("compressed", "expanded", "compact", "nested")
-    else c("compressed", "expanded")
-  if(!style %in% valid_styles)
-    if(!options$error) stop(paste("style must be one of:",
-                                  paste(valid_styles, collapse = ", "), sep = "\n"))
-  else {
-    style = "compressed"
-    warning2(paste("style must be one of:",
-                  paste(valid_styles, collapse = ", "),
-                  "Defaulting to 'compressed'.", sep = "\n"))
+  valid_styles = if (use_package) {
+    c("compressed", "expanded", "compact", "nested")
+  } else {
+    c("compressed", "expanded")
   }
-
+  if (!style %in% valid_styles) {
+    if (!options$error) {
+      stop(paste("style must be one of:",
+                 paste(valid_styles, collapse = ", "), sep = "\n"))
+    } else {
+      style = "compressed"
+      warning2(paste("style must be one of:",
+                     paste(valid_styles, collapse = ", "),
+                     "Defaulting to 'compressed'.", sep = "\n"))
+    }
+  }
   # convert sass/sxss -> css
-  if(use_package){
+  if (use_package) {
     message("Converting sass with R package. For executable, set package = FALSE in engine.opts or set explicit engine.path")
 
     # TODO: after sass R package (https://github.com/rstudio/sass) is released on CRAN
@@ -729,9 +732,8 @@ eng_sxss = function(options) {
     )
 
     # remove final newline chars from output
-    if(!is.null(out)) out = sub("\\n$", "", out)
-  }
-  else{
+    if (!is.null(out)) out = sub("\\n$", "", out)
+  } else {
     message("Converting sass with executable.")
     style = paste0("--style=", style)
 
@@ -739,7 +741,7 @@ eng_sxss = function(options) {
     out = tryCatch(
       system2(command = cmd, args = c(f, style), stdout = TRUE, stderr = TRUE),
       error = function(e) {
-        if(!options$error) stop(e)
+        if (!options$error) stop(e)
         warning2(paste('Error in converting to CSS using executable:', e, sep = "\n"))
         return(NULL)
       }
@@ -747,18 +749,19 @@ eng_sxss = function(options) {
 
     # handle execution errors (status codes) or otherwise reformat valid output
     if (!is.null(attr(out, 'status'))) {
-      if(!options$error) stop(paste(out, collapse = '\n'))
+      if (!options$error) stop(paste(out, collapse = '\n'))
       out = NULL
-      }
-    else if(!is.null(out)) out = paste(out, collapse = "\n")
+    } else if (!is.null(out)) {
+      out = paste(out, collapse = "\n")
+    }
   }
 
   # wrap final output for correct rendering
-  final_out =
-    if (!is.null(out) && is_html_output(excludes = 'markdown')) {
-      out_tagged = paste(c('<style type="text/css">', out, '</style>'), collapse = "\n")
-    }
-  else ""
+  final_out = if (!is.null(out) && is_html_output(excludes = 'markdown')) {
+    out_tagged = paste(c('<style type="text/css">', out, '</style>'), collapse = "\n")
+  } else {
+    ""
+  }
 
   engine_output(options, options$code, final_out)
 


### PR DESCRIPTION
This PR closes #1665 and adds Sass / SCSS language engines.

When available and not specifically declined by the user (via an `r.sass = FALSE` chunk option), conversion is handled by LibSass via the `sass` R package. Otherwise, conversion is done by the standalone DartSass executable found either via PATH or provided via the `engine.path` option.

Following conversion, output is handled the same as in the `css` language engine.