### PR TITLE
fix: When dev == 'svg' use 'grDevices::svg'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 
 - `spin_child()` will also assume the input file is encoded in UTF-8 (thanks, Henrik, https://stackoverflow.com/q/55395422/559676).
 
-- When the chunk option `dev = 'svg'`, `grDevices::svg()` is used to record plots, instead of the default PDF null device (thanks, @trevorld, #729)
+- When the chunk option `dev = 'svg'`, `grDevices::svg()` is used to record plots, instead of the default PDF null device (thanks, @trevorld, #729).
 
 # CHANGES IN knitr VERSION 1.22
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
 
 - `spin_child()` will also assume the input file is encoded in UTF-8 (thanks, Henrik, https://stackoverflow.com/q/55395422/559676).
 
+- When the chunk option `dev = 'svg'`, `grDevices::svg()` is used to record plots, instead of the default PDF null device (thanks, @trevorld, #729)
+
 # CHANGES IN knitr VERSION 1.22
 
 ## NEW FEATURES

--- a/R/block.R
+++ b/R/block.R
@@ -321,6 +321,10 @@ chunk_device = function(
       do.call(grDevices::cairo_pdf, c(list(
         filename = tmp, width = width, height = height
       ), get_dargs(dev.args, 'cairo_pdf')))
+    } else if (identical(dev, 'svg')) {
+      do.call(grDevices::svg, c(list(
+        filename = tmp, width = width, height = height
+      ), get_dargs(dev.args, 'svg')))
     } else if (identical(getOption('device'), pdf_null)) {
       if (!is.null(dev.args)) {
         dev.args = get_dargs(dev.args, 'pdf')


### PR DESCRIPTION
Solves #729 for the ``dev == 'svg'`` case.  In particular for a website I'm building this tweak suppresses dozens/hundreds of bogus ``knitr``  warnings like

````
Warning in grid.Call.graphics(C_text, as.graphicsAnnot(x$label), x$x, x$y,  :
  font family 'Quivira' not found in PostScript font database
````