### PR TITLE
Capture error in eng_sql if error = TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN knitr VERSION 1.31
 
+- `eng_sql` now correctly captures error if `error = TRUE` in chunk options. (thanks, @colearendt, rstudio/rmarkdown#1208)
+
 - The chunk option `collapse = TRUE` now works as expected when the chunk option `attr.*` or `class.*` is provided. By this change, The chunk option `collapse = TRUE` forces `attr.*` and `class.*` be `NULL` except for the chunk options `attr.source` and `class.source` (thanks, @aosavi @cderv @atusy, #1902 #1906).
 
 # CHANGES IN knitr VERSION 1.30


### PR DESCRIPTION
This will fix rstudio/rmarkdown#1208

We capture the error of SQL execution if `error = TRUE` as for some other engine. 

This allows this Rmd to work now without stoping

````md
---
title: "Error Honored"
output: html_document
---

```{r, message=FALSE}
knitr::opts_chunk$set(error = TRUE)
library(DBI)
con <- dbConnect(RSQLite::SQLite(), ":memory:")
```

```{r}
stop('error message that I want to print')
```

```{r}
dbWriteTable(con, "mtcars", mtcars)
```

```{sql, connection=con}
SELECT * FROM mtcars WHERE cyl = 4
```

```{sql, connection=con}
DROP TABLE mtcars
```

```{r}
dbListTables(con)
```

```{sql, connection=con}
select test;
```
````

I'll do a PR in knitr-example to complement this PR with tests