### PR TITLE
better support for pandoc's fenced code attributes

### DIFF
--- a/R/pattern.R
+++ b/R/pattern.R
@@ -29,7 +29,7 @@ all_patterns = list(
     inline.code = '<!--\\s*rinline(.+?)-->', header.begin = '\\s*<head>'),
 
   `md` = list(
-    chunk.begin = '^[\t >]*```+\\s*\\{([a-zA-Z0-9_]+.*)\\}\\s*$',
+    chunk.begin = '^[\t >]*```+\\s*\\{([a-zA-Z0-9_]+( *[ ,].*)?)\\}\\s*$',
     chunk.end = '^[\t >]*```+\\s*$',
     ref.chunk = '^\\s*<<(.+)>>\\s*$', inline.code = '(?<!(^|\n)``)`r[ #]([^`]+)\\s*`'),
 

--- a/tests/testit/test-patterns.R
+++ b/tests/testit/test-patterns.R
@@ -25,3 +25,19 @@ assert(
   identical(grep(ce, '@ asdf'), integer()), # only spaces/comments allowed
   identical(grep(ce, ' @ a% sdf'), integer())
 )
+
+cb_md = all_patterns$md$chunk.begin
+assert(
+  'patterns for md',
+  # Are they chunk options?
+  isTRUE(grepl(cb_md, '```{r}')),
+  isTRUE(grepl(cb_md, '```{r label}')),
+  isTRUE(grepl(cb_md, '```{r, eval=FALSE}')),
+  isTRUE(grepl(cb_md, '```{awk}')),
+  # Are they Pandoc's fenced code attributes?
+  !isTRUE(grepl(cb_md, '```{.class}')),
+  !isTRUE(grepl(cb_md, '```{#id}')),
+  !isTRUE(grepl(cb_md, '```{style="color: red"}')),
+  # Is it Pandoc's raw attribute?
+  !isTRUE(grepl(cb_md, '```{=latex}'))
+)

