### PR TITLE
Clean up sass dependency following sass CRAN release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -134,6 +134,7 @@ Suggests:
     DBI (>= 0.4-1),
     showtext,
     tibble,
+    sass,
     styler
 License: GPL
 URL: https://yihui.name/knitr/

--- a/R/engine.R
+++ b/R/engine.R
@@ -686,15 +686,8 @@ eng_sxss = function(options) {
   if (use_package) {
     message("Converting with the R package sass")
 
-    # TODO: after sass R package (https://github.com/rstudio/sass) is released on CRAN
-    # delete calls to get and replace sass, sass_file, sass_options with sass::function_name()
-    # add sass to Suggests
-    sass = getFromNamespace("sass", "sass")
-    sass_file = getFromNamespace("sass_file", "sass")
-    sass_options = getFromNamespace("sass_options", "sass")
-
     out = tryCatch(
-      sass(sass_file(f), options = sass_options(output_style = style)),
+      sass::sass(sass::sass_file(f), options = sass::sass_options(output_style = style)),
       error = function(e) {
         if (!options$error) stop(e)
         warning2(paste('Error in converting to CSS using sass R package:', e, sep = "\n"))


### PR DESCRIPTION
The `eng_sxss` function previously relied upon `getFromNamespace()` to depend upon the `rstudio/sass` package which had not yet been release to CRAN. I just noticed that this package is now available on CRAN. 

This PR: 

+ updates the code to reference `sass` functions with `sass::` instead
+ adds `sass` to Suggests in the `Description`