### PR TITLE
Add a bslib engine

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -138,6 +138,7 @@ Suggests:
     showtext,
     tibble,
     sass,
+    bslib,
     ragg,
     styler (>= 1.2.0)
 License: GPL

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - The internal function `html_screenshot()`, which takes screenshots of HTML widgets and Shiny apps in **knitr** documents, now prefers the **webshot2** package over the **webshot** package. This is because the backend of the **webshot** package is PhantomJS, which [has been archived since 2018](https://github.com/ariya/phantomjs/issues/15344). If **webshot** is still preferred, use the chunk option `opts_chunk$set(webshot = "webshot")` (thanks, @atusy #1918, @LouisStAmour #1858).
 
+- Added a new engine, `bslib`, which is a special `scss`/`sass` engine for writing [Sass](https://sass-lang.com) code that wants to leverage [Bootstrap Sass](https://getbootstrap.com/docs/4.6/getting-started/theming/). It's primarily designed to work with `rmarkdown::html_document_base`'s `theme` parameter (when it represents a `bslib::bs_theme()`), but the engine can be used anywhere a `bslib::bs_theme()` is set globally with `bslib::bs_global_set()` (thanks, @cpsievert, #1666).
+
 ## BUG FIXES
 
 - Fixed an issue where code source and results would not show when using a numeric vector in `fig.keep` to select all plots (thanks, @dongzhuoer @ajrgodfrey #1579, @cderv #1955).

--- a/R/engine.R
+++ b/R/engine.R
@@ -742,14 +742,14 @@ eng_sxss = function(options) {
 
 eng_bslib = function(options) {
   if (!loadable("bslib")) {
-    stop("The {bslib} package must be installed in order for the {bslib} knitr engine to work.")
+    stop2("The 'bslib' package must be installed in order for the knitr engine 'bslib' to work.")
   }
   if (!is.null(options$engine.opts$sass_fun)) {
-    stop("The {bslib} knitr engine does not allow for customization of the Sass compilation function.", call. = FALSE)
+    stop2("The 'bslib' knitr engine does not allow for customization of the Sass compilation function.")
   }
-  func <- sass::sass_partial
-  formals(func)$bundle <- quote(bslib::bs_global_get())
-  options$engine.opts$sass_fun <- func
+  func = sass::sass_partial
+  formals(func)$bundle = quote(bslib::bs_global_get())
+  options$engine.opts$sass_fun = func
   eng_sxss(options)
 }
 

--- a/R/engine.R
+++ b/R/engine.R
@@ -738,7 +738,19 @@ eng_sxss = function(options) {
   }
 
   engine_output(options, options$code, final_out)
+}
 
+eng_bslib = function(options) {
+  if (!loadable("bslib")) {
+    stop("The {bslib} package must be installed in order for the {bslib} knitr engine to work.")
+  }
+  if (!is.null(options$engine.opts$sass_fun)) {
+    stop("The {bslib} knitr engine does not allow for customization of the Sass compilation function.", call. = FALSE)
+  }
+  func <- sass::sass_partial
+  formals(func)$bundle <- quote(bslib::bs_global_get())
+  options$engine.opts$sass_fun <- func
+  eng_sxss(options)
 }
 
 # set engines for interpreted languages
@@ -756,7 +768,8 @@ knit_engines$set(
   c = eng_shlib, cc = eng_shlib, fortran = eng_shlib, fortran95 = eng_shlib, asy = eng_dot,
   cat = eng_cat, asis = eng_asis, stan = eng_stan, block = eng_block,
   block2 = eng_block2, js = eng_js, css = eng_css, sql = eng_sql, go = eng_go,
-  python = eng_python, julia = eng_julia, sass = eng_sxss, scss = eng_sxss, R = eng_r
+  python = eng_python, julia = eng_julia, sass = eng_sxss, scss = eng_sxss, R = eng_r,
+  bslib = eng_bslib
 )
 
 cache_engines$set(python = cache_eng_python)


### PR DESCRIPTION
Adds a `{bslib}` engine, which provide a more convenient way to write Sass code that wants to leverage the [Bootstrap Sass](https://getbootstrap.com/docs/4.6/getting-started/theming/) behind `html_document_base`'s `theme` parameter. 

This approach works because `html_document_base()` sets the `theme` globally pre-knit when `theme` represents a `bslib::bs_theme()` object. When no global theme is set (i.e., `theme` isn't a `bs_theme()` object, or this code is running in some other document), then `bslib::bs_global_get()` return `NULL`, making the `sass::sass_partial(input, NULL)` equivalent to `sass::sass(input)`)

cc @cderv

Here's an example

````
---
title: "Say hello to the bslib theming engine"
output: 
  html_document:
    theme:
      version: 4
---

```{bslib, echo = FALSE}
p.my-class {color: $danger !important; }
```

<p class="my-class">
If this text appears red, then the `{bslib}` knitr engine is working!
</p>

The `{bslib}` knitr engine is a special version of `{scss}`/`{sass}` engine (it also expects Sass code), but has the added ability to reference `{bslib}`'s [theming options](https://rstudio.github.io/bslib/articles/bs4-variables.html) (aka Bootstrap Sass variables) when `theme` describes a [`bslib::bs_theme()`](https://rstudio.github.io/bslib/reference/bs_theme.html) object. 
````