### PR TITLE
Pass options to showtext()

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -128,7 +128,7 @@ plot2dev = function(plot, name, dev, device, path, width, height, options) {
   dargs = get_dargs(options$dev.args, dev)
   # re-plot the recorded plot to an off-screen device
   do.call(device, c(list(path, width = width, height = height), dargs))
-  showtext(options$fig.showtext)  # showtext support
+  showtext(options)  # maybe begin showtext and set options
   print(plot)
   dev.off()
 


### PR DESCRIPTION
This commit https://github.com/yihui/knitr/commit/c363362d621d171d0943866cbe3bb2d92dd26d9e forgot about a call to `showtext()` in `R/plot.R`...it now takes options instead of `TRUE`/`FALSE`.

(R plots are currently broken on master)