### PR TITLE
Fix Stata engine output

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -93,7 +93,7 @@ engine_output = function(options, code, out, extra = NULL) {
     options$engine
   )
   if (options$engine == 'stata') {
-    out = gsub('\n\nrunning.*profile.do', '', out)
+    out = gsub('\nrunning.*profile.do', '', out)
     out = sub('...\n\n\n', '', out)
     out = sub('\n. \nend of do-file\n', '', out)
   }

--- a/R/engine.R
+++ b/R/engine.R
@@ -93,8 +93,8 @@ engine_output = function(options, code, out, extra = NULL) {
     options$engine
   )
   if (options$engine == 'stata') {
-    out = gsub('\nrunning.*profile.do', '', out)
-    out = sub('...\n\n\n', '', out)
+    out = gsub('\n+running.*profile.do', '', out)
+    out = sub('...\n+', '', out)
     out = sub('\n. \nend of do-file\n', '', out)
   }
   paste(c(


### PR DESCRIPTION
 Accomodate difference between linux and Windows log files.  It turns out there is one tiny difference between Stata log files on linux versus Windows:  the number of blank lines before the "running ..." note!  This modification gives priority to linux, making it easier to work across platforms.