### PR TITLE
Use `conditionMessage()` to render conditions

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -538,7 +538,7 @@ sew.warning = function(x, options, ...) {
 
 #' @export
 sew.message = function(x, options, ...) {
-  msg_wrap(paste(x$message, collapse = ''), 'message', options)
+  msg_wrap(paste(conditionMessage(x), collapse = ''), 'message', options)
 }
 
 #' @export

--- a/R/output.R
+++ b/R/output.R
@@ -533,7 +533,7 @@ sew.warning = function(x, options, ...) {
     call = deparse(x$call)[1]
     if (call == 'eval(expr, envir, enclos)') '' else paste(' in', call)
   }
-  msg_wrap(sprintf('Warning%s: %s', call, x$message), 'warning', options)
+  msg_wrap(sprintf('Warning%s: %s', call, conditionMessage(x)), 'warning', options)
 }
 
 #' @export


### PR DESCRIPTION
When following the [error constructor design pattern](https://design.tidyverse.org/err-constructor.html), we might have condition objects with an empty message field. Instead, their message is constructed via the `conditionMessage()` S3 method. Currently, such condition messages are omitted from the {knitr} output.

`sew.error()` doesn't need fixing because `as.character.error()` internally calls `conditionMessage()` ([see here](https://github.com/wch/r-source/blob/77b3c6f6c8f7615af5bf0dda5e6ec898a54ba087/src/library/base/R/conditions.R#L148-L155)).

This the same problem fixed by https://github.com/r-lib/downlit/pull/100.