### PR TITLE
Enable optional features for Perl code chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 - Fixed a bug introduced when fixing #1648: `include_url()` no longer works at all unless the chunk option `out.extra` is not empty (thanks, @gabrielvazdemelo, #1691).
 
+- When evaluating perl code chunks the interpreter is spawned with the `-E` option, enabling all optional features such as `say`, rather than `-e` (thanks, @kiwiroy, #1699)
+
 ## MAJOR CHANGES
 
 - `knitr::knit()` will try to read the input file with the UTF-8 encoding first. If UTF-8 doesn't work, it will try to read with the system native encoding instead (with a warning). The `encoding` argument of `knitr::knit()` is completely ignored. In the future, only UTF-8 will be supported, and we will stop retrying with the system native encoding. The output file from `knitr::knit()` is always encoded in UTF-8.

--- a/R/engine.R
+++ b/R/engine.R
@@ -140,7 +140,7 @@ eng_interpreted = function(options) {
     )
   } else paste(switch(
     engine, bash = '-c', coffee = '-e', groovy = '-e', lein = 'exec -ep',
-    mysql = '-e', node = '-e', octave = '--eval', perl = '-e', psql = '-c',
+    mysql = '-e', node = '-e', octave = '--eval', perl = '-E', psql = '-c',
     python = '-c', ruby = '-e', scala = '-e', sh = '-c', zsh = '-c', NULL
   ), shQuote(one_string(options$code)))
 


### PR DESCRIPTION
This PR aims to enable optional [features](https://perldoc.pl/feature) when running Perl code chunks.

From [perlrun](https://perldoc.pl/perlrun#-E-commandline)

```
  -E commandline
            behaves just like -e, except that it implicitly enables all optional features (in the main compilation unit). See feature.
```

## Current behaviour

An attempt to use `say`, as in `say "Hello, World!";`, is met with the following error.

```
Error in engine(options) : 
  String found where operator expected at -e line 2, near "say "Hello, $user""
	(Do you need to predeclare say?)
syntax error at -e line 2, near "say "Hello, $user""
Execution of -e aborted due to compilation errors.
Calls: <Anonymous> ... process_group.block -> call_block -> block_exec -> in_dir -> engine
```