### PR TITLE
Add Rust Engine

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,6 +91,7 @@ Authors@R: c(
     person("Thibaut", "Assus", role = "ctb"),
     person("Thibaut", "Lamadon", role = "ctb"),
     person("Thomas", "Leeper", role = "ctb"),
+    person("Tianyi", "Shi", role = "ctb", comment = c(ORCID = "0000-0002-9204-9949")),
     person("Tim", "Mastny", role = "ctb"),
     person("Tom", "Torsney-Weir", role = "ctb"),
     person("Trevor", "Davis", role = "ctb"),

--- a/R/engine.R
+++ b/R/engine.R
@@ -652,9 +652,14 @@ eng_go = function(options) {
 
 # rust engine, added by @TianyiShi https://github.com/yihui/knitr/pull/1823
 eng_rust = function(options) {
+  # make `fn main` optional
+  source <- options$code
+  if (length(grep('fn main', source))==0) {
+    source <- paste0('fn main(){\n', source, '\n}')
+  }
   src = wd_tempfile('code', '.rs')
   bin = strsplit(src, '\\.rs')[[1]]
-  write_utf8(source <- options$code, src)
+  write_utf8(source, src)
   on.exit(unlink(c(src, bin)), add = TRUE)
   cmd = get_engine_path(options$engine.path, "rustc")
   args = sprintf('%s && %s', file.path(getwd(), src), file.path(getwd(), bin))

--- a/R/engine.R
+++ b/R/engine.R
@@ -685,8 +685,14 @@ eng_rust = function(options) {
 # rust engine (cargo), added by @TianyiShi https://github.com/yihui/knitr/pull/1823
 # allows usage of external crates
 # an option "knitr.engines.crate" should be set to the cargo directory
-# (where Config.toml is located). If a relative path is used, it should
+# (where Cargo.toml is located). If a relative path is used, it should
 # be relative to the Rmd document being knitted.
+# It is usually easier to set an invariant cargo directory for all projects,
+# if they don't need different versions of dependencies, and set that to
+# as the default for "knitr.engines.crate", in ~/.Rprofile. You can always
+# override this by using a setup block at the beginning of the Rmd document,
+# when you require specific versions of dependencies and have created a separate
+# cargo directory for this.
 eng_rust_cargo = function(options) {
   src_dir <- if (!is.null(x <- getOption("knitr.engines.crate"))) x else {
     stop("Please set options(knitr.engines.crate='YOUR_PATH_TO_CRATE')")

--- a/R/engine.R
+++ b/R/engine.R
@@ -655,7 +655,7 @@ eng_rust = function(options) {
   # make `fn main` optional
   source <- options$code
   if (length(grep('fn main', source))==0) {
-    source <- paste0('fn main(){\n', source, '\n}')
+    source <- paste0(c('fn main(){\n', source, '\n}'), collapse = '')
   }
   src = wd_tempfile('code', '.rs')
   bin = strsplit(src, '\\.rs')[[1]]

--- a/R/engine.R
+++ b/R/engine.R
@@ -664,7 +664,7 @@ eng_rust = function(options) {
   cmd = get_engine_path(options$engine.path, "rustc")
   args = sprintf('%s && %s', file.path(getwd(), src), file.path(getwd(), bin))
 
-  message(sprintf('Running: %s %s', cmd, args))
+  if (options$message) message(sprintf('Running: %s %s', cmd, args))
 
   output = if (options$eval && options$results != 'hide') {
     tryCatch(

--- a/R/engine.R
+++ b/R/engine.R
@@ -666,7 +666,7 @@ eng_rust = function(options) {
 
   if (options$message) message(sprintf('Running: %s %s', cmd, args))
 
-  output = if (options$eval && options$results != 'hide') {
+  output = if (options$eval) {
     tryCatch(
       system2(cmd, args, stdout = TRUE, stderr = TRUE, env = options$engine.env),
       error = function(e) {
@@ -674,7 +674,9 @@ eng_rust = function(options) {
         sprintf('Error in executing command: %s %s', cmd, args)
       }
     )
-  } else NULL
+  }
+
+  if (options$results == 'hide') output = NULL
 
   engine_output(options, source, output)
 }

--- a/R/engine.R
+++ b/R/engine.R
@@ -684,18 +684,22 @@ eng_rust = function(options) {
 
 # rust engine (cargo), added by @TianyiShi https://github.com/yihui/knitr/pull/1823
 # allows usage of external crates
-# an option "knitr.engines.crate" should be set to the cargo directory
+# an option `knitr.engines.crate` should be set to the cargo directory
 # (where Cargo.toml is located). If a relative path is used, it should
 # be relative to the Rmd document being knitted.
 # It is usually easier to set an invariant cargo directory for all projects,
 # if they don't need different versions of dependencies, and set that to
-# as the default for "knitr.engines.crate", in ~/.Rprofile. You can always
+# as the default for `knitr.cargo.path`, in ~/.Rprofile. You can always
 # override this by using a setup block at the beginning of the Rmd document,
 # when you require specific versions of dependencies and have created a separate
 # cargo directory for this.
+# In very rare cases when you need different cargos in the same document,
+# you can use a chunk option `cargo.path` to override the defualt option.
 eng_rust_cargo = function(options) {
-  src_dir <- if (!is.null(x <- getOption("knitr.engines.crate"))) x else {
-    stop("Please set options(knitr.engines.crate='YOUR_PATH_TO_CRATE')")
+  src_dir <- if (!is.null(x <- getOption("knitr.cargo.path"))) x else {
+    if (!is.null(x <- options$cargo.path)) x else {
+      stop("Please set options(knitr.cargo.path='<PATH_TO_CARGO>') or set the chunk option cargo.path='<PATH_TO_CARGO>'")
+    }
   }
   src <- file.path(x, "src/main.rs")
   # make `fn main` optional

--- a/R/engine.R
+++ b/R/engine.R
@@ -659,17 +659,17 @@ eng_rust = function(options) {
   cmd = get_engine_path(options$engine.path, "rustc")
   args = sprintf('%s && %s', file.path(getwd(), src), file.path(getwd(), bin))
 
-  output = if (options$eval) {
+  message(sprintf('Running: %s %s', cmd, args))
+
+  output = if (options$eval && options$results != 'hide') {
     tryCatch(
       system2(cmd, args, stdout = TRUE, stderr = TRUE, env = options$engine.env),
       error = function(e) {
         if (!options$error) stop(e)
-        'Error in executing go code'
+        sprintf('Error in executing command: %s %s', cmd, args)
       }
     )
-  }
-
-  if (options$results == 'hide') output = NULL
+  } else NULL
 
   engine_output(options, source, output)
 }

--- a/R/engine.R
+++ b/R/engine.R
@@ -652,25 +652,25 @@ eng_go = function(options) {
 
 # rust engine, added by @TianyiShi https://github.com/yihui/knitr/pull/1823
 # unable to use external crates; for that, use eng_rust_cargo instead
-eng_rust = function(options) {
+eng_rust <- function(options) {
   # make `fn main` optional
   source <- options$code
   if (length(grep('fn main', source))==0) {
     source <- paste0(c('fn main(){\n', source, '\n}'), collapse = '')
   }
-  src = wd_tempfile('code', '.rs')
-  bin = strsplit(src, '\\.rs')[[1]]
+  src <- wd_tempfile('code', '.rs')
+  bin <- strsplit(src, '\\.rs')[[1]]
   write_utf8(source, src)
   on.exit(unlink(c(src, bin)), add = TRUE)
-  cmd = get_engine_path(options$engine.path, "rustc")
-  args = sprintf('%s && %s', file.path(getwd(), src), file.path(getwd(), bin))
+  cmd <- get_engine_path(options$engine.path, "rustc")
+  args <- sprintf('%s && %s', file.path(getwd(), src), file.path(getwd(), bin))
 
   if (options$message) message(sprintf('Running: %s %s', cmd, args))
 
-  output = if (options$eval) {
+  output <- if (options$eval) {
     tryCatch(
       system2(cmd, args, stdout = TRUE, stderr = TRUE, env = options$engine.env),
-      error = function(e) {
+      error <- function(e) {
         if (!options$error) stop(e)
         sprintf('Error in executing command: %s %s', cmd, args)
       }
@@ -695,7 +695,7 @@ eng_rust = function(options) {
 # cargo directory for this.
 # In very rare cases when you need different cargos in the same document,
 # you can use a chunk option `cargo.path` to override the defualt option.
-eng_rust_cargo = function(options) {
+eng_rust_cargo <- function(options) {
   src_dir <- if (!is.null(x <- getOption("knitr.cargo.path"))) x else {
     if (!is.null(x <- options$cargo.path)) x else {
       stop("Please set options(knitr.cargo.path='<PATH_TO_CARGO>') or set the chunk option cargo.path='<PATH_TO_CARGO>'")
@@ -708,8 +708,8 @@ eng_rust_cargo = function(options) {
     source <- paste0(c('fn main(){\n', source, '\n}'), collapse = '')
   }
   write_utf8(source, src)
-  cmd = get_engine_path(options$engine.path, "cargo")
-  args = 'run -q'
+  cmd <- get_engine_path(options$engine.path, "cargo")
+  args <- 'run -q'
 
   if (options$message) message(sprintf('Running: %s %s', cmd, args))
 
@@ -717,7 +717,7 @@ eng_rust_cargo = function(options) {
     old_dir <- setwd(src_dir)
     output <- tryCatch(
       system2(cmd, args, stdout = TRUE, stderr = TRUE, env = options$engine.env),
-      error = function(e) {
+      error <- function(e) {
         if (!options$error) stop(e)
         sprintf('Error in executing command: %s %s', cmd, args)
       }
@@ -725,7 +725,7 @@ eng_rust_cargo = function(options) {
     invisible(setwd(old_dir))
   }
 
-  if (options$results == 'hide') output = NULL
+  if (options$results == 'hide') output <- NULL
 
   engine_output(options, source, output)
 }


### PR DESCRIPTION
Adding support for running Rust code in ```` ```{rust} ```` and ```` ```{cargo} ```` chunks.

```` ```{rust} ```` chunks call `rustc`, while ```` ```{cargo} ```` chunks call `cargo run`. The main difference is that, ```` ```{cargo} ```` chunks allow using external crates, but this also comes at a cost of additional configuration (see below). 

### ```` ```{rust} ```` implementation details:

This is achieved by copying code into a temporary file `foo.rs` and then run `rustc foo.rs && ./foo`.

You may need to specify the path to `rustc` in `~/.Renviron` [because `Sys.getenv('PATH')` in R is different from `echo $PATH` in shell.](https://stackoverflow.com/questions/31121645/rstudio-shows-a-different-path-variable)

Demo:

<img width="805" alt="图片" src="https://user-images.githubusercontent.com/38644266/77422220-03ebee80-6dc5-11ea-8717-55a5daa154b2.png">


You can even omit `fn main()` in simple cases:

<img width="793" alt="图片" src="https://user-images.githubusercontent.com/38644266/77388817-134d4680-6d89-11ea-8638-c5855cdeb63d.png">

(this is achieved by first `grep`ping 'fn main', and if it's not found, wrapping your code with `fn main(){` and `}`

### ```` ```{cargo} ```` implementation details:

1. the user sets `options(knitr.cargo.path= "PATH_TO_CARGO")`, where `PATH_TO_CARGO` is the directory that contains `Cargo.toml` **Please suggest a better name for `knitr.cargo.path`!**
2. `eng_rust_cargo()` extracts the cargo directory using `getOption("knitr.cargo.path")`
3. the content of each ```` ```{cargo} ````block is copied to `CARGO_DIR/src/main.rs` (`fn main() {}` added if absent)
4. `setwd()` to the cargo directory, and `cargo run -q` is executed by `system2()`, then wd is reset

Demo:

<img width="721" alt="Screenshot 2020-04-05 at 16 18 03" src="https://user-images.githubusercontent.com/38644266/78470087-33054700-7759-11ea-90e9-046381e45395.png">