### PR TITLE
fix setting col in par() with global.pars = TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.31.1
+Version: 1.31.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Adam", "Vogt", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN knitr VERSION 1.32
 
+## BUG FIXES
+
+- Graphical parameter `par(col =)` is now preserved as expected in following chunks when `knitr::opts_knit$set(global.par = TRUE)` (thanks, @ArnonL, @RolandASc, #1603).
 
 # CHANGES IN knitr VERSION 1.31
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -377,10 +377,11 @@ par2 = function(x) {
     # drawn at (1, 1) instead of (1, 2)
     x$mfg = NULL
   }
-  if (!is.null(x$fg) && !is.null(x$col)) {
-    # set fg before col because setting fg will reset col to the same value
-    par(fg = x$fg, col = x$col)
-    x$fg = x$col = NULL
+  if (!is.null(x$fg)) {
+    # set fg before the rest of the par because
+    # it resets col to the same value #1603
+    par(fg = x$fg)
+    x$fg = NULL
   }
   # you are unlikely to want to reset these pars
   x$fig = x$fin = x$pin = x$plt = x$usr = NULL

--- a/R/plot.R
+++ b/R/plot.R
@@ -377,6 +377,11 @@ par2 = function(x) {
     # drawn at (1, 1) instead of (1, 2)
     x$mfg = NULL
   }
+  if (!is.null(x$fg) && !is.null(x$col)) {
+    # set fg before col because setting fg will reset col to the same value
+    par(fg = x$fg, col = x$col)
+    x$fg = x$col = NULL
+  }
   # you are unlikely to want to reset these pars
   x$fig = x$fin = x$pin = x$plt = x$usr = NULL
   x$ask = NULL  # does not make sense for typical non-interactive R sessions

--- a/tests/testit/test-plot.R
+++ b/tests/testit/test-plot.R
@@ -130,3 +130,39 @@ if (xfun::loadable('tikzDevice') &&
 
 # https://github.com/yihui/knitr/issues/1166
 knit(text = "\\Sexpr{include_graphics('myfigure.pdf', error = FALSE)}", quiet = TRUE)
+
+with_par <- function(expr, ...) {
+  # set par
+  op = graphics::par(...)
+  # reset on exit
+  on.exit(graphics::par(op))
+  # save changed state
+  global.pars = par(no.readonly = TRUE)
+  # reset par
+  graphics::par(op)
+  # simulate what happens when global.par = TRUE by restoring pars
+  par2(global.pars)
+  # evaluate in this state
+  force(expr)
+}
+
+assert("par2 correctly handles specific pars", {
+  (par2(NULL) %==% NULL)
+  # correctly changed
+  (with_par(par("col") %==% "red", col = "red"))
+  (with_par(par("cex") %==% 2, cex = 2))
+  # unchanged
+  old = par("fig")
+  (with_par(par("fig") %==% old, fig = old / 2))
+  old = par("fin")
+  (with_par(par("fin") %==% old, fin = old / 2))
+  old = par("pin")
+  (with_par(par("pin") %==% old, pin = old / 2))
+  old = par("usr")
+  (with_par(par("usr") %==% old, usr = old / 2))
+  old = par("ask")
+  (with_par(par("ask") %==% old, ask = !old))
+  # Does not work - something else is changing plt when setting everything
+  # old = par("plt")
+  # (with_par(par("plt") %==% old, plt = old / 2))
+})

--- a/tests/testit/test-plot.R
+++ b/tests/testit/test-plot.R
@@ -131,7 +131,7 @@ if (xfun::loadable('tikzDevice') &&
 # https://github.com/yihui/knitr/issues/1166
 knit(text = "\\Sexpr{include_graphics('myfigure.pdf', error = FALSE)}", quiet = TRUE)
 
-with_par <- function(expr, ...) {
+with_par = function(expr, ...) {
   # set par
   op = graphics::par(...)
   # reset on exit


### PR DESCRIPTION
This PR fix #1603 by adding the special handling of `fg` option in `par2()`

I took the opportunity to add some test for this function - it seems one of the parameters is changed by others when we use the equivalent of `par(par(no.readonly = TRUE)`. 
There are dependencies between parameters and setting all of them at once seems to have side effect. Usually you do 
```r
op = par(x)
# do something
par(op)
```
and not 
```r
par(x)
all = par(no.readonly = TRUE)
# do something
par(all)
```

It does not seem to be equivalent. But we can't really do the former.