### PR TITLE
fix disappearance of figure captions when a chunk generates multiple figures continuously

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - The chunk option `collapse = TRUE` now works as expected when the chunk option `attr.*` or `class.*` is provided. By this change, The chunk option `collapse = TRUE` forces `attr.*` and `class.*` be `NULL` except for the chunk options `attr.source` and `class.source` (thanks, @aosavi @cderv @atusy, #1902 #1906).
 
+- Captions disappeared when a chunk generates multiple figures continuously (thanks, @atusy, #1760)
+
 # CHANGES IN knitr VERSION 1.30
 
 ## NEW FEATURES

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -1,27 +1,37 @@
 #' @rdname hook_plot
 #' @export
 hook_plot_md = function(x, options) {
+  add_lines = function(x) {
+    if (
+      (isTRUE(options$echo) && options$fig.show != 'hold') ||
+      is.null(options$fig.cap) || options$fig.num %in% c(1L, options$fig.cur)
+    ) {
+      return(x)
+    }
+    paste0(x, "\n\n")
+  }
   # if not using R Markdown v2 or output is HTML, just return v1 output
   if (is.null(to <- pandoc_to()) || is_html_output(to))
-    return(hook_plot_md_base(x, options))
+    return(add_lines(hook_plot_md_base(x, options)))
   if ((options$fig.show == 'animate' || is_tikz_dev(options)) && is_latex_output())
     return(hook_plot_tex(x, options))
+
   office_output = to %in% c('docx', 'pptx', 'rtf', 'odt')
   if (need_special_plot_hook(options)) {
     if (is_latex_output()) {
       # Pandoc < 1.13 does not support \caption[]{} so suppress short caption
       if (is.null(options$fig.scap)) options$fig.scap = NA
-      return(hook_plot_tex(x, options))
+      return(add_lines(hook_plot_tex(x, options)))
     }
     if (office_output) {
       if (options$fig.align != 'default') {
         warning('Chunk options fig.align is not supported for ', to, ' output')
         options$fig.align = 'default'
       }
-      return(hook_plot_md_pandoc(x, options))
+      return(add_lines(hook_plot_md_pandoc(x, options)))
     }
   }
-  hook_plot_md_base(x, options)
+  add_lines(hook_plot_md_base(x, options))
 }
 
 # decide if the markdown plot hook is not enough and needs special hooks like

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -3,7 +3,7 @@
 hook_plot_md = function(x, options) {
   add_lines = function(x) {
     if (
-      (isTRUE(options$echo) && options$fig.show != 'hold') ||
+      (!identical(options$echo, FALSE) && options$fig.show != 'hold') ||
       is.null(options$fig.cap) || options$fig.num %in% c(1L, options$fig.cur)
     ) {
       return(x)

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -67,8 +67,8 @@ x = "1.png"
 w = h = 1
 ex = "style='margin: 0;'"
 cap = "foo"
-opt <- function(w = NULL, h =NULL, ex = NULL, cap = NULL, show = 'asis', ...) {
-  list(out.width = w, out.height = h, out.extra = ex, fig.cap = cap, fig.show = show, ...)
+opt <- function(w = NULL, h =NULL, ex = NULL, cap = NULL, show = 'asis', align = 'default', ...) {
+  list(out.width = w, out.height = h, out.extra = ex, fig.cap = cap, fig.show = show, fig.align = align, ...)
 }
 
 assert("Include a plot by pandoc md", {
@@ -79,4 +79,37 @@ assert("Include a plot by pandoc md", {
   (hook_plot_md_pandoc(x, opt(ex = ex)) %==% sprintf("![](1.png){%s}", ex))
   (hook_plot_md_pandoc(x, opt(w = w, cap = cap, ex = ex)) %==%
     sprintf("![%s](1.png){width=%s %s}", cap, w, ex))
+})
+
+align = 'left'
+link = 'https://example.com'
+
+hook = hook_plot_md_base
+assert("Include a plot in variety of formats with hook_plot_md_base", {
+  # width, height, and extra are null, and align is default
+  (hook(x, opt()) %==% "![](1.png)")
+  (hook(x, opt(cap = cap)) %==% sprintf("![%s](1.png)", cap))
+  (hook(x, opt(fig.link = link)) %==% sprintf("[![](1.png)](%s)", link))
+  opts_knit$set(rmarkdown.pandoc.to = 'latex')
+  (hook(x, opt(cap = '')) %==% "![](1.png)<!-- --> ")
+  opts_knit$set(rmarkdown.pandoc.to = 'html')
+  (hook(x, opt(cap = '')) %==% "![](1.png)<!-- -->")
+  # html output with caption or width
+  (hook(x, opt(align = align, cap = cap)) %==%
+      sprintf('<div class="figure" style="text-align: %s">\n<img src="1.png" alt="%s"  />\n<p class="caption">%s</p>\n</div>', align, cap, cap))
+  ## add link
+  (hook(x, opt(w = w, cap = cap, fig.link = link)) %==%
+      sprintf('<div class="figure">\n<a href="%s" target="_blank"><img src="1.png" alt="%s" width="%s" /></a>\n<p class="caption">%s</p>\n</div>', link, cap, w, cap))
+  ## fig.caption is TRUE
+  (hook(x, opt(w = w, cap = cap, fig.topcaption = TRUE)) %==%
+      sprintf('<div class="figure">\n<p class="caption">%s</p><img src="1.png" alt="%s" width="%s" /></div>', cap, cap, w))
+  ## plot1 is FALSE
+  (hook(x, opt(w = w, cap = cap, show = 'hold', fig.cur = 2, fig.num = 2)) %==%
+      sprintf('<img src="1.png" alt="%s" width="%s" />\n<p class="caption">%s</p>\n</div>', cap, w, cap))
+  ## plot2 is FALSE
+  (hook(x, opt(w = w, cap = cap, show = 'hold', fig.cur = 1, fig.num = 2)) %==%
+      sprintf('<div class="figure">\n<img src="1.png" alt="%s" width="%s" />', cap, w, cap))
+  # else
+  opts_knit$restore()
+  (hook(x, opt(align = 'center')) %==% '<img src="1.png" style="display: block; margin: auto;" />')
 })


### PR DESCRIPTION
Knitr generates multiple figures in one line when a chunk generates multiple figures continuously.

For example,

````
```{r echo=FALSE, fig.cap = c('cap1', 'cap2')}
plot(1)
plot(2)
```
````

becomes something like

```md
![cap1](plot1.png)![cap2](plot2.png)
```

In such case, Pandoc will suppress figure captions.
Yihui pointed out this in #1756 and I did in #1755 .
These issues were about office formats, but the issue occurs also in HTML and PDF.

I think users expect figure captions be shown rather than figures stay in one line.

This PR fixes this problem by adding blank lines between captioned figures.

```md
![cap1](plot1.png)

![cap2](plot2.png)
```

The current implementation requires `fig.show='hold'` or `echo=FALSE`, which is maybe too strict because

````
```{r, fig.cap = c('cap1', 'cap2')}
g <- ggplot2::qplot(1, 1)
purrr::walk(list(g, g), print)
```
````

is still like

```md
![cap1](plot1.png)![cap2](plot2.png)
```

Unfortunately, I have no idea how to detect such a case.
A workaround is to add blank lines regardless of what is specified to  `fig.show` and `echo`.
A disadvantage of the workaround is that needless blank lines will be added when multiple figures are generated by a chunk but are separated from each other by something, i.e.

````
```{r fig.cap = c('cap1', 'cap2')}
plot(1)
plot(2)
```
````

will be like

````
```r
plot(1)
```

![cap1](plot1.png)



```r
plot(2)
```

![cap2](plot2.png)
````

IMO, For the most of the formats, this is okay because the markdown format is just the intermediate format.
Some may dislike the needless blank lines when they want the markdown format as the output format.

Any thoughts?

## Example Rmd

````
---
title: "Untitled"
output :
  html_document: default
  rtf_document: default
  odt_document: default
  powerpoint_presentation: default
  word_document: default
  pdf_document: default
---

# echo is FALSE

```{r base, fig.cap=.cap, echo=FALSE}
.cap <- c('cap1', 'cap2')
plot(1)
plot(2)
```

# fig.show is hold

```{r ref.label='base', fig.cap=.cap, fig.show='hold'}
```
````