### PR TITLE
vectorize include_app and include_url

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- `include_url()` and `include_app()` can now take several urls as argument. (#1948)
+- `include_url()` and `include_app()` can now take a vector of URLs (thanks, @cderv, #1948).
 
 - The `sql` engine now correctly captures error with the chunk option `error = TRUE` (thanks, @colearendt, rstudio/rmarkdown#1208).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## NEW FEATURES
 
+- `include_url()` and `include_app()` can now take several urls as argument. (#1948)
+
 - The `sql` engine now correctly captures error with the chunk option `error = TRUE` (thanks, @colearendt, rstudio/rmarkdown#1208).
 
 - The chunk option `collapse = TRUE` now works as expected when the chunk option `attr.*` or `class.*` is provided. By this change, The chunk option `collapse = TRUE` forces `attr.*` and `class.*` be `NULL` except for the chunk options `attr.source` and `class.source` (thanks, @aosavi @cderv @atusy, #1902 #1906).

--- a/R/plot.R
+++ b/R/plot.R
@@ -470,7 +470,8 @@ include_url2 = function(url, height = '400px', orig = url) {
 #' @export
 include_app = function(url, height = '400px') {
   orig = url  # store the original URL
-  if (!grepl('?', url, fixed = TRUE)) url = paste0(url, '?showcase=0')
+  i = !grepl('?', url, fixed = TRUE)
+  if (any(i)) url[i] = paste0(url[i], '?showcase=0')
   include_url2(url, height, orig)
 }
 
@@ -534,19 +535,22 @@ html_screenshot = function(x, options = opts_current$get(), ...) {
         save_widget(x, f1, FALSE, options = options)
       } else f1 = x$url
       f2 = wd_tempfile('webshot', ext)
-      do.call(webshot::webshot, c(list(f1, f2), wargs))
-      normalizePath(f2)
+      f3 = do.call(webshot::webshot, c(list(f1, f2), wargs))
+      normalizePath(f3)
     } else if (i2) {
-      f = wd_tempfile('webshot', ext)
-      do.call(webshot::appshot, c(list(x, f), wargs))
-      normalizePath(f)
+      f1 = wd_tempfile('webshot', ext)
+      f2 = do.call(webshot::appshot, c(list(x, f1), wargs))
+      normalizePath(f2)
     }
   })
-  res = readBin(f, 'raw', file.info(f)[, 'size'])
-  structure(
-    list(image = res, extension = ext, url = if (i3) x$url.orig),
-    class = 'html_screenshot'
-  )
+  lapply(f, function(filename) {
+    i = which(filename == f)
+    res = readBin(filename, 'raw', file.info(filename)[, 'size'])
+    structure(
+      list(image = res, extension = ext, url = if (i3) x$url.orig[i]),
+      class = 'html_screenshot'
+    )
+  })
 }
 
 save_widget = function(..., options) {

--- a/R/plot.R
+++ b/R/plot.R
@@ -449,10 +449,10 @@ raster_dpi_width = function(path, dpi) {
 #' the output. \code{include_app()} takes the URL of a Shiny app and adds
 #' \samp{?showcase=0} to it (to disable the showcase mode), then passes the URL
 #' to \code{include_url()}.
-#' @param url Character vector containing one or several URL.
-#' @param height Character string with the height of the iframe. If you need different
+#' @param url A character vector of URLs.
+#' @param height A character vector to specify the height of iframes.
 #' @return An R object with a special class that \pkg{knitr} recognizes
-#'   internally to generate the iframe or screenshot.
+#'   internally to generate the iframes or screenshots.
 #' @seealso \code{\link{include_graphics}}
 #' @export
 include_url = function(url, height = '400px') {
@@ -471,7 +471,7 @@ include_url2 = function(url, height = '400px', orig = url) {
 include_app = function(url, height = '400px') {
   orig = url  # store the original URL
   i = !grepl('?', url, fixed = TRUE)
-  if (any(i)) url[i] = paste0(url[i], '?showcase=0')
+  url[i] = paste0(url[i], '?showcase=0')
   include_url2(url, height, orig)
 }
 
@@ -544,10 +544,10 @@ html_screenshot = function(x, options = opts_current$get(), ...) {
     }
   })
   lapply(f, function(filename) {
-    i = which(filename == f)
+    # TODO: use xfun::read_bin()
     res = readBin(filename, 'raw', file.info(filename)[, 'size'])
     structure(
-      list(image = res, extension = ext, url = if (i3) x$url.orig[i]),
+      list(image = res, extension = ext, url = if (i3) x$url.orig[filename == f]),
       class = 'html_screenshot'
     )
   })

--- a/R/plot.R
+++ b/R/plot.R
@@ -449,8 +449,8 @@ raster_dpi_width = function(path, dpi) {
 #' the output. \code{include_app()} takes the URL of a Shiny app and adds
 #' \samp{?showcase=0} to it (to disable the showcase mode), then passes the URL
 #' to \code{include_url()}.
-#' @param url Character string containing a URL.
-#' @param height Character string with the height of the iframe.
+#' @param url Character vector containing one or several URL.
+#' @param height Character string with the height of the iframe. If you need different
 #' @return An R object with a special class that \pkg{knitr} recognizes
 #'   internally to generate the iframe or screenshot.
 #' @seealso \code{\link{include_graphics}}

--- a/man/include_url.Rd
+++ b/man/include_url.Rd
@@ -10,13 +10,13 @@ include_url(url, height = "400px")
 include_app(url, height = "400px")
 }
 \arguments{
-\item{url}{Character vector containing one or several URL.}
+\item{url}{A character vector of URLs.}
 
-\item{height}{Character string with the height of the iframe. If you need different}
+\item{height}{A character vector to specify the height of iframes.}
 }
 \value{
 An R object with a special class that \pkg{knitr} recognizes
-  internally to generate the iframe or screenshot.
+  internally to generate the iframes or screenshots.
 }
 \description{
 When the output format is HTML, \code{include_url()} inserts an iframe in the

--- a/man/include_url.Rd
+++ b/man/include_url.Rd
@@ -10,9 +10,9 @@ include_url(url, height = "400px")
 include_app(url, height = "400px")
 }
 \arguments{
-\item{url}{Character string containing a URL.}
+\item{url}{Character vector containing one or several URL.}
 
-\item{height}{Character string with the height of the iframe.}
+\item{height}{Character string with the height of the iframe. If you need different}
 }
 \value{
 An R object with a special class that \pkg{knitr} recognizes


### PR DESCRIPTION
This is based on webshot vectorization and will close #1326

I think theses changes will do it. It is based on `webshot:::knit_print` also.

I tested with this 

````markdown
---
title: test
output:
  html_document: default
  pdf_document: default
---

# 2 urls

```{r}
knitr::include_url(c('https://google.com', 'https://yihui.org/'))
```

# 1 url

```{r}
knitr::include_url('https://yihui.org/knitr')
```

# screenshot widget too

```{r}
DT::datatable(mtcars)
```

# include 1 app

```{r}
knitr::include_app("https://garrick-rstudio.shinyapps.io/rstudio-global-2021/")
```

# include 2 app

```{r}
knitr::include_app(c("https://garrick-rstudio.shinyapps.io/rstudio-global-2021/", "https://shiny.rstudio.com/gallery/kmeans-example.html"))
```

````

Should we add something like that in knitr-example ? 
