### PR TITLE
Allow sass engine to use an arbitrary sass compilation function

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -686,8 +686,9 @@ eng_sxss = function(options) {
   if (use_package) {
     message("Converting with the R package sass")
 
+    sass_fun = options$engine.opts$sass_fun %n% sass::sass
     out = tryCatch(
-      sass::sass(sass::sass_file(f), options = sass::sass_options(output_style = style)),
+      sass_fun(sass::sass_file(f), options = sass::sass_options(output_style = style)),
       error = function(e) {
         if (!options$error) stop(e)
         warning2(paste('Error in converting to CSS using sass R package:', e, sep = "\n"))


### PR DESCRIPTION
Adds an `engine.opts`, named `sass_fun`, for customizing the R function used to perform sass/scss compilation (instead of `sass::sass`). This will be useful for providing a higher-order function that imports variables/functions/mixins/whatever you'd like your sass chunk to compile against (e.g., [`bootstraplib::bootstrap_sass()`](https://gist.github.com/cpsievert/dc338c78cdd700ae5a9172b74ca30bd1)).

(bootstraplib is not yet public but should be by end of next week)