### PR TITLE
Add an engine option to the tikz engine to add arbitrary LaTeX to the preamble.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,6 +79,7 @@ Authors@R: c(
     person("Niels Richard", "Hansen", role = "ctb"),
     person("Noam", "Ross", role = "ctb"),
     person("Obada", "Mahdi", role = "ctb"),
+    person("Pavel N.", "Krivitsky", role = "ctb", comment=c(ORCID = "0000-0002-9101-3362")),
     person("Qiang", "Li", role = "ctb"),
     person("Ramnath", "Vaidyanathan", role = "ctb"),
     person("Richard", "Cotton", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - When the chunk option `include = FALSE`, `error = TRUE` used to be ignored, i.e., errors are signaled nonetheless (causing the knitting process to fail). To avoid this problem, you can now use the numeric value `error = 0` so that **knitr** will not check the `include` option, i.e., knitting will not fail even if `include = FALSE` and an error has occurred in a code chunk, which you wouldn't notice (thanks, @rundel, #1914).
 
+- For `tikz` code chunks, a new option `engine.opts$extra.preamble` allows arbitrary LaTeX code to be inserted into the preamble of the template. This allows loading of additional LaTeX and tikz libraries without having to recreate a template from scratch (thanks, @krivit, #1886).
+
 ## BUG FIXES
 
 - Fixed an issue where code source and results would not show when using a numeric vector in `fig.keep` to select all plots (thanks, @dongzhuoer @ajrgodfrey #1579, @cderv #1955).
@@ -95,8 +97,6 @@
 - `knitr::write_bib()` uses the `URL` in the package `DESCRIPTION` if it is provided, instead of the canonical CRAN URL for the package.
 
 - `hook_pdfcrop()` and `plot_crop()` will work only when both programs `pdfcrop` and `ghostscript` have been installed. Previously only `pdfcrop` was checked (thanks, @dalupus, #954).
-
-- For `tikz` chunks, a new option `engine.opts$extra_preamble` allows arbitrary LaTeX to be inserted into the chunk's preamble. This allows loading of additional LaTeX and tikz libraries without having to recreate a template from scratch.
 
 # CHANGES IN knitr VERSION 1.29
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,8 @@
 
 - `hook_pdfcrop()` and `plot_crop()` will work only when both programs `pdfcrop` and `ghostscript` have been installed. Previously only `pdfcrop` was checked (thanks, @dalupus, #954).
 
+- For `tikz` chunks, a new option `engine.opts$extra_preamble` allows arbitrary LaTeX to be inserted into the chunk's preamble. This allows loading of additional LaTeX and tikz libraries without having to recreate a template from scratch.
+
 # CHANGES IN knitr VERSION 1.29
 
 ## NEW FEATURES

--- a/R/engine.R
+++ b/R/engine.R
@@ -279,6 +279,15 @@ eng_tikz = function(options) {
 
   lines = read_utf8(options$engine.opts$template %n%
                     system.file('misc', 'tikz2pdf.tex', package = 'knitr'))
+
+  if (!is.null(options$engine.opts$extra_preamble)) {
+    i = grep('%% EXTRA_TIKZ_PREAMBLE_CODE %%', lines)
+    if (length(i) != 1L)
+      stop("Couldn't find replacement string; or the are multiple of them.")
+
+    lines = append(lines, options$engine.opts$extra_preamble, i)
+  }
+
   i = grep('%% TIKZ_CODE %%', lines)
   if (length(i) != 1L)
     stop("Couldn't find replacement string; or the are multiple of them.")

--- a/R/engine.R
+++ b/R/engine.R
@@ -277,22 +277,15 @@ eng_stan = function(options) {
 eng_tikz = function(options) {
   if (!options$eval) return(engine_output(options, options$code, ''))
 
-  lines = read_utf8(options$engine.opts$template %n%
-                    system.file('misc', 'tikz2pdf.tex', package = 'knitr'))
-
-  if (!is.null(options$engine.opts$extra_preamble)) {
-    i = grep('%% EXTRA_TIKZ_PREAMBLE_CODE %%', lines)
-    if (length(i) != 1L)
-      stop("Couldn't find replacement string; or the are multiple of them.")
-
-    lines = append(lines, options$engine.opts$extra_preamble, i)
-  }
-
-  i = grep('%% TIKZ_CODE %%', lines)
-  if (length(i) != 1L)
-    stop("Couldn't find replacement string; or the are multiple of them.")
-
-  s = append(lines, options$code, i)  # insert tikz into tex-template
+  lines = read_utf8(
+    options$engine.opts$template %n% system.file('misc', 'tikz2pdf.tex', package = 'knitr')
+  )
+  # insert code into preamble
+  lines = insert_template(
+    lines, '%% EXTRA_TIKZ_PREAMBLE_CODE %%', options$engine.opts$extra.preamble, TRUE
+  )
+  # insert tikz code into the tex template
+  s = insert_template(lines, '%% TIKZ_CODE %%', options$code)
   write_utf8(s, texf <- wd_tempfile('tikz', '.tex'))
   on.exit(unlink(texf), add = TRUE)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -568,6 +568,18 @@ merge_list = function(x, y) {
   x
 }
 
+# find a token in a template, and replace it with a value
+insert_template = function(text, token, value, ignore = FALSE) {
+  if (is.null(value)) return(text)
+  i = grep(token, text); n = length(i)
+  if (n > 1) stop("There are multiple tokens in the template: '", token, "'")
+  if (n == 0) {
+    if (ignore) return(text)
+    stop("Couldn't find the token '", token, "' in the template.")
+  }
+  append(text, value, i)
+}
+
 # paths of all figures
 all_figs = function(options, ext = options$fig.ext, num = options$fig.num) {
   unlist(lapply(ext, fig_path, options = options, number = seq_len(num)))

--- a/inst/misc/tikz2pdf.tex
+++ b/inst/misc/tikz2pdf.tex
@@ -4,6 +4,7 @@
 \usepackage{amsmath}
 \usepackage{tikz}
 \usetikzlibrary{matrix}
+%% EXTRA_TIKZ_PREAMBLE_CODE %%
 \begin{document}
 \begin{preview}
 %% TIKZ_CODE %%


### PR DESCRIPTION
This addresses yihui#1735. I didn't get much feedback on the proposed fix in that ticket, so I thought I would open a PR to at least get it tested.