### PR TITLE
Suggested improvement of LaTeX header to be compatible with scripts on the knit()ed .tex files

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -125,8 +125,8 @@ rm(list = c('.default.sty', '.knitr.sty')) # do not need them any more
 '
 
 .header.maxwidth =
-'%% maxwidth is the original width if it is less than linewidth
-%% otherwise use linewidth (to make sure the graphics do not exceed the margin)
+'% maxwidth is the original width if it is less than linewidth
+% otherwise use linewidth (to make sure the graphics do not exceed the margin)
 \\makeatletter
 \\def\\maxwidth{ %
   \\ifdim\\Gin@nat@width>\\linewidth


### PR DESCRIPTION
see Issue #1687, essentially:

--- header.R	2018-01-02 11:48:28.000000000 -0500
+++ header_new.R	2019-03-23 09:22:03.000000000 -0400
@@ -123,8 +123,8 @@
'

.header.maxwidth =
-'%% maxwidth is the original width if it is less than linewidth
-%% otherwise use linewidth (to make sure the graphics do not exceed the margin)
+'% maxwidth is the original width if it is less than linewidth
+% otherwise use linewidth (to make sure the graphics do not exceed the margin)
\makeatletter
\def\maxwidth{ %
\ifdim\Gin@nat@width>\linewidth