### PR TITLE
Support out.width|height|extra for office outputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN knitr VERSION 1.25
 
+- Office outputs (e.g., `rmarkdown::word_document`) supports the following chunk options `out.width`, `out.height`, `out.extra`. Their behavior follows the behavior of Pandoc's `link_attributes` extention (thanks, @atusy, #1746).
+
 ## MINOR CHANGES
 
 - The returned value of `combine_words()` is wrapped in `xfun::raw_string()` for pretty printing.

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -78,6 +78,26 @@ hook_plot_md_base = function(x, options) {
   ))
 }
 
+hook_plot_md_pandoc = function(x, options) {
+  if (options$fig.show == 'animate') return(hook_plot_html(x, options))
+
+  base = opts_knit$get('base.url') %n% ''
+  cap = .img.cap(options)
+  at = sprintf(
+    "{%s}",
+    paste(
+      c(
+        sprintf("width=%s", options[['out.width']]),
+        sprintf("height=%s", options[['out.height']]),
+        sprintf("%s", options[['out.extra']])
+      ),
+      collapse = " "
+    )
+  )
+
+  sprintf('![%s](%s%s)%s', cap, base, .upload.url(x), at)
+}
+
 css_align = function(align) {
   sprintf('display: block; margin: %s;', switch(
     align, left = 'auto auto auto 0', center = 'auto', right = 'auto 0 auto auto'

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -16,10 +16,9 @@ hook_plot_md = function(x, options) {
       return(hook_plot_tex(x, options))
     }
     if (office_output) {
-      warning('Chunk options fig.align, out.width, out.height, out.extra ',
-              'are not supported for ', to, ' output')
-      options$out.width = options$out.height = options$out.extra = NULL
+      warning('Chunk options fig.align is not supported for ', to, ' output')
       options$fig.align = 'default'
+      return(hook_plot_md_pandoc(x, options))
     }
   }
   if (options$fig.show == 'hold' && office_output) {

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -90,7 +90,7 @@ hook_plot_md_pandoc = function(x, options) {
       c(
         sprintf("width=%s", options[['out.width']]),
         sprintf("height=%s", options[['out.height']]),
-        sprintf("%s", options[['out.extra']])
+        options[['out.extra']]
       ),
       collapse = " "
     )

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -16,8 +16,10 @@ hook_plot_md = function(x, options) {
       return(hook_plot_tex(x, options))
     }
     if (office_output) {
-      warning('Chunk options fig.align is not supported for ', to, ' output')
-      options$fig.align = 'default'
+      if (options$fig.align != 'default') {
+        warning('Chunk options fig.align is not supported for ', to, ' output')
+        options$fig.align = 'default'
+      }
       return(hook_plot_md_pandoc(x, options))
     }
   }


### PR DESCRIPTION
This PR implments `hook_plot_md_pandoc()` and adds support for `out.width`, `out.height`, and `out.extra` for office outputs (e.g., `rmarkdown::word_document`). It will close #1478.

Pandoc supports resizing images via `link_attributes` extention (https://www.pandoc.org/MANUAL.html#images).

For example,

```md
![](foo.png){width=300 height=300}
```

will resize "foo.png" to 300 pixels by 300 pixels.

Thus, I decided to assign `out.width` and `out.height` to `width` and `height` attributes within curly braces `{}`.

I also decided to put `out.extra` into curly braces, so that we can use it when Pandoc implements some more features via `link_attributes`.

`fig.align` is still not supported and thus is coerced to "default" with warning when specified.

## Example

### Output Docx

![image](https://user-images.githubusercontent.com/30277794/63476788-58409000-c4bd-11e9-84c0-7e7749f4c6c6.png)


### Source Rmd

````
---
output: word_document
---

```{r}
x <- knitr::include_graphics(system.file("img", "Rlogo.png", package="png"))
x
```

```{r, out.width=100, out.height=100}
x
```

```{r, out.extra="width=200 height=200"}
x
```
````