### PR TITLE
moved screenshot check to knit_print.default()

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -657,17 +657,17 @@ add_html_caption = function(options, code) {
 #' # after you define and register the above method, data frames will be printed
 #' # as tables in knitr, which is different with the default print() behavior
 knit_print = function(x, ...) {
-  if (need_screenshot(x, ...)) {
-    html_screenshot(x)
-  } else {
-    UseMethod('knit_print')
-  }
+  UseMethod('knit_print')
 }
 
 #" the default print method is just print()/show()
 #' @export
 knit_print.default = function(x, ..., inline = FALSE) {
-  if (inline) x else normal_print(x)
+  if (need_screenshot(x, ...)) {
+    html_screenshot(x)
+  } else {
+    if (inline) x else normal_print(x)
+  }
 }
 
 #' @export


### PR DESCRIPTION
Referencing my comment in #1853 (itself a reference to #1852 ), in my very limited experience, I think it makes more sense to not immediately force a screenshot check on all objects being printed by `knit_print()`

For example, I want to make a custom method of plotting plotly plots (which inherit `'htmlwidget'`) like so:

```r
knit_print.plotly <- function(x, options, ...) {
  # To stop the `needs_screenshot()` function from using `html_screenshot()`
  options$screenshot.force <- FALSE
  knitr::knit_print(plot_plotly(x), options=options, ...)
}
```

Unfortunately, I'm never able to stop the `needs_screenshot()` function, because it's checked before my `knit_print` method is ever called.

Is there a reason not to put it this check in `knit_print.default()` like I do here, where it won't run rampant over user customization?
