### PR TITLE
Treat out.width|height as CSS when output is html

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN knitr VERSION 1.25
 
-
+- When output format is html, `out.width` and `out.height` are treated as CSS's `width` and `height` properties rather than `img` tag's `width` and `height` tags. This update enables to specify output size with any valid CSS unit (thanks, @atusy).
 
 # CHANGES IN knitr VERSION 1.24
 

--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -34,7 +34,12 @@ hook_animation = function(options) {
 }
 
 .img.attr = function(w, h, extra) {
-  paste(c(sprintf('width="%s"', w), sprintf('height="%s"', h), extra), collapse = ' ')
+  size = paste(c(sprintf('width: %s;', w), sprintf('height: %s;', h)), collapse = ' ')
+  extra = paste(extra, collapse = " ")
+  if (size == "") return(extra)
+  style = "(style * = *['\"])"
+  if (grepl(style, extra)) return(gsub(style, paste0("\\1", size), extra))
+  paste0("style='", size, "' ", extra)
 }
 
 .img.tag = function(src, w, h, caption, extra) {

--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -39,7 +39,7 @@ hook_animation = function(options) {
   if (size == "") return(extra)
   style = "(style * = *['\"])"
   if (grepl(style, extra)) return(gsub(style, paste0("\\1", size), extra))
-  paste0("style='", size, "' ", extra)
+  paste0('style="', size, '" ', extra)
 }
 
 .img.tag = function(src, w, h, caption, extra) {

--- a/tests/testit/test-hooks.R
+++ b/tests/testit/test-hooks.R
@@ -28,8 +28,8 @@ assert(
   identical(img_output('a.png'), '![](a.png)'),
   identical(img_output(c('a.png', 'b.png'), list(fig.show = 'hold')), '![](a.png)![](b.png)'),
   identical(img_output('a.png', list(fig.cap = 'foo bar')), '![foo bar](a.png)'),
-  identical(img_output('a.png', list(out.width = '50%')), '<img src="a.png" width="50%" />'),
-  identical(img_output('a.pdf', list(out.width = '300px')), '<embed src="a.pdf" width="300px" type="application/pdf" />')
+  identical(img_output('a.png', list(out.width = '50%')), '<img src="a.png" style="width: 50%;"  />'),
+  identical(img_output('a.pdf', list(out.width = '300px')), '<embed src="a.pdf" style="width: 300px;" type="application/pdf" />')
 )
 
 hook_src = knit_hooks$get("source")


### PR DESCRIPTION
This PR treats chunk options of `out.width` and `out.height` as CSS rather than `img` tag's attributes.

Thus,

````
```{r out.width="50%"}
knitr::include_graphics("foo.png")
```
````

becomes

```html
<img src="foo.png" style="width: 50%;"  />
```

rather than

```html
<img src="foo.png" width ="50%;"  />
```


This update has two benefits:

1. To support any valid CSS units including `px` and `%`
2. To fix a conflict in `rmarkdown::html_document` and its extentions. Currently, `out.height` is ignored in output because `img` tag's `height` attribute has less priority than CSS height defined as:
    
    ````css
    img {height: auto}
    ````
