### PR TITLE
Always use . as decimal separator in latex_percent_size

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -359,7 +359,7 @@ latex_percent_size = function(x, which = c('width', 'height')) {
   xi = as.numeric(sub('%$', '', x[i]))
   if (any(is.na(xi))) return(x)
   which = match.arg(which)
-  x[i] = paste0(xi / 100, if (which == 'width') '\\linewidth' else '\\textheight')
+  x[i] = paste0(formatC(xi / 100, decimal.mark = '.'), if (which == 'width') '\\linewidth' else '\\textheight')
   x
 }
 


### PR DESCRIPTION
Reason for the change:

Same problem as in #308 knitr is outputting whatever is set as OutDec but the LaTeX code requires a '.' character.

Figure chunks having the out.width/height option set in % resulted in knitr putting out incorrect LaTeX code: knitr outputs `0,5\linewidth` instead of `0.5\linewidth`

Session info:

```
> xfun::session_info('knitr')
R version 4.0.2 (2020-06-22)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 18363), RStudio 1.2.5033

Locale:
  LC_COLLATE=German_Germany.1252  LC_CTYPE=German_Germany.1252    LC_MONETARY=German_Germany.1252
  LC_NUMERIC=C                    LC_TIME=German_Germany.1252    

Package version:
  evaluate_0.14   glue_1.4.1      graphics_4.0.2  grDevices_4.0.2 highr_0.8       knitr_1.29.4    magrittr_1.5   
  markdown_1.1    methods_4.0.2   mime_0.9        stats_4.0.2     stringi_1.4.6   stringr_1.4.0   tools_4.0.2    
  utils_4.0.2     xfun_0.16       yaml_2.2.1   
```

Minimal example:

````r
---
title: "OutDec_mwe"
output: pdf_document
---

```{r setup, include=FALSE}
# results in fig chunks with out.width/height option in % outputting 0,5\linewidth instead of 0.5\linewidth
options(OutDec= ",")
```

```{r pressure, echo=FALSE, fig.cap="This figure will not compile in LaTeX", out.width="50%"}
plot(pressure)
```
````

This is the part of the tex file that was output for the figure chunk:

```LaTeX
\textbackslash begin\{figure\}
\textbackslash includegraphics{[}width=0,5\linewidth{]}\{OutDec\_mwe\_files/figure-latex/pressure-1\}

\caption{This figure will not compile in LaTeX}\label{fig:pressure}

\textbackslash end\{figure\}
```