### PR TITLE
Make kable(format = "pandoc") fall back to markdown format when data has 0 row

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,3 @@
-# CHANGES IN knitr VERSION 1.23 (unreleased)
-
-## BUG FIXES
-
-- `kable()` now generates a table even when the data has 0 rows (thanks, @yutannihilation, #1677).
-
 # CHANGES IN knitr VERSION 1.22
 
 ## NEW FEATURES 
@@ -25,6 +19,8 @@
 - The chunk option `fig.show='hide'` doesn't work for `knitr::include_graphics()` (thanks, @vincentarelbundock, #1675).
 
 - The `tikz` engine doesn't work on Windows (thanks, Andry, https://stackoverflow.com/q/54839403/559676).
+
+- `kable()` now generates a table for R Markdown documents even when the data has 0 rows (thanks, @yutannihilation, #1677).
 
 ## MAJOR CHANGES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# CHANGES IN knitr VERSION 1.23 (unreleased)
+
+## BUG FIXES
+
+- `kable()` now generates a table even when the data has 0 rows (thanks, @yutannihilation, #1677).
+
 # CHANGES IN knitr VERSION 1.22
 
 ## NEW FEATURES 

--- a/R/table.R
+++ b/R/table.R
@@ -365,7 +365,8 @@ kable_markdown = function(x, padding = 1, ...) {
 }
 
 kable_pandoc = function(x, caption = NULL, padding = 1, ...) {
-  tab = if (ncol(x) == 1) kable_markdown(
+  # pandoc's table format cannot create 1-column or 0-row tables
+  tab = if (ncol(x) == 1 || nrow(x) == 0) kable_markdown(
     x, padding = padding, ...
   ) else kable_mark(
     x, c(NA, '-', if (is_blank(colnames(x))) '-' else NA),

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -157,6 +157,11 @@ assert(
   identical(kable2(x2, 'markdown'), c('|a  |', '|:--|'))
 )
 
+assert(
+  'kable(, "pandoc") works for a 0 row 1 column matrix',
+  identical(kable2(x2, 'pandoc'), c('|a  |', '|:--|'))
+)
+
 assert('kable(, "pandoc", caption = "Table Caption") works for a 1-column matrix', {
   x4 = matrix(1:2, ncol = 1, dimnames = list(NULL, 'a'))
   kable2(x4, 'pandoc', caption = 'Table Caption') %==%

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -158,8 +158,11 @@ assert(
 )
 
 assert(
-  'kable(, "pandoc") works for a 0 row 1 column matrix',
-  identical(kable2(x2, 'pandoc'), c('|a  |', '|:--|'))
+  'kable(, "pandoc") works for a 0 row data.frame',
+  identical(
+    kable2(data.frame(x = character(0), y = integer(0)), 'pandoc'),
+    c('|x  |  y|', '|:--|--:|')
+  )
 )
 
 assert('kable(, "pandoc", caption = "Table Caption") works for a 1-column matrix', {


### PR DESCRIPTION
Fix #1677