### PR TITLE
kable() in LaTeX mode to typeset numeric columns in math mode.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.52.1
+Version: 1.52.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - For the `tikz` engine, the class options of the `standalone` document classs can be specified via the chunk option `engine.opts$classoption` (thanks, @XiangyunHuang, #1985). The default value is `tikz`, i.e., `\documentclass[tikz]{standalone}` is used by default.
 
+- `kable()` operating in LaTeX mode now typesets numeric columns in math mode for improved rendering of minus signs; decimal and thousands separator commas are wrapped in braces (`{}`) to preserve spacing (thanks, @krivit, #1709).
+
 ## MAJOR CHANGES
 
 - An error is now thrown when an inline code result is not coercible to character. This has always been the assumed behavior but it happens to be different in certain formats with unknown automatic coercion. This is now enforced to prevent any unexpected output. An inline code expression must evaluate to a character vector or an object coercible by `as.character()` (#2006).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- `kable()` operating in LaTeX mode now typesets numeric columns in math mode for improved rendering of minus signs; decimal and thousands separator commas are wrapped in braces (`{}`) to preserve spacing (thanks, @krivit, #1709).
+- `kable()` operating in LaTeX mode can now optionally typeset numeric columns in math mode for improved rendering of minus signs, infinite values, and scientific notation; in particular, decimal and thousands separator commas are wrapped in braces (`{}`) to preserve spacing (thanks, @krivit, #1709).
 
 # CHANGES IN knitr VERSION 1.52
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- `kable()` operating in LaTeX mode can now optionally typeset numeric columns in math mode for improved rendering of minus signs, infinite values, and scientific notation; in particular, decimal and thousands separator commas are wrapped in braces (`{}`) to preserve spacing (thanks, @krivit, #1709).
+- `kable()` operating in LaTeX mode can now optionally typeset numeric columns in math mode for improved rendering of minus signs, infinite values, and scientific notation; in particular, decimal and thousands separator commas are wrapped in braces (`{}`) to preserve spacing. To enable, use `kable(..., numeric.math = TRUE)` or set `options(knitr.table.numeric.math = TRUE)` globally (thanks, @krivit, #1709).
 
 # CHANGES IN knitr VERSION 1.52
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN knitr VERSION 1.53
 
+## NEW FEATURES
+
+- `kable()` operating in LaTeX mode now typesets numeric columns in math mode for improved rendering of minus signs; decimal and thousands separator commas are wrapped in braces (`{}`) to preserve spacing (thanks, @krivit, #1709).
 
 # CHANGES IN knitr VERSION 1.52
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- `kable()` operating in LaTeX mode can now optionally typeset numeric columns in math mode for improved rendering of minus signs, infinite values, and scientific notation; in particular, decimal and thousands separator commas are wrapped in braces (`{}`) to preserve spacing. To enable, use `kable(..., numeric.math = TRUE)` or set `options(knitr.table.numeric.math = TRUE)` globally (thanks, @krivit, #1709).
+- `kable()` operating in LaTeX mode can now optionally typeset numeric columns in math mode for improved rendering of minus signs, infinite values, and scientific notation; in particular, decimal and thousands separator commas are wrapped in braces (`{}`) to preserve spacing. To enable, use `kable(..., format = "latex", numeric.math = TRUE)` or set `options(knitr.table.numeric.math = TRUE)` globally (thanks, @krivit, #1709).
 
 # CHANGES IN knitr VERSION 1.52
 

--- a/R/table.R
+++ b/R/table.R
@@ -144,6 +144,7 @@ kable = function(
     x = cbind(' ' = rownames(x), x)
     if (!is.null(col.names)) col.names = c(' ', col.names)
     if (!is.null(align)) align = c('l', align)  # left align row names
+    isn = c(FALSE, isn)
   }
   n = nrow(x)
   x = replace_na(to_character(x), is.na(x))
@@ -157,7 +158,7 @@ kable = function(
   if (format == 'simple' && nrow(x) == 0) format = 'pipe'
   res = do.call(
     paste('kable', format, sep = '_'),
-    list(x = x, caption = caption, escape = escape, ...)
+    list(x = x, caption = caption, escape = escape, isn = isn,...)
   )
   structure(res, format = format, class = 'knitr_kable')
 }
@@ -281,7 +282,7 @@ kable_latex = function(
   midrule = getOption('knitr.table.midrule', if (booktabs) '\\midrule' else '\\hline'),
   linesep = if (booktabs) c('', '', '', '', '\\addlinespace') else '\\hline',
   caption = NULL, caption.short = '', table.envir = if (!is.null(caption)) 'table',
-  escape = TRUE
+  escape = TRUE, isn = logical(ncol(x))
 ) {
   if (!is.null(align <- attr(x, 'align'))) {
     align = paste(align, collapse = vline)
@@ -308,6 +309,7 @@ kable_latex = function(
   linesep = ifelse(linesep == "", linesep, paste0('\n', linesep))
 
   x = escape_latex_table(x, escape, booktabs)
+  x[, isn] = paste0('\\(', gsub(',', '{,}', x[, isn], fixed=TRUE), '\\)')
   if (!is.character(toprule)) toprule = NULL
   if (!is.character(bottomrule)) bottomrule = NULL
   tabular = if (longtable) 'longtable' else 'tabular'

--- a/R/table.R
+++ b/R/table.R
@@ -48,6 +48,11 @@
 #' @param escape Whether to escape special characters when producing HTML or
 #'   LaTeX tables. When `escape = FALSE`, you have to make sure that
 #'   special characters will not trigger syntax errors in LaTeX or HTML.
+#' @param numeric.math Whether to typeset numeric columns in math
+#'   mode. This option currently only affects LaTeX output, in which
+#'   it improves typesetting of minus signs, infinite values, and
+#'   scientific notation. The default can be set globally with option
+#'   `knitr.table.numeric.math`.
 #' @param ... Other arguments (see Examples and References).
 #' @return A character vector of the table source code.
 #' @seealso Other R packages such as \pkg{huxtable}, \pkg{xtable},
@@ -105,7 +110,7 @@
 kable = function(
   x, format, digits = getOption('digits'), row.names = NA, col.names = NA,
   align, caption = opts_current$get('tab.cap'), label = NULL, format.args = list(),
-  escape = TRUE, ...
+  escape = TRUE, numeric.math = getOption('knitr.table.numeric.math', FALSE), ...
 ) {
 
   format = kable_format(format)
@@ -118,7 +123,7 @@ kable = function(
     res = lapply(
       x, kable, format = format, digits = digits, row.names = row.names,
       col.names = col.names, align = align, caption = NA,
-      format.args = format.args, escape = escape, ...
+      format.args = format.args, escape = escape, numeric.math = numeric.math, ...
     )
     return(kables(res, format, caption, label))
   }
@@ -166,7 +171,7 @@ kable = function(
   if (format == 'simple' && nrow(x) == 0) format = 'pipe'
   res = do.call(
     paste('kable', format, sep = '_'),
-    list(x = x, caption = caption, escape = escape, isn = isn,...)
+    list(x = x, caption = caption, escape = escape, isn = isn & numeric.math, ...)
   )
   structure(res, format = format, class = 'knitr_kable')
 }
@@ -323,7 +328,7 @@ kable_latex = function(
   linesep = ifelse(linesep == "", linesep, paste0('\n', linesep))
 
   x = escape_latex_table(x, escape, booktabs)
-  x[, isn] = paste0('\\(', gsub(',', '{,}', x[, isn], fixed=TRUE), '\\)')
+  x[, isn] = transform_num_for_latex(x[, isn])
   if (!is.character(toprule)) toprule = NULL
   if (!is.character(bottomrule)) bottomrule = NULL
 

--- a/R/table.R
+++ b/R/table.R
@@ -151,6 +151,7 @@ kable = function(
     x = cbind(' ' = rownames(x), x)
     if (!is.null(col.names)) col.names = tail(c(' ', col.names), ncol(x))
     if (!is.null(align)) align = c('l', align)  # left align row names
+    isn = c(FALSE, isn)
   }
   n = nrow(x)
   x = replace_na(to_character(x), is.na(x))
@@ -165,7 +166,7 @@ kable = function(
   if (format == 'simple' && nrow(x) == 0) format = 'pipe'
   res = do.call(
     paste('kable', format, sep = '_'),
-    list(x = x, caption = caption, escape = escape, ...)
+    list(x = x, caption = caption, escape = escape, isn = isn,...)
   )
   structure(res, format = format, class = 'knitr_kable')
 }
@@ -295,7 +296,7 @@ kable_latex = function(
   midrule = getOption('knitr.table.midrule', if (booktabs) '\\midrule' else '\\hline'),
   linesep = if (booktabs) c('', '', '', '', '\\addlinespace') else '\\hline',
   caption = NULL, caption.short = '', table.envir = if (!is.null(caption)) 'table',
-  escape = TRUE, ...
+  escape = TRUE, isn = logical(ncol(x)), ...
 ) {
   if (!is.null(align <- attr(x, 'align'))) {
     align = paste(align, collapse = vline)
@@ -322,6 +323,7 @@ kable_latex = function(
   linesep = ifelse(linesep == "", linesep, paste0('\n', linesep))
 
   x = escape_latex_table(x, escape, booktabs)
+  x[, isn] = paste0('\\(', gsub(',', '{,}', x[, isn], fixed=TRUE), '\\)')
   if (!is.character(toprule)) toprule = NULL
   if (!is.character(bottomrule)) bottomrule = NULL
 

--- a/R/table.R
+++ b/R/table.R
@@ -48,12 +48,14 @@
 #' @param escape Whether to escape special characters when producing HTML or
 #'   LaTeX tables. When `escape = FALSE`, you have to make sure that
 #'   special characters will not trigger syntax errors in LaTeX or HTML.
-#' @param numeric.math Whether to typeset numeric columns in math
-#'   mode. This option currently only affects LaTeX output, in which
-#'   it improves typesetting of minus signs, infinite values, and
-#'   scientific notation. The default can be set globally with option
-#'   `knitr.table.numeric.math`.
 #' @param ... Other arguments (see Examples and References).
+#' @section Arguments for the \code{latex} format:
+#' \describe{
+#'   \item{`numeric.math`}{Whether to typeset numeric columns in math mode,
+#'   which improves rendering of minus signs, infinite values, and scientific
+#'   notation. The default can be set globally via
+#'   `options(knitr.table.numeric.math = TRUE)`.}
+#' }
 #' @return A character vector of the table source code.
 #' @seealso Other R packages such as \pkg{huxtable}, \pkg{xtable},
 #'   \pkg{kableExtra}, \pkg{gt} and \pkg{tables} for HTML and LaTeX tables, and
@@ -110,7 +112,7 @@
 kable = function(
   x, format, digits = getOption('digits'), row.names = NA, col.names = NA,
   align, caption = opts_current$get('tab.cap'), label = NULL, format.args = list(),
-  escape = TRUE, numeric.math = getOption('knitr.table.numeric.math', FALSE), ...
+  escape = TRUE, ...
 ) {
 
   format = kable_format(format)
@@ -123,7 +125,7 @@ kable = function(
     res = lapply(
       x, kable, format = format, digits = digits, row.names = row.names,
       col.names = col.names, align = align, caption = NA,
-      format.args = format.args, escape = escape, numeric.math = numeric.math, ...
+      format.args = format.args, escape = escape, ...
     )
     return(kables(res, format, caption, label))
   }
@@ -136,19 +138,19 @@ kable = function(
   if (identical(col.names, NA)) col.names = colnames(x)
   m = ncol(x)
   # numeric columns
-  isn = if (is.matrix(x)) rep(is.numeric(x), m) else sapply(x, is.numeric)
+  is_num = if (is.matrix(x)) rep(is.numeric(x), m) else sapply(x, is.numeric)
   if (missing(align) || (format == 'latex' && is.null(align)))
-    align = ifelse(isn, 'r', 'l')
+    align = ifelse(is_num, 'r', 'l')
   # rounding
   digits = rep(digits, length.out = m)
   for (j in seq_len(m)) {
     if (is_numeric(x[, j])) x[, j] = round(x[, j], digits[j])
   }
-  if (any(isn)) {
+  if (any(is_num)) {
     if (is.matrix(x)) {
       if (is.table(x) && length(dim(x)) == 2) class(x) = 'matrix'
       x = format_matrix(x, format.args)
-    } else x[, isn] = format_args(x[, isn], format.args)
+    } else x[, is_num] = format_args(x[, is_num], format.args)
   }
   if (is.na(row.names)) row.names = has_rownames(x)
   if (!is.null(align)) align = rep(align, length.out = m)
@@ -156,7 +158,7 @@ kable = function(
     x = cbind(' ' = rownames(x), x)
     if (!is.null(col.names)) col.names = tail(c(' ', col.names), ncol(x))
     if (!is.null(align)) align = c('l', align)  # left align row names
-    isn = c(FALSE, isn)
+    is_num = c(FALSE, is_num)
   }
   n = nrow(x)
   x = replace_na(to_character(x), is.na(x))
@@ -167,11 +169,12 @@ kable = function(
   if (format != 'latex' && length(align) && !all(align %in% c('l', 'r', 'c')))
     stop("'align' must be a character vector of possible values 'l', 'r', and 'c'")
   attr(x, 'align') = align
+  attr(x, 'is_num') = is_num
   # simple tables do not 0-row tables (--- will be treated as an hr line)
   if (format == 'simple' && nrow(x) == 0) format = 'pipe'
   res = do.call(
     paste('kable', format, sep = '_'),
-    list(x = x, caption = caption, escape = escape, isn = isn & numeric.math, ...)
+    list(x = x, caption = caption, escape = escape, ...)
   )
   structure(res, format = format, class = 'knitr_kable')
 }
@@ -301,7 +304,7 @@ kable_latex = function(
   midrule = getOption('knitr.table.midrule', if (booktabs) '\\midrule' else '\\hline'),
   linesep = if (booktabs) c('', '', '', '', '\\addlinespace') else '\\hline',
   caption = NULL, caption.short = '', table.envir = if (!is.null(caption)) 'table',
-  escape = TRUE, isn = logical(ncol(x)), ...
+  escape = TRUE, numeric.math = getOption('knitr.table.numeric.math', FALSE), ...
 ) {
   if (!is.null(align <- attr(x, 'align'))) {
     align = paste(align, collapse = vline)
@@ -328,7 +331,8 @@ kable_latex = function(
   linesep = ifelse(linesep == "", linesep, paste0('\n', linesep))
 
   x = escape_latex_table(x, escape, booktabs)
-  x[, isn] = transform_num_for_latex(x[, isn])
+  if (numeric.math && any(is_num <- attr(x, 'is_num')))
+    x[, is_num] = latex_num(x[, is_num])
   if (!is.character(toprule)) toprule = NULL
   if (!is.character(bottomrule)) bottomrule = NULL
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -240,6 +240,19 @@ format_sci = function(x, ...) {
   vapply(x, format_sci_one, character(1L), ..., USE.NAMES = FALSE)
 }
 
+# unlike the format_sci() family above, this function is given only
+# characters and has to infer from their structure
+transform_num_for_latex = function(x, times = getOption('knitr.inline.times', '\\times ')) {
+  ifelse(x == "Inf", "\\(\\infty\\)",
+  ifelse(x == "-Inf", "\\(-\\infty\\)",
+  # plain old numbers:
+  ifelse(grepl("^ *[0-9., +-]+ *$", x), paste0('\\(', gsub(',', '{,}', x, fixed=TRUE), '\\)'),
+  # scientific notation: initial + and 0s (unless the only 0) in the exponent get dropped
+  ifelse(lengths(sci <- regmatches(x, regexec("^ *([+-]?[0-9.,]+)e[+]?(-?)0*([0-9.,]+) *$", x))),
+         vapply(sci, function(m) if (length(m)) gsub(',', '{,}', sprintf('\\(%s%s10^{%s%s}\\)', m[2], times, m[3], m[4]), fixed=TRUE)
+                                 else "", ""), x))))
+}
+
 # is tikz device without externalization?
 is_tikz_dev = function(options) {
   'tikz' %in% options$dev && !options$external

--- a/R/utils.R
+++ b/R/utils.R
@@ -240,17 +240,41 @@ format_sci = function(x, ...) {
   vapply(x, format_sci_one, character(1L), ..., USE.NAMES = FALSE)
 }
 
-# unlike the format_sci() family above, this function is given only
-# characters and has to infer from their structure
-transform_num_for_latex = function(x, times = getOption('knitr.inline.times', '\\times ')) {
-  ifelse(x == "Inf", "\\(\\infty\\)",
-  ifelse(x == "-Inf", "\\(-\\infty\\)",
-  # plain old numbers:
-  ifelse(grepl("^ *[0-9., +-]+ *$", x), paste0('\\(', gsub(',', '{,}', x, fixed=TRUE), '\\)'),
-  # scientific notation: initial + and 0s (unless the only 0) in the exponent get dropped
-  ifelse(lengths(sci <- regmatches(x, regexec("^ *([+-]?[0-9.,]+)e[+]?(-?)0*([0-9.,]+) *$", x))),
-         vapply(sci, function(m) if (length(m)) gsub(',', '{,}', sprintf('\\(%s%s10^{%s%s}\\)', m[2], times, m[3], m[4]), fixed=TRUE)
-                                 else "", ""), x))))
+# wrap a character vector of formatted numbers in LaTeX math mode;
+# x is already stringified (e.g. by format_args()), so we parse structure from strings
+latex_num = function(x, times = getOption('knitr.inline.times', '\\times ')) {
+  brace_comma = function(s) gsub(',', '{,}', s, fixed = TRUE)
+  math = function(s) paste0('\\(', s, '\\)')
+
+  # scientific notation: capture base, sign of exponent, and exponent digits;
+  # zero-exponent (e.g. "0e+00") is treated as plain zero below
+  sci_pat  = "^ *([+-]?[0-9.,]+)e[+]?(-?)0*([1-9][0-9]*) *$"
+  zero_sci = grepl("^ *[+-]?[0-9.,]+e[+]?0+ *$", x)
+  is_sci   = grepl(sci_pat, x)
+  is_inf   = x %in% c("Inf", "-Inf")
+  is_plain = !is_sci & !is_inf & !zero_sci & grepl("^ *[0-9., +-]+ *$", x)
+
+  out = x  # non-numeric (NA, NaN, ...) pass through unchanged
+
+  out[x == "Inf"]  = math("\\infty")
+  out[x == "-Inf"] = math("-\\infty")
+  out[zero_sci] = math("0")
+  out[is_plain] = math(brace_comma(x[is_plain]))
+
+  if (any(is_sci)) {
+    m = regmatches(x[is_sci], regexec(sci_pat, x[is_sci]))
+    out[is_sci] = vapply(m, function(parts) {
+      base = brace_comma(parts[2])
+      exp  = paste0(parts[3], parts[4])
+      if (base %in% c('1', '-1')) {
+        math(sprintf('%s10^{%s}', if (base == '-1') '-' else '', exp))
+      } else {
+        math(sprintf('%s%s10^{%s}', base, times, exp))
+      }
+    }, character(1))
+  }
+
+  out
 }
 
 # is tikz device without externalization?

--- a/man/kable.Rd
+++ b/man/kable.Rd
@@ -16,7 +16,6 @@ kable(
   label = NULL,
   format.args = list(),
   escape = TRUE,
-  numeric.math = getOption("knitr.table.numeric.math", FALSE),
   ...
 )
 
@@ -66,12 +65,6 @@ to format table values, e.g. \code{list(big.mark = ',')}.}
 LaTeX tables. When \code{escape = FALSE}, you have to make sure that
 special characters will not trigger syntax errors in LaTeX or HTML.}
 
-\item{numeric.math}{Whether to typeset numeric columns in math
-mode. This option currently only affects LaTeX output, in which
-it improves typesetting of minus signs, infinite values, and
-scientific notation. The default can be set globally with option
-\code{knitr.table.numeric.math}.}
-
 \item{...}{Other arguments (see Examples and References).}
 }
 \value{
@@ -101,44 +94,56 @@ need to explicitly \code{print()} it due to R's automatic implicit
 printing. When it is wrapped inside other expressions (such as a
 \code{for} loop), you must explicitly \code{print(kable(...))}.
 }
+\section{Arguments for the \code{latex} format}{
+
+\describe{
+\item{\code{numeric.math}}{Whether to typeset numeric columns in math mode,
+which improves rendering of minus signs, infinite values, and scientific
+notation. The default can be set globally via
+\code{options(knitr.table.numeric.math = TRUE)}.}
+}
+}
+
 \examples{
-d1 = head(iris); d2 = head(mtcars)
+d1 = head(iris)
+d2 = head(mtcars)
 # pipe tables by default
 kable(d1)
 kable(d2[, 1:5])
 # no inner padding
-kable(d2, format = 'pipe', padding = 0)
+kable(d2, format = "pipe", padding = 0)
 # more padding
-kable(d2, format = 'pipe', padding = 2)
-kable(d1, format = 'latex')
-kable(d1, format = 'html')
-kable(d1, format = 'latex', caption = 'Title of the table')
-kable(d1, format = 'html', caption = 'Title of the table')
+kable(d2, format = "pipe", padding = 2)
+kable(d1, format = "latex")
+kable(d1, format = "html")
+kable(d1, format = "latex", caption = "Title of the table")
+kable(d1, format = "html", caption = "Title of the table")
 # use the booktabs package
-kable(mtcars, format = 'latex', booktabs = TRUE)
+kable(mtcars, format = "latex", booktabs = TRUE)
 # use the longtable package
-kable(matrix(1000, ncol=5), format = 'latex', digits = 2, longtable = TRUE)
+kable(matrix(1000, ncol = 5), format = "latex", digits = 2, longtable = TRUE)
 # change LaTeX default table environment
-kable(d1, format = "latex", caption = "My table", table.envir='table*')
+kable(d1, format = "latex", caption = "My table", table.envir = "table*")
 # add some table attributes
-kable(d1, format = 'html', table.attr = 'id="mytable"')
+kable(d1, format = "html", table.attr = "id=\"mytable\"")
 # reST output
-kable(d2, format = 'rst')
+kable(d2, format = "rst")
 # no row names
-kable(d2, format = 'rst', row.names = FALSE)
+kable(d2, format = "rst", row.names = FALSE)
 # Pandoc simple tables
-kable(d2, format = 'simple', caption = 'Title of the table')
+kable(d2, format = "simple", caption = "Title of the table")
 # format numbers using , as decimal point, and ' as thousands separator
-x = as.data.frame(matrix(rnorm(60, 1e6, 1e4), 10))
-kable(x, format.args = list(decimal.mark = ',', big.mark = "'"))
+x = as.data.frame(matrix(rnorm(60, 1e+06, 10000), 10))
+kable(x, format.args = list(decimal.mark = ",", big.mark = "'"))
 # save the value
-x = kable(d2, format = 'html')
-cat(x, sep = '\n')
+x = kable(d2, format = "html")
+cat(x, sep = "\n")
 # can also set options(knitr.table.format = 'html') so that the output is HTML
 
-# multiple tables via either kable(list(x1, x2)) or kables(list(kable(x1), kable(x2)))
-kable(list(d1, d2), caption = 'A tale of two tables')
-kables(list(kable(d1, align = 'l'), kable(d2)), caption = 'A tale of two tables')
+# multiple tables via either kable(list(x1, x2)) or kables(list(kable(x1),
+# kable(x2)))
+kable(list(d1, d2), caption = "A tale of two tables")
+kables(list(kable(d1, align = "l"), kable(d2)), caption = "A tale of two tables")
 }
 \references{
 See

--- a/man/kable.Rd
+++ b/man/kable.Rd
@@ -16,6 +16,7 @@ kable(
   label = NULL,
   format.args = list(),
   escape = TRUE,
+  numeric.math = getOption("knitr.table.numeric.math", FALSE),
   ...
 )
 
@@ -65,6 +66,12 @@ to format table values, e.g. \code{list(big.mark = ',')}.}
 LaTeX tables. When \code{escape = FALSE}, you have to make sure that
 special characters will not trigger syntax errors in LaTeX or HTML.}
 
+\item{numeric.math}{Whether to typeset numeric columns in math
+mode. This option currently only affects LaTeX output, in which
+it improves typesetting of minus signs, infinite values, and
+scientific notation. The default can be set globally with option
+\code{knitr.table.numeric.math}.}
+
 \item{...}{Other arguments (see Examples and References).}
 }
 \value{
@@ -95,45 +102,43 @@ printing. When it is wrapped inside other expressions (such as a
 \code{for} loop), you must explicitly \code{print(kable(...))}.
 }
 \examples{
-d1 = head(iris)
-d2 = head(mtcars)
+d1 = head(iris); d2 = head(mtcars)
 # pipe tables by default
 kable(d1)
 kable(d2[, 1:5])
 # no inner padding
-kable(d2, format = "pipe", padding = 0)
+kable(d2, format = 'pipe', padding = 0)
 # more padding
-kable(d2, format = "pipe", padding = 2)
-kable(d1, format = "latex")
-kable(d1, format = "html")
-kable(d1, format = "latex", caption = "Title of the table")
-kable(d1, format = "html", caption = "Title of the table")
+kable(d2, format = 'pipe', padding = 2)
+kable(d1, format = 'latex')
+kable(d1, format = 'html')
+kable(d1, format = 'latex', caption = 'Title of the table')
+kable(d1, format = 'html', caption = 'Title of the table')
 # use the booktabs package
-kable(mtcars, format = "latex", booktabs = TRUE)
+kable(mtcars, format = 'latex', booktabs = TRUE)
 # use the longtable package
-kable(matrix(1000, ncol = 5), format = "latex", digits = 2, longtable = TRUE)
+kable(matrix(1000, ncol=5), format = 'latex', digits = 2, longtable = TRUE)
 # change LaTeX default table environment
-kable(d1, format = "latex", caption = "My table", table.envir = "table*")
+kable(d1, format = "latex", caption = "My table", table.envir='table*')
 # add some table attributes
-kable(d1, format = "html", table.attr = "id=\"mytable\"")
+kable(d1, format = 'html', table.attr = 'id="mytable"')
 # reST output
-kable(d2, format = "rst")
+kable(d2, format = 'rst')
 # no row names
-kable(d2, format = "rst", row.names = FALSE)
+kable(d2, format = 'rst', row.names = FALSE)
 # Pandoc simple tables
-kable(d2, format = "simple", caption = "Title of the table")
+kable(d2, format = 'simple', caption = 'Title of the table')
 # format numbers using , as decimal point, and ' as thousands separator
-x = as.data.frame(matrix(rnorm(60, 1e+06, 10000), 10))
-kable(x, format.args = list(decimal.mark = ",", big.mark = "'"))
+x = as.data.frame(matrix(rnorm(60, 1e6, 1e4), 10))
+kable(x, format.args = list(decimal.mark = ',', big.mark = "'"))
 # save the value
-x = kable(d2, format = "html")
-cat(x, sep = "\n")
+x = kable(d2, format = 'html')
+cat(x, sep = '\n')
 # can also set options(knitr.table.format = 'html') so that the output is HTML
 
-# multiple tables via either kable(list(x1, x2)) or kables(list(kable(x1),
-# kable(x2)))
-kable(list(d1, d2), caption = "A tale of two tables")
-kables(list(kable(d1, align = "l"), kable(d2)), caption = "A tale of two tables")
+# multiple tables via either kable(list(x1, x2)) or kables(list(kable(x1), kable(x2)))
+kable(list(d1, d2), caption = 'A tale of two tables')
+kables(list(kable(d1, align = 'l'), kable(d2)), caption = 'A tale of two tables')
 }
 \references{
 See

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -36,9 +36,22 @@ assert('kable() does not add extra spaces to character columns', {
 \\hline
 x & y\\\\
 \\hline
-1.20 & fooooo\\\\
+\\(1.20\\) & fooooo\\\\
 \\hline
-4.87 & bar\\\\
+\\(4.87\\) & bar\\\\
+\\hline
+\\end{tabular}'
+})
+
+assert('kable() in LaTeX mode formats minus signs and decimal and thousands separators correctly', {
+  kable2(data.frame(x = c(-1111, 2222), y = c(1111, -0.5), z = c('text,comma', '-0.5')), 'latex', format.arg=list(big.mark = ',')) %==% '
+\\begin{tabular}{r|r|l}
+\\hline
+x & y & z\\\\
+\\hline
+\\(-1{,}111\\) & \\(1{,}111.0\\) & text,comma\\\\
+\\hline
+\\(2{,}222\\) & \\(-0.5\\) & -0.5\\\\
 \\hline
 \\end{tabular}')
 })
@@ -89,11 +102,11 @@ assert('kable(format = "latex", linesep = ...) works', {
 \\hline
 x\\\\
 \\hline
-1\\\\
-2\\\\
-3\\\\
+\\(1\\)\\\\
+\\(2\\)\\\\
+\\(3\\)\\\\
 \\midrule
-4\\\\
+\\(4\\)\\\\
 \\hline
 \\end{tabular}')
 })

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -74,6 +74,17 @@ w & x & y & z\\\\
 \\(-5.000\\times 10^{-6}\\) & \\(-\\infty\\) & \\(-0.5\\) & -0.5\\\\
 \\hline
 \\end{tabular}'
+  # zero in a sci-notation column renders as \(0\), not \(0\times 10^{0}\)
+  kable2(data.frame(x = c(0, 1e-5)), 'latex', numeric.math = TRUE) %==% '
+\\begin{tabular}{r}
+\\hline
+x\\\\
+\\hline
+\\(0\\)\\\\
+\\hline
+\\(10^{-5}\\)\\\\
+\\hline
+\\end{tabular}'
 })
 
 assert('kable() escapes LaTeX special characters by default', {

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -55,22 +55,23 @@ assert('kable() does not add extra spaces to character columns', {
 \\hline
 x & y\\\\
 \\hline
-\\(1.20\\) & fooooo\\\\
+1.20 & fooooo\\\\
 \\hline
-\\(4.87\\) & bar\\\\
+4.87 & bar\\\\
 \\hline
 \\end{tabular}')
 })
 
-assert('kable() in LaTeX mode formats minus signs and decimal and thousands separators correctly', {
-  kable2(data.frame(x = c(-1111, 2222), y = c(1111, -0.5), z = c('text,comma', '-0.5')), 'latex', format.args=list(big.mark = ',')) %==% '
-\\begin{tabular}{r|r|l}
+assert('kable() in LaTeX mode formats minus signs, infinities, scientific notation, and decimal and thousands separators correctly', {
+  kable2(data.frame(w = c(1111e10, -0.5e-5), x = c(-1111, -Inf), y = c(1111, -0.5), z = c('text,comma', '-0.5')), 'latex',
+         format.args = list(big.mark = ','), numeric.math = TRUE) %==% '
+\\begin{tabular}{r|r|r|l}
 \\hline
-x & y & z\\\\
+w & x & y & z\\\\
 \\hline
-\\(-1{,}111\\) & \\(1{,}111.0\\) & text,comma\\\\
+\\(1.111\\times 10^{13}\\) & \\(-1{,}111\\) & \\(1{,}111.0\\) & text,comma\\\\
 \\hline
-\\(2{,}222\\) & \\(-0.5\\) & -0.5\\\\
+\\(-5.000\\times 10^{-6}\\) & \\(-\\infty\\) & \\(-0.5\\) & -0.5\\\\
 \\hline
 \\end{tabular}'
 })
@@ -130,8 +131,8 @@ assert('kable() adds {} before [] when booktabs = TRUE', {
 \\toprule
 x & y\\\\
 \\midrule
-{}[0, 1] & \\(35\\)\\\\
-(1, 2] & \\(62\\)\\\\
+{}[0, 1] & 35\\\\
+(1, 2] & 62\\\\
 \\bottomrule
 \\end{tabular}'
    )
@@ -143,11 +144,11 @@ assert('kable(format = "latex", linesep = ...) works', {
 \\hline
 x\\\\
 \\hline
-\\(1\\)\\\\
-\\(2\\)\\\\
-\\(3\\)\\\\
+1\\\\
+2\\\\
+3\\\\
 \\midrule
-\\(4\\)\\\\
+4\\\\
 \\hline
 \\end{tabular}')
 })

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -55,11 +55,24 @@ assert('kable() does not add extra spaces to character columns', {
 \\hline
 x & y\\\\
 \\hline
-1.20 & fooooo\\\\
+\\(1.20\\) & fooooo\\\\
 \\hline
-4.87 & bar\\\\
+\\(4.87\\) & bar\\\\
 \\hline
 \\end{tabular}')
+})
+
+assert('kable() in LaTeX mode formats minus signs and decimal and thousands separators correctly', {
+  kable2(data.frame(x = c(-1111, 2222), y = c(1111, -0.5), z = c('text,comma', '-0.5')), 'latex', format.args=list(big.mark = ',')) %==% '
+\\begin{tabular}{r|r|l}
+\\hline
+x & y & z\\\\
+\\hline
+\\(-1{,}111\\) & \\(1{,}111.0\\) & text,comma\\\\
+\\hline
+\\(2{,}222\\) & \\(-0.5\\) & -0.5\\\\
+\\hline
+\\end{tabular}'
 })
 
 assert('kable() escapes LaTeX special characters by default', {
@@ -117,8 +130,8 @@ assert('kable() adds {} before [] when booktabs = TRUE', {
 \\toprule
 x & y\\\\
 \\midrule
-{}[0, 1] & 35\\\\
-(1, 2] & 62\\\\
+{}[0, 1] & \\(35\\)\\\\
+(1, 2] & \\(62\\)\\\\
 \\bottomrule
 \\end{tabular}'
    )
@@ -130,11 +143,11 @@ assert('kable(format = "latex", linesep = ...) works', {
 \\hline
 x\\\\
 \\hline
-1\\\\
-2\\\\
-3\\\\
+\\(1\\)\\\\
+\\(2\\)\\\\
+\\(3\\)\\\\
 \\midrule
-4\\\\
+\\(4\\)\\\\
 \\hline
 \\end{tabular}')
 })


### PR DESCRIPTION
This is a partial fix for #1709, addressing the `LaTeX` case by typesetting numeric columns in math mode and wrapping commas (as decimal or thousands separators) in braces (`{}`) for correct spacing. This is, in my opinion, the cleanest option that does not require additional `LaTeX` packages.

I've looked into the other output types (`pandoc`, `html`, `md`, etc.), but I am not quite sure what *should* be their output.

I've updated `NEWS.md` and `DESCRIPTION` to save time, and apologise for the presumption of adding myself as a contributor and adding "thanks" to myself. If this PR doesn't merit a line in the `DESCRIPTION`, I'll be happy to remove it.