### PR TITLE
When counting plots, html_screenshots are missed.

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -247,6 +247,7 @@ block_exec = function(options) {
     options$fig.num = if (length(res)) sum(sapply(res, function(x) {
       if (evaluate::is.recordedplot(x)) return(1)
       if (inherits(x, 'knit_image_paths')) return(length(x))
+      if (inherits(x, 'html_screenshot')) return(1)
       0
     })) else 0L
 


### PR DESCRIPTION
If there are multiple plots with captions in a code chunk in an Rnw document (aimed at LaTeX), `knitr` generates separate labels for each plot, so that references to each plot can be made from the text.  If there is only one plot, the label is the chunk label.

This scheme fails when some of the plots are `html_screenshot` objects, because they aren't counted when determining whether there are multiple plots or not.  The labels are generated correctly if there are multiple regular plots in the same chunk, but not if there are none or one.

The document `test.Rnw` included below illustrates the problem.  References to the first two figures fail,
because they both end up labelled as `fig:bad` instead of `fig:bad-1` and `fig:bad-2`.

The fix is simply to count `html_screenshot` objects in the appropriate place.

```
\documentclass{article}

\begin{document}

<<bad,fig.cap=c("First", "Second")>>=
library(leaflet)
leaflet() %>% addTiles()
plot(2)
@
Those were figures \ref{fig:bad-1} and \ref{fig:bad-2}.

<<good,fig.cap=c("Third", "Fourth", "Fifth")>>=
leaflet() %>% addTiles()
plot(4)
plot(5)
@
Those were figures \ref{fig:good-1}, \ref{fig:good-2} and
\ref{fig:good-3}.

\end{document}
```