### PR TITLE
Update kable to allow custom formating

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Authors@R: c(
     person("Doug", "Hemken", role = "ctb"),
     person("Duncan", "Murdoch", role = "ctb"),
     person("Elio", "Campitelli", role = "ctb"),
+    person("Ellis", "Hughes", role = "ctb"),
     person("Emily", "Riederer", role = "ctb"),
     person("Fabian", "Hirschmann", role = "ctb"),
     person("Fitch", "Simeon", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - The argument `error` of `include_graphics()` takes value from the global R option `knitr.graphics.error` by default, e.g., you may set `options(knitr.graphics.error = FALSE)` so `include_graphics()` won't signal an error if the graphics file to be included doesn't exist.
 
+- change the behavior of `kable()` to allow for custom formatting of contents.
+
 ## BUG FIXES
 
 - For non-R code chunks that generate plots and use the chunk option `fig.cap`, the `plot` hook in **knitr** stopped working in v1.27 and v1.28 (thanks, @XiangyunHuang, https://d.cosx.org/d/421249).

--- a/R/table.R
+++ b/R/table.R
@@ -159,7 +159,7 @@ kable = function(
     if (!is.null(align)) align = c('l', align)  # left align row names
   }
   n = nrow(x)
-  x = replace_na(to_format_matrix(x, format.args), is.na(x))
+  x = replace_na(to_character(x, format.args), is.na(x))
   if (!is.matrix(x)) x = matrix(x, nrow = n)
   x = trimws(x)
   colnames(x) = col.names
@@ -176,14 +176,12 @@ kable = function(
 # convert to character while preserving dim/dimnames attributes
 to_character = function(x) {
   if (is.character(x)) return(x)
+  # format columns individually if x is not a matrix
+  if (!is.matrix(x)) {
+    for (j in seq_len(ncol(x)) x[, j] = format_args(x[, j])
+    x = as.matrix(x)
+  }
   x2 = as.character(x); dim(x2) = dim(x); dimnames(x2) = dimnames(x)
-  x2
-}
-
-# convert to chatacter, applying formatting, and maintain dim/dimnames attributes
-to_format_matrix <- function(x, args){
-  x2 <- as.character(as.matrix(data.frame(lapply(x,format,... = args))))
-  dim(x2) = dim(x)
   x2
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -159,7 +159,7 @@ kable = function(
     if (!is.null(align)) align = c('l', align)  # left align row names
   }
   n = nrow(x)
-  x = replace_na(to_character(x, format.args), is.na(x))
+  x = replace_na(to_character(x), is.na(x))
   if (!is.matrix(x)) x = matrix(x, nrow = n)
   x = trimws(x)
   colnames(x) = col.names

--- a/R/table.R
+++ b/R/table.R
@@ -182,7 +182,7 @@ to_character = function(x) {
 
 # convert to chatacter, applying formatting, and maintain dim/dimnames attributes
 to_format_matrix <- function(x, args){
-  x2 <- as.matrix(apply(x,2,format,... = args))
+  x2 <- as.character(as.matrix(data.frame(lapply(x,format,... = args))))
   dim(x2) = dim(x)
   x2
 }

--- a/R/table.R
+++ b/R/table.R
@@ -178,7 +178,7 @@ to_character = function(x) {
   if (is.character(x)) return(x)
   # format columns individually if x is not a matrix
   if (!is.matrix(x)) {
-    for (j in seq_len(ncol(x)) x[, j] = format_args(x[, j])
+    for (j in seq_len(ncol(x))) x[, j] = format_args(x[, j])
     x = as.matrix(x)
   }
   x2 = as.character(x); dim(x2) = dim(x); dimnames(x2) = dimnames(x)

--- a/R/table.R
+++ b/R/table.R
@@ -159,7 +159,7 @@ kable = function(
     if (!is.null(align)) align = c('l', align)  # left align row names
   }
   n = nrow(x)
-  x = replace_na(to_character(as.matrix(x)), is.na(x))
+  x = replace_na(to_format_matrix(x, format.args), is.na(x))
   if (!is.matrix(x)) x = matrix(x, nrow = n)
   x = trimws(x)
   colnames(x) = col.names
@@ -177,6 +177,13 @@ kable = function(
 to_character = function(x) {
   if (is.character(x)) return(x)
   x2 = as.character(x); dim(x2) = dim(x); dimnames(x2) = dimnames(x)
+  x2
+}
+
+# convert to chatacter, applying formatting, and maintain dim/dimnames attributes
+to_format_matrix <- function(x, args){
+  x2 <- format_matrix(x,args)
+  dimnames(x2) = dimnames(x)
   x2
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -182,8 +182,8 @@ to_character = function(x) {
 
 # convert to chatacter, applying formatting, and maintain dim/dimnames attributes
 to_format_matrix <- function(x, args){
-  x2 <- format_matrix(x,args)
-  dimnames(x2) = dimnames(x)
+  x2 <- as.matrix(apply(x,2,format,... = args))
+  dim(x2) = dim(x)
   x2
 }
 

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -188,3 +188,20 @@ assert(
     c('|  a|  b|', '|--:|--:|', '|  1|  3|', '|   |  4|')
 )
 options(op)
+
+
+formatted_df <- tibble::tibble(x = structure("print_me", .to_upper = TRUE, class = "make_upper"))
+format.make_upper = function(x,...){
+  xout <- unclass(x)
+  if(isTRUE(attr(x,".to_upper"))){
+    xout <- toupper(xout)
+  }
+  as.character(xout)
+}
+
+assert(
+  'kable() can apply formatting to custom objects',
+  kable2(formatted_df) %==%
+    c('|x        |','|:--------|','|PRINT_ME |')
+)
+

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -189,19 +189,24 @@ assert(
 )
 options(op)
 
-
-formatted_df <- tibble::tibble(x = structure("print_me", .to_upper = TRUE, class = "make_upper"))
-format.make_upper = function(x,...){
-  xout <- unclass(x)
-  if(isTRUE(attr(x,".to_upper"))){
-    xout <- toupper(xout)
-  }
-  as.character(xout)
-}
-
 assert(
-  'kable() can apply formatting to custom objects',
+  'kable() can apply formatting to custom objects',{
+
+    formatted_df <-
+      tibble::tibble(x = structure("print_me",
+                                   .to_upper = TRUE,
+                                   class = "make_upper"))
+
+    # need to make available in the global environment
+    format.make_upper <<- function(x, ...) {
+      xout <- unclass(x)
+      if (isTRUE(attr(x, ".to_upper"))) {
+        xout <- toupper(xout)
+      }
+      as.character(xout)
+    }
+
   kable2(formatted_df) %==%
     c('|x        |','|:--------|','|PRINT_ME |')
-)
+})
 

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -189,24 +189,19 @@ assert(
 )
 options(op)
 
-assert(
-  'kable() can apply formatting to custom objects',{
-
-    formatted_df <-
-      tibble::tibble(x = structure("print_me",
-                                   .to_upper = TRUE,
-                                   class = "make_upper"))
-
-    # need to make available in the global environment
-    format.make_upper <<- function(x, ...) {
-      xout <- unclass(x)
-      if (isTRUE(attr(x, ".to_upper"))) {
-        xout <- toupper(xout)
+assert('kable() can apply formatting to custom objects', {
+    d = tibble::tibble(x = structure(
+      'print_me', .to_upper = TRUE, class = 'make_upper'
+    ))
+    
+    format.make_upper = function(x, ...) {
+      xout = unclass(x)
+      if (isTRUE(attr(x, '.to_upper'))) {
+        xout = toupper(xout)
       }
       as.character(xout)
     }
-
-  kable2(formatted_df) %==%
-    c('|x        |','|:--------|','|PRINT_ME |')
+    registerS3method('format', 'make_upper', format.make_upper, environment(format))
+    
+    (kable2(d) %==% c('|x        |', '|:--------|', '|PRINT_ME |'))
 })
-


### PR DESCRIPTION
With the coming of vctrs, it is probably inevitable that there will be a number of new vector classes. And with that, a number of custom printing methods. With the current format of kable, it uses `as.matrix()` to handle the conversion, but it might be better to handle the conversion explicitly.

As far as I could test, this would not change the general behavior.



