### PR TITLE
Extended combine_words with support for exclusion of the Oxford comma

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - New links added in `?knitr::kable()` help page to the Rmarkdown Cookbook relevant pages. 
 
+- Added a new argument `oxford_comma` to the function `combine_words()` (thanks, @thompsonsed, #1946).
+
 ## MINOR CHANGES
 
 - Vignette engines for R Markdown vignettes no longer check for availability of `pandoc-citeproc` since it has gone since Pandoc 2.11.

--- a/R/utils.R
+++ b/R/utils.R
@@ -808,7 +808,7 @@ create_label = function(..., latex = FALSE) {
 #' combine_words(c('a', 'b', 'c'), sep = ' / ', and = '')
 #' combine_words(c('a', 'b', 'c'), and = '')
 #' combine_words(c('a', 'b', 'c'), before = '"', after = '"')
-combine_words = function(words, sep = ', ', and = ' and ', before = '', after = before) {
+combine_words = function(words, sep = ', ', and = ' and ', before = '', after = before, oxford_comma = TRUE) {
   n = length(words); rs = xfun::raw_string
   if (n == 0) return(words)
   words = paste0(before, words, after)
@@ -816,7 +816,8 @@ combine_words = function(words, sep = ', ', and = ' and ', before = '', after = 
   if (n == 2) return(rs(paste(words, collapse = and)))
   if (grepl('^ ', and) && grepl(' $', sep)) and = gsub('^ ', '', and)
   words[n] = paste0(and, words[n])
-  rs(paste(words, collapse = sep))
+  if(oxford_comma)  return(rs(paste(words, collapse = sep)))
+  return(rs(paste(paste(words[1:(length(words)-1)], collapse=sep), words[length(words)])))
 }
 
 warning2 = function(...) warning(..., call. = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -818,8 +818,12 @@ combine_words = function(words, sep = ', ', and = ' and ', before = '', after = 
   if (n == 2) return(rs(paste(words, collapse = and)))
   if (grepl('^ ', and) && grepl(' $', sep)) and = gsub('^ ', '', and)
   words[n] = paste0(and, words[n])
-  if(oxford_comma)  return(rs(paste(words, collapse = sep)))
-  return(rs(paste(paste(words[1:(length(words)-1)], collapse=sep), words[length(words)])))
+  # combine the last two words directly without the comma
+  if (oxford_comma) {
+    words[n - 1] = paste0(words[n - 1:0], collapse = '')
+    words = words[-n]
+  }
+  rs(paste(words, collapse = sep))
 }
 
 warning2 = function(...) warning(..., call. = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -822,7 +822,7 @@ combine_words = function(
   if (oxford_comma && grepl('^ ', and) && grepl(' $', sep)) and = gsub('^ ', '', and)
   words[n] = paste0(and, words[n])
   # combine the last two words directly without the comma
-  if (oxford_comma) {
+  if (!oxford_comma) {
     words[n - 1] = paste0(words[n - 1:0], collapse = '')
     words = words[-n]
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -801,6 +801,7 @@ create_label = function(..., latex = FALSE) {
 #' @param sep Separator to be inserted between words.
 #' @param and Character string to be prepended to the last word.
 #' @param before,after A character string to be added before/after each word.
+#' @param oxford_comma If false, removes the comma separating the last two elements in the list.
 #' @return A character string marked by \code{xfun::\link{raw_string}()}.
 #' @export
 #' @examples combine_words('a'); combine_words(c('a', 'b'))
@@ -808,6 +809,7 @@ create_label = function(..., latex = FALSE) {
 #' combine_words(c('a', 'b', 'c'), sep = ' / ', and = '')
 #' combine_words(c('a', 'b', 'c'), and = '')
 #' combine_words(c('a', 'b', 'c'), before = '"', after = '"')
+#' combine_words(c('a', 'b', 'c'), before = '"', after = '"', oxford_comma=FALSE)
 combine_words = function(words, sep = ', ', and = ' and ', before = '', after = before, oxford_comma = TRUE) {
   n = length(words); rs = xfun::raw_string
   if (n == 0) return(words)

--- a/R/utils.R
+++ b/R/utils.R
@@ -801,7 +801,8 @@ create_label = function(..., latex = FALSE) {
 #' @param sep Separator to be inserted between words.
 #' @param and Character string to be prepended to the last word.
 #' @param before,after A character string to be added before/after each word.
-#' @param oxford_comma If false, removes the comma separating the last two elements in the list.
+#' @param oxford_comma Whether to insert the separator between the last two
+#'   elements in the list.
 #' @return A character string marked by \code{xfun::\link{raw_string}()}.
 #' @export
 #' @examples combine_words('a'); combine_words(c('a', 'b'))
@@ -810,7 +811,9 @@ create_label = function(..., latex = FALSE) {
 #' combine_words(c('a', 'b', 'c'), and = '')
 #' combine_words(c('a', 'b', 'c'), before = '"', after = '"')
 #' combine_words(c('a', 'b', 'c'), before = '"', after = '"', oxford_comma=FALSE)
-combine_words = function(words, sep = ', ', and = ' and ', before = '', after = before, oxford_comma = TRUE) {
+combine_words = function(
+  words, sep = ', ', and = ' and ', before = '', after = before, oxford_comma = TRUE
+) {
   n = length(words); rs = xfun::raw_string
   if (n == 0) return(words)
   words = paste0(before, words, after)

--- a/R/utils.R
+++ b/R/utils.R
@@ -819,7 +819,7 @@ combine_words = function(
   words = paste0(before, words, after)
   if (n == 1) return(rs(words))
   if (n == 2) return(rs(paste(words, collapse = and)))
-  if (grepl('^ ', and) && grepl(' $', sep)) and = gsub('^ ', '', and)
+  if (oxford_comma && grepl('^ ', and) && grepl(' $', sep)) and = gsub('^ ', '', and)
   words[n] = paste0(and, words[n])
   # combine the last two words directly without the comma
   if (oxford_comma) {

--- a/man/combine_words.Rd
+++ b/man/combine_words.Rd
@@ -22,7 +22,8 @@ combine_words(
 
 \item{before, after}{A character string to be added before/after each word.}
 
-\item{oxford_comma}{If false, removes the comma separating the last two elements in the list.}
+\item{oxford_comma}{Whether to insert the separator between the last two
+elements in the list.}
 }
 \value{
 A character string marked by \code{xfun::\link{raw_string}()}.

--- a/man/combine_words.Rd
+++ b/man/combine_words.Rd
@@ -21,6 +21,8 @@ combine_words(
 \item{and}{Character string to be prepended to the last word.}
 
 \item{before, after}{A character string to be added before/after each word.}
+
+\item{oxford_comma}{If false, removes the comma separating the last two elements in the list.}
 }
 \value{
 A character string marked by \code{xfun::\link{raw_string}()}.
@@ -44,4 +46,5 @@ combine_words(c("a", "b", "c"))
 combine_words(c("a", "b", "c"), sep = " / ", and = "")
 combine_words(c("a", "b", "c"), and = "")
 combine_words(c("a", "b", "c"), before = "\"", after = "\"")
+combine_words(c("a", "b", "c"), before = "\"", after = "\"", oxford_comma = FALSE)
 }

--- a/man/combine_words.Rd
+++ b/man/combine_words.Rd
@@ -4,7 +4,14 @@
 \alias{combine_words}
 \title{Combine multiple words into a single string}
 \usage{
-combine_words(words, sep = ", ", and = " and ", before = "", after = before)
+combine_words(
+  words,
+  sep = ", ",
+  and = " and ",
+  before = "",
+  after = before,
+  oxford_comma = TRUE
+)
 }
 \arguments{
 \item{words}{A character vector.}

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -139,7 +139,7 @@ assert(
   cw(c('a', 'b', 'c'), and = '') %==% 'a, b, c',
   cw(c('a', 'b', 'c'), ' / ', '') %==% 'a / b / c',
   cw(c('a', 'b', 'c'), before = '"') %==% '"a", "b", and "c"',
-  cw(c('a', 'b', 'c'), before = '``', after = "''") %==% "``a'', ``b'', and ``c''"
+  cw(c('a', 'b', 'c'), before = '``', after = "''") %==% "``a'', ``b'', and ``c''",
   cw(c('a', 'b', 'c'), before = '``', after = "''", oxford_comma = FALSE) %==% "``a'', ``b'' and ``c''"
 )
 rm(list = 'cw')

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -140,6 +140,7 @@ assert(
   cw(c('a', 'b', 'c'), ' / ', '') %==% 'a / b / c',
   cw(c('a', 'b', 'c'), before = '"') %==% '"a", "b", and "c"',
   cw(c('a', 'b', 'c'), before = '``', after = "''") %==% "``a'', ``b'', and ``c''"
+  cw(c('a', 'b', 'c'), before = '``', after = "''", oxford_comma = FALSE) %==% "``a'', ``b'' and ``c''"
 )
 rm(list = 'cw')
 


### PR DESCRIPTION
`combine_words` separates all elements with commas by default. This PR adds support for removing the penultimate comma (the "Oxford comma") in a list of terms.

Example:

```{r}
# Default behaviour (unchanged)
> combine_words(c("a", "b", "c"))
a, b, and c

# Remove Oxford comma
> combine_words(c("a", "b", "c"), oxford_comma = FALSE)
a, b and c
```

I needed this for formatting in personal projects, but figured it might be useful more generally.