### PR TITLE
add fig.alt to the special need options for office ouput correct handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
 
 - For Rnw documents, the commented `%\begin{document}` will no longer cause trouble (thanks, @NewbieKnitter @shrektan, #1819).
 
-- Fixed an issue with `fig.alt` chunk option causing figure to disappear with `rmarkdownn::word_document()`. This options is currently supported for HTML output only. If provided for office output in **rmarkdown**, it will emit a warning and be ignored. (#1966)
+- Fixed an issue with the chunk option `fig.alt` causing figures to disappear in `rmarkdownn::word_document()` output. This option is currently supported for HTML output only. If provided for office output in **rmarkdown**, it will emit a warning and be ignored (#1966).
 
 ## MINOR CHANGES
 
@@ -1946,4 +1946,3 @@
 - **knitr** won an Honorable Mention prize (before it was formally released to CRAN) in the Applications of R in Business Contest hosted by Revolution Analytics: http://bit.ly/wP1Dii http://bit.ly/wDRCPV
 
 - in this NEWS file, #n means the issue number on GitHub, e.g. #142 is https://github.com/yihui/knitr/issues/142
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 - For Rnw documents, the commented `%\begin{document}` will no longer cause trouble (thanks, @NewbieKnitter @shrektan, #1819).
 
+- Fixed an issue with `fig.alt` chunk option causing figure to disappear with `rmarkdownn::word_document()`. This options is currently supported for HTML output only. If provided for office output in **rmarkdown**, it will emit a warning and be ignored. (#1966)
+
 ## MINOR CHANGES
 
 - For Rnw documents, if a chunk's output ends with `\n`, **knitr** will no longer add another `\n` to it (thanks, @krivit #1958, @jpritikin 1092).

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -15,13 +15,21 @@ hook_plot_md = function(x, options) {
     }
     if (office_output) {
       if (options$fig.align != 'default') {
-        warning('Chunk options fig.align is not supported for ', to, ' output')
+        warn_options_unsupported('fig.align', to)
         options$fig.align = 'default'
+      }
+      if (!is.null(options$fig.alt)) {
+        warn_options_unsupported('fig.alt', to)
+        options$fig.alt = NULL
       }
       return(hook_plot_md_pandoc(x, options))
     }
   }
   hook_plot_md_base(x, options)
+}
+
+warn_options_unsupported = function(option, to) {
+  warning2('Chunk options ', option, ' is not supported for ', to, ' output')
 }
 
 # decide if the markdown plot hook is not enough and needs special hooks like

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -29,8 +29,8 @@ hook_plot_md = function(x, options) {
 need_special_plot_hook = function(options) {
   opts = opts_chunk$get(default = TRUE)
   for (i in c(
-    'out.width', 'out.height', 'out.extra',
-    'fig.align', 'fig.subcap', 'fig.env', 'fig.scap'
+    'out.width', 'out.height', 'out.extra', 'fig.align', 'fig.subcap',
+    'fig.env', 'fig.scap', 'fig.alt'
   )) if (!identical(options[[i]], opts[[i]])) return(TRUE)
   FALSE
 }

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -28,10 +28,6 @@ hook_plot_md = function(x, options) {
   hook_plot_md_base(x, options)
 }
 
-warn_options_unsupported = function(option, to) {
-  warning2('Chunk options ', option, ' is not supported for ', to, ' output')
-}
-
 # decide if the markdown plot hook is not enough and needs special hooks like
 # hook_plot_tex() to handle chunk options like out.width
 need_special_plot_hook = function(options) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -849,6 +849,10 @@ combine_words = function(
 warning2 = function(...) warning(..., call. = FALSE)
 stop2 = function(...) stop(..., call. = FALSE)
 
+warn_options_unsupported = function(option, to) {
+  warning2('Chunk options ', option, ' is not supported for ', to, ' output')
+}
+
 raw_markers = c('!!!!!RAW-KNITR-CONTENT', 'RAW-KNITR-CONTENT!!!!!')
 
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -850,7 +850,7 @@ warning2 = function(...) warning(..., call. = FALSE)
 stop2 = function(...) stop(..., call. = FALSE)
 
 warn_options_unsupported = function(option, to) {
-  warning2('Chunk options ', option, ' is not supported for ', to, ' output')
+  warning2('Chunk option ', option, ' is not supported for ', to, ' output')
 }
 
 raw_markers = c('!!!!!RAW-KNITR-CONTENT', 'RAW-KNITR-CONTENT!!!!!')

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -67,8 +67,10 @@ x = "1.png"
 w = h = 1
 ex = "style='margin: 0;'"
 cap = "foo"
-opt <- function(w = NULL, h =NULL, ex = NULL, cap = NULL, show = 'asis', ...) {
-  list(out.width = w, out.height = h, out.extra = ex, fig.cap = cap, fig.show = show, ...)
+opt <- function(w = NULL, h =NULL, ex = NULL, cap = NULL, show = 'asis',
+                fig.align = 'default', ...) {
+  list(out.width = w, out.height = h, out.extra = ex,
+       fig.cap = cap, fig.show = show, fig.align = fig.align, ...)
 }
 
 assert("Include a plot by pandoc md", {
@@ -79,4 +81,12 @@ assert("Include a plot by pandoc md", {
   (hook_plot_md_pandoc(x, opt(ex = ex)) %==% sprintf("![](1.png){%s}", ex))
   (hook_plot_md_pandoc(x, opt(w = w, cap = cap, ex = ex)) %==%
     sprintf("![%s](1.png){width=%s %s}", cap, w, ex))
+})
+
+assert("fig.alt does not break office document", {
+  old = opts_knit$get('rmarkdown.pandoc.to')
+  opts_knit$set('rmarkdown.pandoc.to' = "docx")
+  on.exit(opts_knit$set('rmarkdown.pandoc.to' = old))
+  (suppressWarnings(hook_plot_md(x, opt())) %==% "![](1.png)")
+  (suppressWarnings(hook_plot_md(x, opt(fig.alt = "bar"))) %==% "![](1.png)")
 })

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -67,7 +67,6 @@ x = "1.png"
 w = h = 1
 ex = "style='margin: 0;'"
 cap = "foo"
-```suggestion
 opt = function(
   w = NULL, h = NULL, ex = NULL, cap = NULL, show = 'asis',
   fig.align = 'default', ...

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -67,10 +67,15 @@ x = "1.png"
 w = h = 1
 ex = "style='margin: 0;'"
 cap = "foo"
-opt <- function(w = NULL, h =NULL, ex = NULL, cap = NULL, show = 'asis',
-                fig.align = 'default', ...) {
-  list(out.width = w, out.height = h, out.extra = ex,
-       fig.cap = cap, fig.show = show, fig.align = fig.align, ...)
+```suggestion
+opt = function(
+  w = NULL, h = NULL, ex = NULL, cap = NULL, show = 'asis',
+  fig.align = 'default', ...
+) {
+  list(
+    out.width = w, out.height = h, out.extra = ex,
+    fig.cap = cap, fig.show = show, fig.align = fig.align, ...
+  )
 }
 
 assert("Include a plot by pandoc md", {
@@ -85,7 +90,7 @@ assert("Include a plot by pandoc md", {
 
 assert("fig.alt does not break office document", {
   old = opts_knit$get('rmarkdown.pandoc.to')
-  opts_knit$set('rmarkdown.pandoc.to' = "docx")
+  opts_knit$set(rmarkdown.pandoc.to = "docx")
   (suppressWarnings(hook_plot_md(x, opt())) %==% "![](1.png)")
   (suppressWarnings(hook_plot_md(x, opt(fig.alt = "bar"))) %==% "![](1.png)")
   opts_knit$set('rmarkdown.pandoc.to' = old)

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -86,7 +86,7 @@ assert("Include a plot by pandoc md", {
 assert("fig.alt does not break office document", {
   old = opts_knit$get('rmarkdown.pandoc.to')
   opts_knit$set('rmarkdown.pandoc.to' = "docx")
-  on.exit(opts_knit$set('rmarkdown.pandoc.to' = old))
   (suppressWarnings(hook_plot_md(x, opt())) %==% "![](1.png)")
   (suppressWarnings(hook_plot_md(x, opt(fig.alt = "bar"))) %==% "![](1.png)")
+  opts_knit$set('rmarkdown.pandoc.to' = old)
 })


### PR DESCRIPTION
This fix #1965 and complement #1900 

Currently fig.alt is not supported for docx output. 

This support will be added in another PR because it would be nice.