--- a/tests/testit/test-patterns.R
+++ b/tests/testit/test-patterns.R
@@ -12,8 +12,8 @@ assert('detect_pattern() automatically detects syntax patterns', {
 
 assert('group_pattern() checks if a pattern contains a group', {
   (group_pattern('(.*)'))
-  (group_pattern('()'))
-  (group_pattern('abc'))
+  (!group_pattern('()'))
+  (!group_pattern('abc'))
   (!group_pattern(NULL))
 })
 

--- a/tests/testit/test-patterns.R
+++ b/tests/testit/test-patterns.R
@@ -7,14 +7,14 @@ assert('detect_pattern() automatically detects syntax patterns', {
   (detect_pattern('<!--begin.rcode') %==% 'html')
   (detect_pattern('``` {r}') %==% 'md')
   (detect_pattern('asdf', 'rnw') %==% 'rnw')
-  (detect_pattern('foo') %==% NULL)
+  (is.null(detect_pattern('foo')))
 })
 
 assert('group_pattern() checks if a pattern contains a group', {
-  (group_pattern('(.*)') %==% TRUE)
-  (group_pattern('()') %==% FALSE)
-  (group_pattern('abc') %==% FALSE)
-  (group_pattern(NULL) %==% FALSE)
+  (group_pattern('(.*)'))
+  (group_pattern('()'))
+  (group_pattern('abc'))
+  (!group_pattern(NULL))
 })
 
 ce_rnw = all_patterns$rnw$chunk.end
@@ -28,15 +28,15 @@ assert('patterns for Rnw', {
 
 cb_md = all_patterns$md$chunk.begin
 assert('patterns for md', {
-  # TRUE for chunk options
-  (grepl(cb_md, '```{r}') %==% TRUE)
-  (grepl(cb_md, '```{r label}') %==% TRUE)
-  (grepl(cb_md, '```{r, eval=FALSE}') %==% TRUE)
-  (grepl(cb_md, '```{awk}') %==% TRUE)
-  # FALSE for Pandoc's fenced code attributes
-  (grepl(cb_md, '```{.class}') %==% FALSE)
-  (grepl(cb_md, '```{#id}') %==% FALSE)
-  (grepl(cb_md, '```{style="color: red"}') %==% FALSE)
-  # FALSE for Pandoc's raw attribute
-  (grepl(cb_md, '```{=latex}') %==% FALSE)
+  # Chunk options
+  (grepl(cb_md, '```{r}'))
+  (grepl(cb_md, '```{r label}'))
+  (grepl(cb_md, '```{r, eval=FALSE}'))
+  (grepl(cb_md, '```{awk}'))
+  # Pandoc's fenced code attributes
+  (!grepl(cb_md, '```{.class}'))
+  (!grepl(cb_md, '```{#id}'))
+  (!grepl(cb_md, '```{style="color: red"}'))
+  # Pandoc's raw attribute
+  (!grepl(cb_md, '```{=latex}'))
 })

--- a/tests/testit/test-patterns.R
+++ b/tests/testit/test-patterns.R
@@ -1,43 +1,42 @@
 library(testit)
 
-assert(
-  'detect_pattern() automatically detects syntax patterns',
-  identical(detect_pattern('<<>>='), 'rnw'),
-  identical(detect_pattern('<<foo, bar=TRUE>>='), 'rnw'),
-  identical(detect_pattern('% begin.rcode'), 'tex'),
-  identical(detect_pattern('<!--begin.rcode'), 'html'),
-  identical(detect_pattern('``` {r}'), 'md'),
-  identical(detect_pattern('asdf', 'rnw'), 'rnw'),
-  detect_pattern('foo') %==% NULL
-)
+assert('detect_pattern() automatically detects syntax patterns', {
+  (detect_pattern('<<>>=') %==% 'rnw')
+  (detect_pattern('<<foo, bar=TRUE>>=') %==% 'rnw')
+  (detect_pattern('% begin.rcode') %==% 'tex')
+  (detect_pattern('<!--begin.rcode') %==% 'html')
+  (detect_pattern('``` {r}') %==% 'md')
+  (detect_pattern('asdf', 'rnw') %==% 'rnw')
+  (detect_pattern('foo') %==% NULL)
+})
 
-assert(
-  'group_pattern() checks if a pattern contains a group',
-  group_pattern('(.*)'), !group_pattern('()'), !group_pattern('abc'), !group_pattern(NULL)
-)
+assert('group_pattern() checks if a pattern contains a group', {
+  (group_pattern('(.*)') %==% TRUE)
+  (group_pattern('()') %==% FALSE)
+  (group_pattern('abc') %==% FALSE)
+  (group_pattern(NULL) %==% FALSE)
+})
 
-ce = all_patterns$rnw$chunk.end
-assert(
-  'patterns for Rnw',
-  identical(grep(ce, '  @'), 1L), # spaces before @
-  identical(grep(ce, '@  '), 1L), # spaces after @
-  identical(grep(ce, '@ %asdf'), 1L), # comments after %
-  identical(grep(ce, '@ asdf'), integer()), # only spaces/comments allowed
-  identical(grep(ce, ' @ a% sdf'), integer())
-)
+ce_rnw = all_patterns$rnw$chunk.end
+assert('patterns for Rnw', {
+  (grep(ce_rnw, '  @') %==% 1L) # spaces before @
+  (grep(ce_rnw, '@  ') %==% 1L) # spaces after @
+  (grep(ce_rnw, '@ %asdf') %==% 1L) # comments after %
+  (grep(ce_rnw, '@ asdf') %==% integer()) # only spaces/comments allowed
+  (grep(ce_rnw, ' @ a% sdf') %==% integer())
+})
 
 cb_md = all_patterns$md$chunk.begin
-assert(
-  'patterns for md',
-  # Are they chunk options?
-  isTRUE(grepl(cb_md, '```{r}')),
-  isTRUE(grepl(cb_md, '```{r label}')),
-  isTRUE(grepl(cb_md, '```{r, eval=FALSE}')),
-  isTRUE(grepl(cb_md, '```{awk}')),
-  # Are they Pandoc's fenced code attributes?
-  !isTRUE(grepl(cb_md, '```{.class}')),
-  !isTRUE(grepl(cb_md, '```{#id}')),
-  !isTRUE(grepl(cb_md, '```{style="color: red"}')),
-  # Is it Pandoc's raw attribute?
-  !isTRUE(grepl(cb_md, '```{=latex}'))
-)
+assert('patterns for md', {
+  # TRUE for chunk options
+  (grepl(cb_md, '```{r}') %==% TRUE)
+  (grepl(cb_md, '```{r label}') %==% TRUE)
+  (grepl(cb_md, '```{r, eval=FALSE}') %==% TRUE)
+  (grepl(cb_md, '```{awk}') %==% TRUE)
+  # FALSE for Pandoc's fenced code attributes
+  (grepl(cb_md, '```{.class}') %==% FALSE)
+  (grepl(cb_md, '```{#id}') %==% FALSE)
+  (grepl(cb_md, '```{style="color: red"}') %==% FALSE)
+  # FALSE for Pandoc's raw attribute
+  (grepl(cb_md, '```{=latex}') %==% FALSE)
+})


### PR DESCRIPTION
Pandoc's `fenced_code_attributes` may start with `.` to specify a class, `#` to specify a identifier, or a `name=value` pair, and `raw_attribute` starts with `=`.
Currently, the `name=value` pair is is not supported, and thus I made an update.

For example, a following code block is treated as chunk in the current `knitr`

````
```{style='background-color: skyblue'}
Skyblue
```
````

and returns error:

```
(*) NOTE: I saw chunk options "='background-color: skyblue', engine="style""
 please go to https://yihui.name/knitr/options
 (it is likely that you forgot to quote "character" options)
Error in parse(text = code, keep.source = FALSE) : 
  <text>:1:11: unexpected symbol
1: alist( '='background
              ^
Calls: <Anonymous> ... parse_params -> withCallingHandlers -> eval -> parse_only -> parse
Execution halted
```

This is fixed by updating regex pattern.

## Testing new regex pattern

```r
grepl(
  '^[\t >]*```+\\s*\\{([a-zA-Z0-9_]+( *[ ,].*)?)\\}\\s*$',
  c(
    '```{r}',
    '```{r label}',
    '```{r, eval=FALSE}',
    '```{awk}',
    '```{.class}',
    '```{#id}',
    '```{=latex}',
    '```{style="color: red"}'
  )
)
# [1]  TRUE  TRUE  TRUE  TRUE FALSE FALSE FALSE FALSE
```