### PR TITLE
correctly get the dev.arg option for ragg_png device

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -325,7 +325,7 @@ chunk_device = function(options, record = TRUE, tmp = tempfile()) {
     ), get_dargs(dev.args, 'png')))
   } else if (identical(dev, 'ragg_png')) {
     # handle bg -> background gracefully
-    args = dev.args$ragg_png %n% dev.args
+    args = get_dargs(dev.args, 'ragg_png')
     args$background = args$background %n% args$bg
     args$bg = NULL
     do.call(ragg::agg_png, c(list(

--- a/R/block.R
+++ b/R/block.R
@@ -324,13 +324,9 @@ chunk_device = function(options, record = TRUE, tmp = tempfile()) {
       filename = tmp, width = width, height = height, units = 'in', res = dpi
     ), get_dargs(dev.args, 'png')))
   } else if (identical(dev, 'ragg_png')) {
-    # handle bg -> background gracefully
-    args = get_dargs(dev.args, 'ragg_png')
-    args$background = args$background %n% args$bg
-    args$bg = NULL
-    do.call(ragg::agg_png, c(list(
+    do.call(ragg_png_dev, c(list(
       filename = tmp, width = width, height = height, units = 'in', res = dpi
-    ), args))
+    ), get_dargs(dev.args, 'ragg_png')))
   } else if (identical(dev, 'tikz')) {
     dargs = c(list(
       file = tmp, width = width, height = height

--- a/R/plot.R
+++ b/R/plot.R
@@ -58,6 +58,16 @@ tikz_dev = function(...) {
   tikzDevice::tikz(..., packages = c('\n\\nonstopmode\n', packages, .knitEnv$tikzPackages))
 }
 
+# a wrapper of the ragg::agg_png device
+ragg_png_dev = function(...) {
+  loadNamespace('ragg')
+  args = list(...)
+  # handle bg -> background gracefully
+  args$background = args$background %n% args$bg
+  args$bg = NULL
+  do.call(ragg::agg_png, args)
+}
+
 # save a recorded plot
 save_plot = function(plot, name, dev, width, height, ext, dpi, options) {
 
@@ -112,7 +122,7 @@ save_plot = function(plot, name, dev, width, height, ext, dpi, options) {
 
     # similar to load_device(), but the `dpi` argument is named `res`
     ragg_png = function(...) {
-      ragg::agg_png(..., res = dpi, units = 'in')
+      ragg_png_dev(..., res = dpi, units = 'in')
     },
 
     tikz = function(...) {

--- a/tests/testit/test-plot.R
+++ b/tests/testit/test-plot.R
@@ -90,6 +90,17 @@ if (requireNamespace("ragg", quietly = TRUE) &&
       TRUE
     }
   )
+  assert(
+    'ragg_png_dev correctly handles bg dev.arg into background arg',
+    {
+      chunk_device(opts_chunk$merge(list(
+        dev = 'ragg_png', dev.args = list(bg = "grey")
+      )))
+      plot(1:10)
+      dev.off()
+      TRUE
+    }
+  )
 }
 # should not error (find `pdf` correctly in grDevices, instead of the one
 # defined below)

--- a/tests/testit/test-plot.R
+++ b/tests/testit/test-plot.R
@@ -77,7 +77,20 @@ if (!has_error({png(); dev.off()})) assert(
     TRUE
   }
 )
-
+if (requireNamespace("ragg", quietly = TRUE) &&
+    !has_error({ragg::agg_png(); dev.off()})) {
+  assert(
+    'chunk_device() correctly opens the ragg::agg_png device with dev.args',
+    {
+      chunk_device(opts_chunk$merge(list(
+        dev = 'ragg_png', dev.args = list(pdf = list(useDingbats = FALSE))
+      )))
+      plot(1:10)
+      dev.off()
+      TRUE
+    }
+  )
+}
 # should not error (find `pdf` correctly in grDevices, instead of the one
 # defined below)
 pdf = function() {}


### PR DESCRIPTION
This will fix #1845 by 

* using internal `get_dargs` function that knows how to handle the different type of `dev.arg` object
* add test like for `png` device

It completes the addition of the device in #1834 