### PR TITLE
Add more control to fig.link option

### DIFF
--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -46,6 +46,8 @@ hook_plot_md_base = function(x, options) {
   s = options$out.extra; a = options$fig.align
   ai = options$fig.show == 'asis'
   lnk = options$fig.link
+  lnktarget = options$fig.link.target 
+  lnkid = options$fig.link.id
   pandoc_html = cap != '' && is_html_output()
   in_bookdown = isTRUE(opts_knit$get('bookdown.internal.label'))
   plot1 = ai || options$fig.cur <= 1L
@@ -62,7 +64,7 @@ hook_plot_md_base = function(x, options) {
   }
   add_link = function(x) {
     if (is.null(lnk) || is.na(lnk)) return(x)
-    sprintf('<a href="%s" target="_blank">%s</a>', lnk, x)
+    sprintf('<a href="%s" target="%s" id="%s">%s</a>', lnk, lnktarget, lnkid, x)
   }
   # use HTML syntax <img src=...>
   if (pandoc_html && !isTRUE(grepl('-implicit_figures', from))) {


### PR DESCRIPTION
This is definitely **not a valid PR** but illustrates a desired feature enhancement, namely the addition of 2 new chunk options:
- `fig.link.target` to define the link behavior with possible values being:  '_blank' (default), '_self, '_parent' or '_top'
- `fig.link.id` for attributing a custom id to the `<a>` tag

I find that having these options will make it possible to have greater control on the figure and would allow to display it in a lightbox for instance (using the id as a javascript selector like this https://sachinchoolur.github.io/lightgallery.js/demos/html-markup.html) as for now there seems to be no reasonable way to do so.

An alternative to this could be to provide a `fig.link.out.extra` option that would behave just like `out.extra` but for the `<a>` tag.

If this proposal catches your attention, I can work on a proper PR.