### PR TITLE
使用  standalone 文类简化 tikz 模版

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,8 @@
 
 - For `kable(x, format = 'simple')`, it no longer generates a `pipe` table but a `simple` table instead when `x` has only one column (thanks, @alusiani, #1968). For `kable(x, format = 'pipe')`, it no longer warns when `x` has no column names, but just generate an empty table header.
 
+- For `tikz` code chunks, the default LaTeX template uses `\documentclass[tikz]{standalone}` instead of `\documentclass{article}` and \usepackage{preview}` now (thanks, @XiangyunHuang, #1985).
+
 # CHANGES IN knitr VERSION 1.31
 
 ## NEW FEATURES

--- a/inst/misc/tikz2pdf.tex
+++ b/inst/misc/tikz2pdf.tex
@@ -1,12 +1,7 @@
-\documentclass{article}
-\include{preview}
-\usepackage[pdftex,active,tightpage]{preview}
+\documentclass[tikz]{standalone}
 \usepackage{amsmath}
-\usepackage{tikz}
 \usetikzlibrary{matrix}
 %% EXTRA_TIKZ_PREAMBLE_CODE %%
 \begin{document}
-\begin{preview}
 %% TIKZ_CODE %%
-\end{preview}
 \end{document}


### PR DESCRIPTION
[standalone](https://ctan.org/pkg/standalone) 文类替换可以支持 PDFLaTeX 和 XeLaTeX 两种编译方式，当前仅支持 PDFLaTeX， 这对图形中有中文的情况不利，此外，standalone 默认无需指定 preview 且不推荐 preview，preview 设置起来比较繁琐。