### PR TITLE
require styler 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -136,7 +136,7 @@ Suggests:
     showtext,
     tibble,
     sass,
-    styler
+    styler (>= 1.2.0)
 License: GPL
 URL: https://yihui.name/knitr/
 BugReports: https://github.com/yihui/knitr/issues


### PR DESCRIPTION
In particular because {{ is now recognized as rlang *curly curly*. Before, the line was broken between the two curly braces. Also, there were many other improvements over the last two years. For details see https://github.com/r-lib/styler/releases/tag/v1.2.0.