### PR TITLE
Package build will fail if rmarkdown is not declared as a dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -107,6 +107,7 @@ Description: Provides a general-purpose tool for dynamic report generation in R
 Depends:
     R (>= 3.2.3)
 Imports:
+    desc,
     evaluate (>= 0.10),
     highr,
     methods,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -108,7 +108,6 @@ Description: Provides a general-purpose tool for dynamic report generation in R
 Depends:
     R (>= 3.2.3)
 Imports:
-    desc,
     evaluate (>= 0.10),
     highr,
     methods,

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 - When the chunk option `include = FALSE`, `error = TRUE` used to be ignored, i.e., errors are signaled nonetheless (causing the knitting process to fail). To avoid this problem, you can now use the numeric value `error = 0` so that **knitr** will not check the `include` option, i.e., knitting will not fail even if `include = FALSE` and an error has occurred in a code chunk, which you wouldn't notice (thanks, @rundel, #1914).
 
-- When processing package vignettes that require **rmarkdown**, we now check that it is declared as a package dependency in the `DESCRIPTION` file (thanks, @dmurdoch, #1919).
+- When processing package vignettes that require **rmarkdown** or **markdown**, we now check that it is declared as a package dependency in the `DESCRIPTION` file (thanks, @dmurdoch, #1919).
 
 - For `tikz` code chunks, a new option `engine.opts$extra.preamble` allows arbitrary LaTeX code to be inserted into the preamble of the template. This allows loading of additional LaTeX and tikz libraries without having to recreate a template from scratch (thanks, @krivit, #1886).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - When the chunk option `include = FALSE`, `error = TRUE` used to be ignored, i.e., errors are signaled nonetheless (causing the knitting process to fail). To avoid this problem, you can now use the numeric value `error = 0` so that **knitr** will not check the `include` option, i.e., knitting will not fail even if `include = FALSE` and an error has occurred in a code chunk, which you wouldn't notice (thanks, @rundel, #1914).
 
+- When processing package vignettes that require **rmarkdown**, we now check that it is declared as a package dependency in the `DESCRIPTION` file (thanks, @dmurdoch, #1919).
+
 ## BUG FIXES
 
 - Fixed an issue where code source and results would not show when using a numeric vector in `fig.keep` to select all plots (thanks, @dongzhuoer @ajrgodfrey #1579, @cderv #1955).

--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -109,21 +109,6 @@ knit2pdf = function(
 #' unlink(c('test.Rmd', 'test.html', 'test.md'))
 knit2html = function(input, output = NULL, ..., envir = parent.frame(), text = NULL,
                      quiet = FALSE, encoding = 'UTF-8', force_v1 = FALSE) {
-  # packages containing vignettes using R Markdown v1 should declare dependency
-  # on 'markdown' in DESCRIPTION (typically in Suggests)
-  if (!is.na(pkg <- xfun::check_package_name()) && pkg != 'markdown') {
-    info = packageDescription(pkg, fields = c('Depends', 'Imports', 'Suggests'))
-    if (!'markdown' %in% unlist(strsplit(unlist(info), '[[:space:],]+'))) {
-      if (xfun::is_CRAN_incoming()) stop2(
-        "The 'markdown' package should be declared as a dependency of the '", pkg,
-        "' package (e.g., in the  'Suggests' field of DESCRIPTION), because it ",
-        "contains vignette(s) built with the 'markdown' package. Please see ",
-        "https://github.com/yihui/knitr/issues/1864 for more information."
-      )
-    }
-  }
-  # TODO: remove the above hack in the future when no CRAN packages have the issue
-
   if (!force_v1 && is.null(text)) {
     signal = if (is_R_CMD_check()) warning2 else stop2
     if (length(grep('^---\\s*$', head(read_utf8(input), 1)))) signal(
@@ -139,7 +124,12 @@ knit2html = function(input, output = NULL, ..., envir = parent.frame(), text = N
   } else markdown::markdownToHTML(text = out, ...)
 }
 
-knit2html_v1 = function(...) knit2html(..., force_v1 = TRUE)
+knit2html_v1 = function(...) {
+  # packages containing vignettes using R Markdown v1 should declare dependency
+  # on 'markdown' in DESCRIPTION (typically in Suggests)
+  test_vig_dep('markdown')
+  knit2html(..., force_v1 = TRUE)
+}
 
 #' Knit an R Markdown document and post it to WordPress
 #'

--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -89,15 +89,17 @@ register_vignette_engines = function(pkg) {
   vig_engine('knitr', vweave, '[.]([rRsS](nw|tex)|[Rr](md|html|rst))$')
   vig_engine('docco_linear', vweave_docco_linear, '[.][Rr](md|markdown)$')
   vig_engine('docco_classic', vweave_docco_classic, '[.][Rr]mk?d$')
-  vig_engine('rmarkdown', function(...) if (has_package('rmarkdown')) {
+  vig_engine('rmarkdown', function(file, ...) if (has_package('rmarkdown')) {
+    if (!desc::desc_has_dep("rmarkdown", file = dirname(file)))
+      stop("Package 'rmarkdown' not found as a package dependency.")
     if (pandoc_available()) {
-      vweave_rmarkdown(...)
+      vweave_rmarkdown(file, ...)
     } else {
       warning(
         'Pandoc (>= 1.12.3) and/or pandoc-citeproc not available. ',
         'Falling back to R Markdown v1.'
       )
-      vweave(...)
+      vweave(file, ...)
     }
   } else {
     # TODO: no longer allow fallback to R Markdown v1
@@ -106,7 +108,7 @@ register_vignette_engines = function(pkg) {
       'package is not available. Did you forget to add it to Suggests in DESCRIPTION? ',
       'Please see https://github.com/yihui/knitr/issues/1864 for more information.'
     )
-    vweave(...)
+    vweave(file, ...)
   }, '[.][Rr](md|markdown)$')
   # vignette engines that disable tangle
   vig_list = tools::vignetteEngine(package = 'knitr')

--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -84,26 +84,17 @@ register_vignette_engines = function(pkg) {
   vig_engine('knitr', vweave, '[.]([rRsS](nw|tex)|[Rr](md|html|rst))$')
   vig_engine('docco_linear', vweave_docco_linear, '[.][Rr](md|markdown)$')
   vig_engine('docco_classic', vweave_docco_classic, '[.][Rr]mk?d$')
-  vig_engine('rmarkdown', function(file, ...) if (has_package('rmarkdown')) {
-    if (!desc::desc_has_dep("rmarkdown", file = dirname(file)))
-      stop("Package 'rmarkdown' not found as a package dependency.")
+  vig_engine('rmarkdown', function(...) if (has_package('rmarkdown')) {
+    test_vig_dep('rmarkdown')
     if (pandoc_available()) {
-      vweave_rmarkdown(file, ...)
+      vweave_rmarkdown(...)
     } else {
-      warning(
-        'Pandoc (>= 1.12.3) and/or pandoc-citeproc not available. ',
-        'Falling back to R Markdown v1.'
-      )
-      vweave(file, ...)
+      warning('Pandoc (>= 1.12.3) not available. Falling back to R Markdown v1.')
+      vweave(...)
     }
   } else {
     # TODO: no longer allow fallback to R Markdown v1
-    (if (xfun::is_CRAN_incoming()) stop2 else warning)(
-      'The vignette engine knitr::rmarkdown is not available because the rmarkdown ',
-      'package is not available. Did you forget to add it to Suggests in DESCRIPTION? ',
-      'Please see https://github.com/yihui/knitr/issues/1864 for more information.'
-    )
-    vweave(file, ...)
+    vweave(...)
   }, '[.][Rr](md|markdown)$')
   # vignette engines that disable tangle
   vig_list = tools::vignetteEngine(package = 'knitr')


### PR DESCRIPTION
... when there's an rmarkdown vignette.

This is too strong:  a warning would be better, but warnings appear to be suppressed in the package build code.  So at a minimum there needs to be a way to suppress this check.  I haven't added one, because I don't know your conventions for doing that.  Or maybe the doc warning is enough, or this check belongs in the RStudio template for an RMarkdown vignette.

This is what I was asking for in issue #1919 , but I'm not sure you'll want it...