### PR TITLE
Spin comments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,6 +76,7 @@ Authors@R: c(
     person("Niels Richard", "Hansen", role = "ctb"),
     person("Noam", "Ross", role = "ctb"),
     person("Obada", "Mahdi", role = "ctb"),
+    person("Peter", "DeWitt", role = "ctb"),
     person("Qiang", "Li", role = "ctb"),
     person("Ramnath", "Vaidyanathan", role = "ctb"),
     person("Richard", "Cotton", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 - By default, `include_graphics(files)` will signal an error if any `files` do not exist and are not web resources. To avoid the error (e.g., if you think it is a false positive), use `include_graphics(..., error = FALSE)` (thanks, @hadley, #1717).
 
+## BUG FIXES
+
+- Check for the correct ordering of start/end deliminators of comments for spin files (#1801)
+
 # CHANGES IN knitr VERSION 1.27
 
 ## NEW FEATURES

--- a/R/spin.R
+++ b/R/spin.R
@@ -195,28 +195,26 @@ check_comments <- function(c1, c2) {
   cs <- sort(c(openers = c1, closers = c2))
   err <- FALSE
   notes <- character()
-
   while(length(cs)) {
-    if (grepl("closer", names(cs)[1])) {
-      notes <- append(notes, paste0("  unopened comment; closed on line ", cs[1]))
-      cs <- cs[-1]
-      err <- TRUE
-    }
-
     i <- 1
-    while(i < length(cs)) {
-      if (grepl("opener", names(cs)[i]) & grepl("closer", names(cs)[i + 1])) {
-        notes <- append(notes, paste0("  opened on line ", cs[i], "; closed on line ", cs[i + 1]))
-        cs <- cs[-c(i, i+1)]
-      } else {
-        i <- i + 1
-      }
-    }
-
-    if (length(cs) == 1L & grepl("opener", names(cs)[1])) {
-      notes <- append(notes, paste0("  opened on line ", cs[1], "; unclosed"))
+    if (grepl("closer", names(cs)[1])) {
+      notes <- append(notes, paste0("  * unopened comment; closed on line ", cs[1]))
       cs <- cs[-1]
       err <- TRUE
+    } else if (all(grepl("opener", names(cs)))) {
+      notes <- append(notes, paste0("  * opened on line ", cs[1], "; unclosed"))
+      cs <- cs[-1]
+      err <- TRUE
+    } else {
+      while (i < length(cs)) {
+        if (grepl("opener", names(cs)[i]) & grepl("closer", names(cs)[i + 1])) {
+          notes <- append(notes, paste0("  * opened on line ", cs[i], "; closed on line ", cs[i + 1]))
+          cs <- cs[-c(i, i + 1)]
+          break
+        } else {
+          i <- i + 1
+        }
+      }
     }
   }
 

--- a/R/spin.R
+++ b/R/spin.R
@@ -198,17 +198,17 @@ check_comments <- function(c1, c2) {
   while(length(cs)) {
     i <- 1
     if (grepl("closer", names(cs)[1])) {
-      notes <- append(notes, paste0("  * unopened comment; closed on line ", cs[1]))
+      notes <- append(notes, paste0("  * no starting delimiter; ended on line ", cs[1]))
       cs <- cs[-1]
       err <- TRUE
     } else if (all(grepl("opener", names(cs)))) {
-      notes <- append(notes, paste0("  * opened on line ", cs[1], "; unclosed"))
+      notes <- append(notes, paste0("  * started on line ", cs[1], "; no end delimiter"))
       cs <- cs[-1]
       err <- TRUE
     } else {
       while (i < length(cs)) {
         if (grepl("opener", names(cs)[i]) & grepl("closer", names(cs)[i + 1])) {
-          notes <- append(notes, paste0("  * opened on line ", cs[i], "; closed on line ", cs[i + 1]))
+          notes <- append(notes, paste0("  * started on line ", cs[i], "; ended on line ", cs[i + 1]))
           cs <- cs[-c(i, i + 1)]
           break
         } else {


### PR DESCRIPTION

These examples are the same as in \#1801. With this PR an error is thrown
when delimiters are not as expected.

An innocuous example:

``` r
txt1 <-
  paste("#' # A reprex for knitr::spin comments",
        "#'",
        "#' The check for start (/*) and end (*/) comments can fail to identify",
        "#' notable issues.  Consider a document with the first occurance of comment to",
        "#' be the *end* comment and the last comment to be an *start* comment.",
        "#'",
        "# */",
        "#' This text is in an 'comment' section but the characters denoting the comment",
        "#' are backwards. This will not be in the .Rmd file, even though the start and",
        "#' end delimiters are backwards",
        "# /*",
        "#'",
        "#' This doc can be spun to a .Rmd",
        sep = "\n")

x1 <- knitr::spin(text = txt1, knit = FALSE, format = "Rmd")
#> Error: comments must be put in pairs of start and end delimiters.
#>    * no starting delimiter; ended on line 7
#>   * started on line 11; no end delimiter
```

The miss ordering can result is something is difficult for a human. When
skimming txt2 I would ex the first “comment” block to be in the .Rmd file,
the R code chunk to be omitted, the statment “annother comment” to be in the
.Rmd, and last line to be omitted. This is assuming that an error isn’t
thrown because of the first comment delimiters is the “end” delimiters and
the last delimiter is the “start” delimiter.

``` r
txt2 <-
  paste("#' # A reprex for knitr::spin comments",
        "#'",
        "# */",
        "#' This text is in an 'comment' section but the characters denoting the comment",
        "#' are backwards. This will not be in the .Rmd file.",
        "# /*",
        "#'",
        "#' A little R code",
        "2 + 2",
        "#'",
        "# */",
        "#' Another comment",
        "# /*",
        "#' This doc can be spun to a .Rmd, but the comment start and end delimators are",
        "#' interchangeable.",
        sep = "\n")

x2 <- knitr::spin(text = txt2, knit = FALSE, format = "Rmd")
#> Error: comments must be put in pairs of start and end delimiters.
#>    * no starting delimiter; ended on line 3
#>   * started on line 6; ended on line 11
#>   * started on line 13; no end delimiter
```

What about nested comments? If the comment delimiters were correctly
specified the following would work, but as written, an error is thrown.

``` r
txt3 <-
  paste("#' # A reprex for knitr::spin comments",
        "#'",
        "#' text ...",
        "#'",
        "# */ outside comment",
        "#",
        "# ... code that is commented out during dev work, perhaps,",
        "#",
        "# */",
        "# A comment that is a comment and will be here for the long term.",
        "# /*",
        "#",
        "# ... code and text, next line ends outside comment.",
        "# /*",
        "#'",
        "#' document text",
        sep = "\n")

x3 <- knitr::spin(text = txt3, knit = FALSE, format = "Rmd")
#> Error: comments must be put in pairs of start and end delimiters.
#>    * no starting delimiter; ended on line 9
#>   * started on line 11; no end delimiter
#>   * started on line 14; no end delimiter
```

With correct comments:

``` r
txt1 <-
  paste("#' # A reprex for knitr::spin comments",
        "#'",
        "#' The check for start (/*) and end (*/) comments can fail to identify",
        "#' notable issues.  Consider a document with the first occurance of comment to",
        "#' be the *end* comment and the last comment to be an *start* comment.",
        "#'",
        "# /*",
        "#' This text is in an 'comment' section but the characters denoting the comment",
        "#' are backwards. This will not be in the .Rmd file, even though the start and",
        "#' end delimiters are backwards",
        "# */",
        "#'",
        "#' This doc can be spun to a .Rmd",
        sep = "\n")

x1 <- knitr::spin(text = txt1, knit = FALSE, format = "Rmd")
cat(x1, sep = "\n")
#> # A reprex for knitr::spin comments
#> 
#> The check for start (/*) and end (*/) comments can fail to identify
#> notable issues.  Consider a document with the first occurance of comment to
#> be the *end* comment and the last comment to be an *start* comment.
#> 
#> 
#> This doc can be spun to a .Rmd
```

The miss ordering can result is something is difficult for a human. When
skimming txt2 I would ex the first “comment” block to be in the .Rmd file,
the R code chunk to be omitted, the statment “annother comment” to be in the
.Rmd, and last line to be omitted. This is assuming that an error isn’t
thrown because of the first comment delimiters is the “end” delimiters and
the last delimiter is the “start” delimiter.

```` r
txt2 <-
  paste("#' # A reprex for knitr::spin comments",
        "#'",
        "# /*",
        "#' This text is in an 'comment' section but the characters denoting the comment",
        "#' are backwards. This will not be in the .Rmd file.",
        "# */",
        "#'",
        "#' A little R code",
        "2 + 2",
        "#'",
        "# /*",
        "#' Another comment",
        "# */",
        "#' This doc can be spun to a .Rmd, but the comment start and end delimators are",
        "#' interchangeable.",
        sep = "\n")

x2 <- knitr::spin(text = txt2, knit = FALSE, format = "Rmd")
cat(x2, sep = "\n")
#> # A reprex for knitr::spin comments
#> 
#> 
#> A little R code
#> 
#> ```{r }
#> 2 + 2
#> ```
#> 
#> 
#> This doc can be spun to a .Rmd, but the comment start and end delimators are
#> interchangeable.


txt3 <-
  paste("#' # A reprex for knitr::spin comments",
        "#'",
        "#' text ...",
        "#'",
        "# /* outside comment",
        "#",
        "# ... code that is commented out during dev work, perhaps,",
        "#",
        "# /*",
        "# A comment that is a comment and will be here for the long term.",
        "# */",
        "#",
        "# ... code and text, next line ends outside comment.",
        "# */",
        "#'",
        "#' document text",
        sep = "\n")

x3 <- knitr::spin(text = txt3, knit = FALSE, format = "Rmd")
cat(x3, sep = "\n")
#> # A reprex for knitr::spin comments
#> 
#> text ...
#> 
#> 
#> document text

xfun::session_info("knitr")
#> R version 3.6.2 (2019-12-12)
#> Platform: x86_64-apple-darwin15.6.0 (64-bit)
#> Running under: macOS Catalina 10.15.2
#> 
#> Locale: en_US.UTF-8 / en_US.UTF-8 / en_US.UTF-8 / C / en_US.UTF-8 / en_US.UTF-8
#> 
#> Package version:
#>   evaluate_0.14   glue_1.3.1      graphics_3.6.2  grDevices_3.6.2
#>   highr_0.8       knitr_1.27.2    magrittr_1.5    markdown_1.1   
#>   methods_3.6.2   mime_0.8        stats_3.6.2     stringi_1.4.5  
#>   stringr_1.4.0   tools_3.6.2     utils_3.6.2     xfun_0.12      
#>   yaml_2.2.0
````

<sup>Created on 2020-01-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>