### PR TITLE
make stitch template work without knitr being attached

### DIFF
--- a/inst/misc/knitr-template.Rnw
+++ b/inst/misc/knitr-template.Rnw
@@ -27,7 +27,7 @@
 
 <<setup,include=FALSE,cache=FALSE>>=
 options(width=90)
-opts_chunk$set(out.width = '.6\\linewidth')
+knitr::opts_chunk$set(out.width = '.6\\linewidth')
 .knitr.title = if (exists('.knitr.title')) paste('\\title{', .knitr.title, '}', sep = '') else ''
 .knitr.author = if (nzchar(.knitr.title) && exists('.knitr.author')) {
   paste('\\author{', .knitr.author, '%\n',


### PR DESCRIPTION
The default Rnw template assumes **knitr** to be attached on the search path.
This trivial PR resolves this drawback and thus enables stitching via
```bash
R -e "knitr::stitch('script.R')" 
```
The other default templates (for `stitch_rmd()` and `stitch_rhtml()`) already allow for such usage.