### PR TITLE
fig.process allows a function to have the options argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN knitr VERSION 1.25
 
+- The chunk option `fig.process` can be specified by a function with the `options` argument to read chunk options (thanks, @atusy, #1749).
+
 ## MINOR CHANGES
 
 - The returned value of `combine_words()` is wrapped in `xfun::raw_string()` for pretty printing.

--- a/R/plot.R
+++ b/R/plot.R
@@ -252,11 +252,8 @@ pdf_null = function(width = 7, height = 7, ...) {
 
 fig_process = function(FUN, path, options) {
   if (is.function(FUN)) {
-    path2 = if ("options" %in% names(formals(FUN))) {
-      FUN(path, options = options)
-    } else {
-      FUN(path)
-    }
+    ARG = intersect(c("options", names(options)), names(formals(FUN)))
+    path2 = do.call(FUN, c(path, c(options = list(options), options)[ARG]))
     if (!is.character(path2) || length(path2) != 1L)
       stop("'fig.process' must be a function that returns a character string")
     path = path2

--- a/R/plot.R
+++ b/R/plot.R
@@ -137,7 +137,7 @@ plot2dev = function(plot, name, dev, device, path, width, height, options) {
     path = tinytex::latexmk(path, getOption('tikzDefaultEngine'))
   }
 
-  fig_process(options$fig.process, path)
+  fig_process(options$fig.process, path, options)
 }
 
 # filter the dev.args option
@@ -250,9 +250,13 @@ pdf_null = function(width = 7, height = 7, ...) {
   grDevices::pdf(NULL, width, height, ...)
 }
 
-fig_process = function(FUN, path) {
+fig_process = function(FUN, path, options) {
   if (is.function(FUN)) {
-    path2 = FUN(path)
+    path2 = if ("options" %in% names(formals(FUN))) {
+      FUN(path, options = options)
+    } else {
+      FUN(path)
+    }
     if (!is.character(path2) || length(path2) != 1L)
       stop("'fig.process' must be a function that returns a character string")
     path = path2


### PR DESCRIPTION
By this PR, users can specify to the `fig.process` option a function with `options` argument.

For backward compatibility, the function can be without the `options` argument.

## Example

### Output

![image](https://user-images.githubusercontent.com/30277794/63638007-0a46aa80-c6be-11e9-9f93-71d606e1bbc6.png)

### Rmd

````
---
output: html_document
---

```{r setup, include=FALSE}
knitr::opts_chunk$set(fig.width = 2, fig.height = 2, dev.args = list(bg = "#cccccc"))
library(imager)
library(magrittr)
```

## Function without the `options` argument

```{r, fig.process=identity}
g <- ggplot2::qplot(c(1, 3), c(1, 5)) + ggplot2::coord_equal()
g
```

## Function with the `options` argument

`fig_crop` autocrops margin with a specified color or a color of the top-left pixel.
The color can be specified via `fig.bg` in chunk option.

```{r}
fig_crop <- function(x, options) {
  x %>%
    imager::load.image() %>%
    imager::autocrop(
      if (is.null(options$fig.bg)) imager::color.at(., 1, 1) else options$fig.bg
    ) %>%
    imager::save.image(x)
  x
}
```

Let's remove gray margin from the figure in the previous section.

```{r, fig.process=fig_crop, fig.bg='#cccccc', out.extra="style='width: auto; height: 2in;'"}
g
```
````