### PR TITLE
use a single-line progress bar, addresses #1880

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -102,7 +102,8 @@ Authors@R: c(
     person("Viktoras", "Veitas", role = "ctb"),
     person("Weicheng", "Zhu", role = "ctb"),
     person("Wush", "Wu", role = "ctb"),
-    person("Zachary", "Foster", role = "ctb")
+    person("Zachary", "Foster", role = "ctb"),
+    person("Marius", "Barth", role = "ctb", comment = c(ORCID = "0000-0002-3421-6665"))
     )
 Description: Provides a general-purpose tool for dynamic report generation in R
     using Literate Programming techniques.
@@ -172,6 +173,7 @@ Collate:
     'hooks-rst.R'
     'hooks-textile.R'
     'hooks.R'
+    'knit_progress.R'
     'output.R'
     'package.R'
     'pandoc.R'

--- a/R/block.R
+++ b/R/block.R
@@ -73,6 +73,7 @@ call_block = function(block) {
     if (!params$eval) return('')
     cmds = lapply(sc_split(params$child), knit_child, options = block$params)
     out = one_string(unlist(cmds))
+    set_knit_progress("child: ", params$child)
     return(out)
   }
 

--- a/R/block.R
+++ b/R/block.R
@@ -53,7 +53,16 @@ call_block = function(block) {
   # save current chunk options in opts_current
   opts_current$restore(params)
 
-  if (opts_knit$get('progress')) print(block)
+  if (opts_knit$get("progress")) {
+    set_knit_progress("chunk: ", label)
+    if (opts_knit$get('verbose')) {
+      code = knit_code$get(params$label)
+      if(is_blank(code)) break
+      for (i in seq_along(code)) {
+        set_knit_progress(code[[i]])
+      }
+    }
+  }
 
   if (!is.null(params$child)) {
     if (!is_blank(params$code)) warning(
@@ -96,7 +105,7 @@ call_block = function(block) {
     if (cache$exists(hash, params$cache.lazy) &&
         isFALSE(params$cache.rebuild) &&
         params$engine != 'Rcpp') {
-      if (opts_knit$get('verbose')) message('  loading cache from ', hash)
+      if (opts_knit$get('verbose')) set_knit_progress(paste0("Loading cache from ", hash))
       cache$load(hash, lazy = params$cache.lazy)
       cache_engine(params)
       if (!params$include) return('')

--- a/R/block.R
+++ b/R/block.R
@@ -53,13 +53,14 @@ call_block = function(block) {
   # save current chunk options in opts_current
   opts_current$restore(params)
 
-  if (opts_knit$get("progress")) {
+  if (opts_knit$get("progress") && !is_R_CMD_check()) {
     set_knit_progress("chunk: ", label)
     if (opts_knit$get('verbose')) {
       code = knit_code$get(params$label)
-      if(is_blank(code)) break
-      for (i in seq_along(code)) {
-        set_knit_progress(code[[i]])
+      if(!is_blank(code)) {
+        for (i in seq_along(code)) {
+          set_knit_progress(code[[i]])
+        }
       }
     }
   }
@@ -520,7 +521,7 @@ merge_character = function(res) {
 }
 
 call_inline = function(block) {
-  if (opts_knit$get('progress')) print(block)
+  if (opts_knit$get('progress') && !is_R_CMD_check()) print(block)
   in_dir(input_dir(), inline_exec(block))
 }
 

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -55,7 +55,7 @@ knit_progress <- function (
     .killed <<- TRUE
   }
 
-  up(value = 0, text = "Knitting...", carriage_return = "\n ")
+  up(value = 0, text = "Knitting...", carriage_return = "\n")
   structure(list(getVal = getVal, getText = getText, up = up, kill = kill), class = "txtProgressBar")
 }
 

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -1,4 +1,7 @@
 
+# Functions in this file are derived from utils::txtProgressBar(),
+# author: R Core Team and contributors worldwide
+
 knit_progress <- function (
   max = 1
   , title

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -20,7 +20,7 @@ knit_progress <- function (
   text_width <- getOption("width") - width - 8
 
 
-  up <- function(value, text, carriage_return = "\r ") {
+  up <- function(value, text, carriage_return = "\r") {
 
     nb <- round(width * value/max)
     pc <- round(100 * value/max)
@@ -28,7 +28,7 @@ knit_progress <- function (
     if (nb == .nb && pc == .pc && text == .text) return()
     if (!is.finite(value) || value > max) stop("knitr::knit_progress() 'value' is ", value)
 
-    if(isTRUE(knitr::opts_knit$get("verbose")) && text != .text) carriage_return <- "\n "
+    if(isTRUE(knitr::opts_knit$get("verbose")) && text != .text) carriage_return <- "\n"
 
     .text <<- text
     .val <<- value

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -17,7 +17,7 @@ knit_progress <- function (
   char = "."
 
   width <- floor(getOption("width") * 2/5)
-  text_width <- getOption("width") - width - 6
+  text_width <- getOption("width") - width - 7
 
 
   up <- function(value, text, carriage_return = "\r ") {

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -17,7 +17,7 @@ knit_progress <- function (
   char = "."
 
   width <- floor(getOption("width") * 2/5)
-  text_width <- getOption("width") - width - 7
+  text_width <- getOption("width") - width - 8
 
 
   up <- function(value, text, carriage_return = "\r ") {

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -36,7 +36,7 @@ knit_progress <- function (
 
     cat(
       carriage_return
-      , stringr::str_trunc(encodeString(text, width = text_width), width = text_width)
+      , strtrim(encodeString(text, width = text_width), width = text_width)
       , "|"
       , rep.int(char, nb)
       , rep.int(" ", width - nb)

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -68,6 +68,7 @@ set_knit_progress.character <- function(x, ...) {
   x <- paste0(x, ..., collapse = "")
 
   pb <- getOption("knitr.knit_progress")
+  if(is.null(pb)) return()
   oldval <- pb$getVal()
   oldtext <- pb$getText()
   pb$up(value = oldval, text = x)
@@ -76,6 +77,7 @@ set_knit_progress.character <- function(x, ...) {
 
 set_knit_progress.numeric <- function(x, ...) {
   pb <- getOption("knitr.knit_progress")
+  if(is.null(pb)) return()
   oldval <- pb$getVal()
   oldtext <- pb$getText()
   pb$up(value = x, text = oldtext)

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -1,0 +1,80 @@
+
+knit_progress <- function (
+  max = 1
+  , title
+  , message
+  , style = 1
+) {
+
+  .val <- 0
+  .text <- character(1L)
+  .killed <- FALSE
+  .nb <- 0L
+  .pc <- -1L
+  char = "."
+
+  width <- floor(getOption("width") * 2/5)
+  text_width <- getOption("width") - width - 6
+
+
+  up <- function(value, text, carriage_return = "\r ") {
+
+    nb <- round(width * value/max)
+    pc <- round(100 * value/max)
+
+    if (nb == .nb && pc == .pc && text == .text) return()
+    if (!is.finite(value) || value > max) stop("knitr::knit_progress() 'value' is ", value)
+
+    if(isTRUE(knitr::opts_knit$get("verbose")) && text != .text) carriage_return <- "\n "
+
+    .text <<- text
+    .val <<- value
+
+
+    cat(
+      carriage_return
+      , encodeString(stringr::str_trunc(text, width = text_width), width = text_width)
+      , "|"
+      , rep.int(char, nb)
+      , rep.int(" ", width - nb)
+      , sprintf("| %3d%%", pc)
+      , sep = ""
+    )
+    flush.console()
+    .nb <<- nb
+    .pc <<- pc
+  }
+  getVal <- function() .val
+  getText <- function() .text
+  kill <- function() if (!.killed) {
+    cat("\n")
+    flush.console()
+    .killed <<- TRUE
+  }
+
+  up(value = 0, text = "Knitting...", carriage_return = "\n ")
+  structure(list(getVal = getVal, getText = getText, up = up, kill = kill), class = "txtProgressBar")
+}
+
+
+set_knit_progress <- function(x, ...) {
+  UseMethod("set_knit_progress")
+}
+
+set_knit_progress.character <- function(x, ...) {
+  x <- paste0(x, ..., collapse = "")
+
+  pb <- getOption("knitr.knit_progress")
+  oldval <- pb$getVal()
+  oldtext <- pb$getText()
+  pb$up(value = oldval, text = x)
+  invisible(oldval)
+}
+
+set_knit_progress.numeric <- function(x, ...) {
+  pb <- getOption("knitr.knit_progress")
+  oldval <- pb$getVal()
+  oldtext <- pb$getText()
+  pb$up(value = x, text = oldtext)
+  invisible(oldval)
+}

--- a/R/knit_progress.R
+++ b/R/knit_progress.R
@@ -36,7 +36,7 @@ knit_progress <- function (
 
     cat(
       carriage_return
-      , encodeString(stringr::str_trunc(text, width = text_width), width = text_width)
+      , stringr::str_trunc(encodeString(text, width = text_width), width = text_width)
       , "|"
       , rep.int(char, nb)
       , rep.int(" ", width - nb)

--- a/R/output.R
+++ b/R/output.R
@@ -333,6 +333,7 @@ process_file = function(text, output) {
     )
 
     messages <- message_env$messages
+    # warnings <- message_env$warnings
 
     if(length(messages) > 0L) {
       message(
@@ -349,6 +350,23 @@ process_file = function(text, output) {
     for (j in seq_along(messages)) {
       message("  ", messages[[j]], appendLF = FALSE)
     }
+
+    # if(length(warnings) > 0L) {
+    #   warning(
+    #     if (!opts_knit$get("verbose")) "\r" else "\n", strrep(" ", getOption("width")),
+    #     "\rWarnings from lines ",
+    #     paste(current_lines(i), collapse = '-'),
+    #     " in ",
+    #     encodeString(knit_concord$get('infile'), quote = "'"),
+    #     ":",
+    #     immediate. = TRUE,
+    #     call. = FALSE
+    #   )
+    # }
+
+    # for (j in seq_along(warnings)) {
+    #   message("  ", warnings[[j]])
+    # }
   }
 
   if (!tangle) res = insert_header(res)  # insert header
@@ -830,25 +848,3 @@ knit_meta_add = function(meta, label = '') {
   .knitEnv$meta
 }
 
-# tryCatch.M.W.E <- function(expr) {
-#   w.handler <- function(w){ # warning handler
-#     cat(w$message, "\n")
-#     invokeRestart("muffleWarning")
-#   }
-#   m.handler <- function(m) {
-#     cat(m$message, "\n")
-#     invokeRestart("muffleMessage")
-#   }
-#   list(value = withCallingHandlers(
-#     tryCatch(expr, error = function(e) e),
-#       warning = w.handler,
-#       message = m.handler
-#     )
-#   )
-# }
-#
-# res <- tryCatch.M.W.E(expr = {
-#   warning("first warning")
-#   warning("second warning")
-#   message("first message")
-# })

--- a/R/output.R
+++ b/R/output.R
@@ -333,6 +333,8 @@ process_file = function(text, output) {
 
     if(inherits(res[[i]], "try-error")) {
       cat("\n")
+      setwd(wd)
+      cat(unlist(res[seq_len(i - 1L)]), sep = '\n', file = output %n% '')
       stop(
         "Quitting from lines ",
         paste(current_lines(i), collapse = '-'),

--- a/R/output.R
+++ b/R/output.R
@@ -315,8 +315,20 @@ process_file = function(text, output) {
       , type = "message"
     )
 
+    if(length(messages) > 0L) {
+      message(
+        if (!opts_knit$get("verbose")) "\r" else "\n", strrep(" ", getOption("width")),
+        "\rMessages from lines ",
+        paste(current_lines(i), collapse = '-'),
+        " in ",
+        encodeString(knit_concord$get('infile'), quote = "'"),
+        ":",
+        appendLF = TRUE
+      )
+    }
+
     for (j in seq_along(messages)) {
-      message(if (!opts_knit$get("verbose")) "\r" else "\n", strrep(" ", getOption("width")), "\r", messages[[j]], appendLF = TRUE)
+      message("  ", messages[[j]], appendLF = TRUE)
     }
 
     if(inherits(res[[i]], "try-error")) {

--- a/R/output.R
+++ b/R/output.R
@@ -289,7 +289,6 @@ process_file = function(text, output) {
     on.exit(close(getOption("knitr.knit_progress")), add = TRUE)
   }
   wd = getwd()
-  on.exit(setwd(wd))
 
   for (i in seq_len(n)) {
     if (!is.null(.knitEnv$terminate)) {

--- a/R/output.R
+++ b/R/output.R
@@ -319,6 +319,7 @@ process_file = function(text, output) {
   if (!tangle) res = insert_header(res)  # insert header
   # output line numbers
   if (concord_mode()) knit_concord$set(outlines = line_count(res))
+  close(getOption("knitr.knit_progress")) # ensures that cat('\n') is executed before `print_knitlog()`
   print_knitlog()
   if (tangle) res = strip_white(res)
 

--- a/R/output.R
+++ b/R/output.R
@@ -319,7 +319,7 @@ process_file = function(text, output) {
   if (!tangle) res = insert_header(res)  # insert header
   # output line numbers
   if (concord_mode()) knit_concord$set(outlines = line_count(res))
-  close(getOption("knitr.knit_progress")) # ensures that cat('\n') is executed before `print_knitlog()`
+  if(progress) close(getOption("knitr.knit_progress")) # ensures that cat('\n') is executed before `print_knitlog()`
   print_knitlog()
   if (tangle) res = strip_white(res)
 

--- a/R/parser.R
+++ b/R/parser.R
@@ -222,16 +222,10 @@ parse_inline = function(input, patterns) {
 
 print.inline = function(x, ...) {
   if (nrow(x$location)) {
-    cat('   ')
     if (opts_knit$get('verbose')) {
-      cat(stringr::str_pad(' inline R code fragments ',
-                  getOption('width') - 10L, 'both', '-'), '\n')
-      cat(sprintf('    %s:%s %s', x$location[, 1], x$location[, 2], x$code),
-          sep = '\n')
-      cat('  ', stringr::str_dup('-', getOption('width') - 10L), '\n')
-    } else cat('inline R code fragments\n')
-  } else cat('  ordinary text without R code\n')
-  cat('\n')
+      set_knit_progress("inline code: ", sprintf("%s:%s %s", x$location[, 1], x$location[, 2], x$code))
+    } else  set_knit_progress('inline code')
+  } else set_knit_progress('text')
 }
 
 #' Read chunks from an external script


### PR DESCRIPTION
Hi all,

along the lines of #1880, this is an attempt at creating a more compact progress bar.

- creates a globally accessible, bespoke progress bar `knit_progress()`
- create `set_knit_progress()` to update value and/or printed text
- also use `cat()` (instead of `message()` for printing information about processed files, to prevent mixing of streams from `stdout` and `stderr`

If `knitr::opts_knit$set(verbose = TRUE)`, new lines are added between the following lines:
```
processing file:  test.rmd
 chunk: setup                              |..............                  |  43%
 text                                      |..................              |  57%
 chunk: cars                               |..................              |  57%
 summary(cars)                             |..................              |  57%
 x <- sample(2e6)                          |.......................         |  71%
 text                                      |...........................     |  86%
 chunk: pressure                           |...........................     |  86%
 plot(pressure)                            |...........................     |  86%
 x <- sample(2e6)                          |................................| 100%
 text                                      |................................| 100%
output file:  test.knit.md 
```
If `verbose = FALSE`, code bits are not printed, and all lines (except `proceccing file: test.rmd` and `output file: test.knit.md`) are overwritten. I hope this is quiet close to what @hadley had in mind.

To avoid messages messing up the console (and the progress bar), ~~I now use `capture.output(..., type = "message")` to first capture messages and then `cat()` them *above* the progress bar. I'm fully aware that this might be a bit too much, but I couldn't come up with a better solution.~~ EDIT: I came up with a better solution, a proper message handler, and could switch back to `withCallingHandlers()`.

If there are any necessary changes, just let me know.