### PR TITLE
fix: Travis CI missing required header GL/gl.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
     - cargo
     - libmagick++-dev
     - libpoppler-cpp-dev
+    - libglu1-mesa-dev
 
 repos:
   XRAN: https://xran.yihui.name


### PR DESCRIPTION
This PR fixes master branch failing Travis CI with the following error message

```
configure: error: missing required header GL/gl.h
ERROR: configuration failed for package ‘rgl’
```

https://travis-ci.org/atusy/knitr/builds/553992460