### PR TITLE
Fix collapse = TRUE when attr.source or classe.source is set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN knitr VERSION 1.31
 
-- `collapse = TRUE` now works as expected if `attr.source` or `class.source` is provided (thanks, @aosavi, #1902)
+- The chunk option `collapse = TRUE` now works as expected when the chunk option `attr.source` or `class.source` is provided (thanks, @aosavi @cderv, #1902).
 
 # CHANGES IN knitr VERSION 1.30
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN knitr VERSION 1.31
 
-
+- `collapse = TRUE` now works as expected if `attr.source` or `class.source` is provided (thanks, @aosavi, #1902)
 
 # CHANGES IN knitr VERSION 1.30
 

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -192,7 +192,7 @@ hooks_markdown = function(strict = FALSE, fence_char = '`') {
       x = gsub('[\n]+$', '', x)
       x = gsub('^[\n]+', '\n', x)
       if (isTRUE(options$collapse)) {
-        reg_chunk = sprintf('\n([%s]{3,})\n+\\1((\\{\\.)?%s[^\n]*)?\n', fence_char, tolower(options$engine), tolower(options$engine))
+        reg_chunk = sprintf('\n([%s]{3,})\n+\\1((\\{\\.)?%s[^\n]*)?\n', fence_char, tolower(options$engine))
         x = gsub(reg_chunk, "\n", x)
       }
       if (is.null(s <- options$indent)) return(x)

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -192,8 +192,8 @@ hooks_markdown = function(strict = FALSE, fence_char = '`') {
       x = gsub('[\n]+$', '', x)
       x = gsub('^[\n]+', '\n', x)
       if (isTRUE(options$collapse)) {
-        reg_chunk = sprintf('\n([%s]{3,})\n+\\1((\\{\\.)?%s[^\n]*)?\n', fence_char, tolower(options$engine))
-        x = gsub(reg_chunk, "\n", x)
+        r = sprintf('\n([%s]{3,})\n+\\1((\\{[.])?%s[^\n]*)?\n', fence_char, tolower(options$engine))
+        x = gsub(r, '\n', x)
       }
       if (is.null(s <- options$indent)) return(x)
       line_prompt(x, prompt = s, continue = s)

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -192,7 +192,8 @@ hooks_markdown = function(strict = FALSE, fence_char = '`') {
       x = gsub('[\n]+$', '', x)
       x = gsub('^[\n]+', '\n', x)
       if (isTRUE(options$collapse)) {
-        x = gsub(paste0('\n([', fence_char, ']{3,})\n+\\1(', tolower(options$engine), ')?\n'), "\n", x)
+        reg_chunk = sprintf('\n([%s]{3,})\n+\\1((\\{\\.)?%s[^\n]*)?\n', fence_char, tolower(options$engine), tolower(options$engine))
+        x = gsub(reg_chunk, "\n", x)
       }
       if (is.null(s <- options$indent)) return(x)
       line_prompt(x, prompt = s, continue = s)

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -29,13 +29,22 @@ assert('include_graphics() includes custom images correctly', {
 hook_src = knit_hooks$get("source")
 options_ = list(engine = "r", prompt = FALSE, highlight = TRUE)
 
-assert('Attributes for souce can be specified class.source and attr.source', {
+assert('Attributes for source can be specified class.source and attr.source', {
   (hook_src("1", c(options_, class.source = "a b")) %==% "\n\n```{.r .a .b}\n1\n```\n\n")
   (hook_src("1", c(options_, attr.source = ".a .b")) %==% "\n\n```{.r .a .b}\n1\n```\n\n")
   (hook_src("1", c(options_, class.source = "a", attr.source = "b='1'")) %==%
     "\n\n```{.r .a b='1'}\n1\n```\n\n")
   (hook_src("1", c(options_, attr.source = ".a b='1'")) %==%
     "\n\n```{.r .a b='1'}\n1\n```\n\n")
+})
+
+assert('class.source and attr.source works also with collapse = TRUE', {
+  hook_chunk = hooks_markdown()$chunk
+  (hook_chunk("```{.r .a b=1}\n1\n```", c(options_, collapse = TRUE)) %==%
+      "```{.r .a b=1}\n1\n```")
+  (hook_chunk("```{.r .a b=1}\n1\n```\n```{.r .a b=1}\n1\n```",
+              c(options_, collapse = TRUE)) %==%
+      "```{.r .a b=1}\n1\n1\n```")
 })
 
 hook_out = knit_hooks$get("output")


### PR DESCRIPTION
This will fix #1893 

This was a regex to change so that the header is correctly match

* Without class or attributes  we need to match 
````
```r
code1
```
```r
code2
```
````
* With the class or attr provided it becomes
````
```{.engine .class1 .class2 attr=val}
code1
```
```{.engine .class1 .class2 attr=val}
code2
```
````

Added some tests too