### PR TITLE
Let collapse work even if class.* or attr.* are provided (closes #1906)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN knitr VERSION 1.31
 
-- The chunk option `collapse = TRUE` now works as expected when the chunk option `attr.source` or `class.source` is provided (thanks, @aosavi @cderv, #1902).
+- The chunk option `collapse = TRUE` now works as expected when the chunk option `attr.*` or `class.*` is provided. By this change, The chunk option `collapse = TRUE` forces `attr.*` and `class.*` be `NULL` except for the chunk options `attr.source` and `class.source` (thanks, @aosavi @cderv @atusy, #1902 #1906).
 
 # CHANGES IN knitr VERSION 1.30
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -309,7 +309,7 @@ fix_options = function(options) {
 
   if (options$collapse) {
     options[unlist(lapply(
-      c("class.", "attr."), paste0, c("output", "message", "warning", "error")
+      c('class.', 'attr.'), paste0, c('output', 'message', 'warning', 'error')
     ))] = NULL
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -307,6 +307,12 @@ fix_options = function(options) {
     }
   }
 
+  if (options$collapse) {
+    options[unlist(lapply(
+      c("class.", "attr."), paste0, c("output", "message", "warning", "error")
+    ))] = NULL
+  }
+
   options
 }
 

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -194,14 +194,12 @@ assert('block_attr(x) turns a character vector into Pandoc attributes', {
 })
 
 
-keys = unlist(lapply(c('class.', 'attr.'),
-                     paste0,
-                     c('source', 'output', 'message', 'warning', 'error')))
+keys = unlist(lapply(
+  c('class.', 'attr.'), paste0, c('source', 'output', 'message', 'warning', 'error')
+))
 keys_source = c('class.source', 'attr.source')
-opts = fix_options(c(setNames(as.list(keys), keys), list(
-  fig.path = '.', cache.path = '.', cache = 0, engine = 'R', collapse = TRUE
-)))
-assert('When collapse is TRUE, class.* and attr.* becomes NULL except for class.source and attr.source', {
-  (opts[keys_source] %==% as.list(keys_source))
-  (any(names(opts) %in% setdiff(keys, keys_source)) %==% FALSE)
+opts = fix_options(opts_chunk$merge(c(setNames(as.list(keys), keys), list(collapse = TRUE))))
+assert('when collapse is TRUE, class.* and attr.* become NULL except for class.source and attr.source', {
+  (opts[keys_source] %==% as.list(setNames(keys_source, keys_source)))
+  (!any(names(opts) %in% setdiff(keys, keys_source)))
 })

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -192,3 +192,16 @@ assert('block_attr(x) turns a character vector into Pandoc attributes', {
   (block_attr('.a b="11"') %==% '{.a b="11"}')
   (block_attr(c('.a', 'b="11"')) %==% '{.a b="11"}')
 })
+
+
+keys = unlist(lapply(c('class.', 'attr.'),
+                     paste0,
+                     c('source', 'output', 'message', 'warning', 'error')))
+keys_source = c('class.source', 'attr.source')
+opts = fix_options(c(setNames(as.list(keys), keys), list(
+  fig.path = '.', cache.path = '.', cache = 0, engine = 'R', collapse = TRUE
+)))
+assert('When collapse is TRUE, class.* and attr.* becomes NULL except for class.source and attr.source', {
+  opts[keys_source] %==% as.list(keys_source)
+  any(names(opts) %in% setdiff(keys, keys_source)) %==% FALSE
+})

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -202,6 +202,6 @@ opts = fix_options(c(setNames(as.list(keys), keys), list(
   fig.path = '.', cache.path = '.', cache = 0, engine = 'R', collapse = TRUE
 )))
 assert('When collapse is TRUE, class.* and attr.* becomes NULL except for class.source and attr.source', {
-  opts[keys_source] %==% as.list(keys_source)
-  any(names(opts) %in% setdiff(keys, keys_source)) %==% FALSE
+  (opts[keys_source] %==% as.list(keys_source))
+  (any(names(opts) %in% setdiff(keys, keys_source)) %==% FALSE)
 })


### PR DESCRIPTION
#1906 mentions `class.output` and `attr.output`, but I also added those for message, warning, and error.