### PR TITLE
add lock bot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: 'Lock threads'
 
 on:
   schedule:
-    - cron: '10 * * * *'
+    - cron: '*/10 * * * *'
 
 jobs:
   lock:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+# From https://github.com/marketplace/actions/lock-threads
+name: 'Lock threads'
+
+on:
+  schedule:
+    - cron: '10 * * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2.0.1
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '180'
+          # issue-exclude-created-before: ''
+          # issue-exclude-labels: ''
+          # issue-lock-labels: ''
+          issue-lock-comment: >
+            This old thread has been automatically locked. If you think you have
+            found something related to this, please open a new issue by following
+            the issue guide (<https://yihui.org/issue/>), and link to this
+            old issue if necessary.
+          issue-lock-reason: 'resolved'
+          pr-lock-inactive-days: '180'
+          # pr-exclude-created-before: ''
+          # pr-exclude-labels: ''
+          # pr-lock-labels: ''
+          # pr-lock-comment: ''
+          # pr-lock-reason: ''
+          # process-only: ''


### PR DESCRIPTION
This add the lock thread action. 

I set it up every hour for a start in order to lock every existing closed thread. We need that because it locks by batch of 50 max. 
After that, we could set it every week or every month only. 

I let you merge when you decide it is time to run the bot 😄 