### PR TITLE
In Rnw LaTeX files, suppress the paragraph break at the end of the chunk if chunk option end.paragraph=FALSE.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
 
 - For Rnw documents, the commented `%\begin{document}` will no longer cause trouble (thanks, @NewbieKnitter @shrektan, #1819).
 
+## MINOR CHANGES
+
+- For Rnw documents, if a chunk's output ends with `\n`, **knitr** will no longer add another `\n` to it (thanks, @krivit #1958, @jpritikin 1092).
+
 # CHANGES IN knitr VERSION 1.31
 
 ## NEW FEATURES

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -191,7 +191,13 @@ hook_plot_tex = function(x, options) {
   k2 = '\\end{kframe}'
   x = .rm.empty.envir(paste0(k1, x, k2))
   size = if (options$size == 'normalsize') '' else sprintf('\\%s', options$size)
-  if (!ai) x = sprintf('\\begin{knitrout}%s\n%s%s\n\\end{knitrout}', size, x, if (options$end.paragraph %n% TRUE) '' else '%')
+  if (!ai) {
+    # if the chunk content starts with \n, don't add \n; similarly, if it ends with \n, don't append \n
+    n1 = n2 = '\n'
+    if (grepl('^\\s*\n', x)) n1 = ''
+    if (grepl('\n\\s*$', x)) n2 = ''
+    x = sprintf('\\begin{knitrout}%s%s%s%s\\end{knitrout}', size, n1, x, n2)
+  }
   if (options$split) {
     name = fig_path('.tex', options, NULL)
     if (!file.exists(dirname(name)))

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -191,7 +191,7 @@ hook_plot_tex = function(x, options) {
   k2 = '\\end{kframe}'
   x = .rm.empty.envir(paste0(k1, x, k2))
   size = if (options$size == 'normalsize') '' else sprintf('\\%s', options$size)
-  if (!ai) x = sprintf('\\begin{knitrout}%s\n%s\n\\end{knitrout}', size, x)
+  if (!ai) x = sprintf('\\begin{knitrout}%s\n%s%s\n\\end{knitrout}', size, x, if (options$end.paragraph %n% TRUE) '' else '%')
   if (options$split) {
     name = fig_path('.tex', options, NULL)
     if (!file.exists(dirname(name)))


### PR DESCRIPTION
 Fixes yihui#1851.

@cderv , here's the PR. A few questions:

1. Should I also update `NEWS.md`, and is this a sufficient contribution for the author list in the `DESCRIPTION`?
2. Is `end.paragraph` a good name for the option?
3. Where does this need to be documented? (I don't think the `knitr` R help documents the chunk options anywhere.)
4. Do tests need to be added anywhere?

Also closes #1092.