### PR TITLE
added "rmarkdown" engine to process code blocks

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -392,6 +392,12 @@ eng_asis = function(options) {
   if (options$echo && options$eval) one_string(options$code)
 }
 
+## output the code, processing as though it's a markdown block
+eng_rmarkdown = function(options) {
+  if (options$echo && options$eval)
+    one_string(knit(text = options$code, envir = knit_global()))
+}
+
 # write a block environment according to the output format
 eng_block = function(options) {
   if (isFALSE(options$echo)) return()
@@ -745,9 +751,10 @@ local({
 knit_engines$set(
   highlight = eng_highlight, Rcpp = eng_Rcpp, tikz = eng_tikz, dot = eng_dot,
   c = eng_shlib, fortran = eng_shlib, fortran95 = eng_shlib, asy = eng_dot,
-  cat = eng_cat, asis = eng_asis, stan = eng_stan, block = eng_block,
-  block2 = eng_block2, js = eng_js, css = eng_css, sql = eng_sql, go = eng_go,
-  python = eng_python, julia = eng_julia, sass = eng_sxss, scss = eng_sxss
+  cat = eng_cat, asis = eng_asis, rmarkdown = eng_rmarkdown, stan = eng_stan,
+  block = eng_block, block2 = eng_block2, js = eng_js, css = eng_css,
+  sql = eng_sql, go = eng_go, python = eng_python, julia = eng_julia,
+  sass = eng_sxss, scss = eng_sxss
 )
 
 cache_engines$set(python = cache_eng_python)


### PR DESCRIPTION
I ran into a situation where I wanted to be able to turn on or off different pieces of commentary in the markdown throughout a document. For example, I would ideally like to set a flag to include more technical commentary for an analytic audience, but then strip them out for a general audience.  

Although the `asis` engine works in most cases, it doesn't process inline code blocks that I often use for communicating results. To address this, I added a new `rmarkdown` engine to pre-process the text using `knitr::knit`.

Here is an example document where this is useful:

`````
---
title: "test"
output: pdf_document
---

```{r, echo=FALSE}
# create a flag to easily turn on/off markdown 'code' blocks
.show_analysis_commentary <- TRUE
```

this is some general text

```{r analysis, echo = FALSE}
# derive answer to life, the universe and everything
var <- 42
```

```{rmarkdown, echo = .show_analysis_commentary}
# print out analysis result only if `.show_analysis_commentary` is `TRUE`
the answer to life, the universe and everything is `r sprintf('%.f', var)`
```

```{r}
hist(mtcars$mpg)
```
`````

---
_let me know if any tests should be added. I couldn't find any for the `asis` engine and figured this would only necessitate a similar level of testing._