### PR TITLE
Add a new targets engine

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -142,7 +142,8 @@ Suggests:
     sass,
     bslib,
     ragg,
-    styler (>= 1.2.0)
+    styler (>= 1.2.0),
+    targets (>= 0.6.0)
 License: GPL
 URL: https://yihui.org/knitr/
 BugReports: https://github.com/yihui/knitr/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - For the `tikz` engine, the class options of the `standalone` document classs can be specified via the chunk option `engine.opts$classoption` (thanks, @XiangyunHuang, #1985). The default value is `tikz`, i.e., `\documentclass[tikz]{standalone}` is used by default.
 
+- Added a new `targets` engine (https://github.com/ropensci/targets/issues/503, @wlandau). Details: https://books.ropensci.org/targets/markdown.html.
+
 ## MAJOR CHANGES
 
 - An error is now thrown when an inline code result is not coercible to character. This has always been the assumed behavior but it happens to be different in certain formats with unknown automatic coercion. This is now enforced to prevent any unexpected output. An inline code expression must evaluate to a character vector or an object coercible by `as.character()` (#2006).

--- a/R/engine.R
+++ b/R/engine.R
@@ -765,6 +765,14 @@ eng_bslib = function(options) {
   eng_sxss(options)
 }
 
+# Target Markdown engine contributed by @wlandau
+# Thread: https://github.com/ropensci/targets/issues/503
+# Usage: https://books.ropensci.org/targets/markdown.html
+# Docs: https://docs.ropensci.org/targets/reference/tar_engine_knitr.html
+eng_targets = function(options) {
+  targets::tar_engine_knitr(options = options)
+}
+
 # set engines for interpreted languages
 local({
   for (i in c(
@@ -781,7 +789,7 @@ knit_engines$set(
   cat = eng_cat, asis = eng_asis, stan = eng_stan, block = eng_block,
   block2 = eng_block2, js = eng_js, css = eng_css, sql = eng_sql, go = eng_go,
   python = eng_python, julia = eng_julia, sass = eng_sxss, scss = eng_sxss, R = eng_r,
-  bslib = eng_bslib
+  bslib = eng_bslib, targets = eng_targets
 )
 
 cache_engines$set(python = cache_eng_python)


### PR DESCRIPTION
`targets` version 0.6.0 is on CRAN, and it includes the [Target Markdown](https://books.ropensci.org/targets/markdown.html) engine as implemented in [tar_engine_knitr()](https://docs.ropensci.org/targets/reference/tar_engine_knitr.html). @yihui, you generously allowed this engine to be incorporated directly into `knitr`, and this PR does just that. Thread: https://github.com/ropensci/targets/issues/503.