### PR TITLE
utils-vignettes: Don't disable vtangle if .Rout.save exists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@
 
 - Fix a regression with `fig.keep` chunk option used in chunks with only one figure where the figure was not showing in output (thanks, @fmichonneau, #1993).
 
-- Allow vignettes to be tangled (and output compared) in CMD check if they have a corresponding .Rout.save (thanks, @lentinj, #2018).
+- Allow vignettes to be tangled (and output compared) in `R CMD check` if they have a corresponding `.Rout.save` (thanks, @lentinj, #2018).
 
 # CHANGES IN knitr VERSION 1.33
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 - Fix a regression with `fig.keep` chunk option used in chunks with only one figure where the figure was not showing in output (thanks, @fmichonneau, #1993).
 
+- Allow vignettes to be tangled (and output compared) in CMD check if they have a corresponding .Rout.save (thanks, @lentinj, #2018).
+
 # CHANGES IN knitr VERSION 1.33
 
 ## NEW FEATURES

--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -39,7 +39,11 @@ vweave = function(file, driver, syntax, encoding = 'UTF-8', quiet = FALSE, ...) 
 }
 
 vtangle = function(file, ..., encoding = 'UTF-8', quiet = FALSE) {
-  if (is_R_CMD_check()) {
+  if (is_R_CMD_check() && !file.exists(with_ext(file, 'Rout.save'))) {
+    # Inside CMD check, and no .Rout.save file to compare with, so return an
+    # empty script to avoid errors from vignettes that won't tangle correctly.
+    # NB: This is ~equivalent to setting _R_CHECK_VIGNETTES_SKIP_RUN_MAYBE_=TRUE
+    # and if that becomes the default this is redundant.
     file = with_ext(file, 'R')
     file.create(file)
     return(file)


### PR DESCRIPTION
When inside CMD check, vtangle() returns an empty file to avoid
unnecessary code execution (that already ran as part of the weave), and
prevent vignettes that don't tangle correctly breaking check output.
However, this output is needed if you're trying to compare tangled
output to an ".Rout.save".

This whole code block is nearly redundant, CMD check will perform
similar checks and not tangle, but only if
_R_CHECK_VIGNETTES_SKIP_RUN_MAYBE_ is enabled, which it currently isn't
by default.

Fixes #2017