### PR TITLE
drop obsolete vtangle hack for R CMD check

### DIFF
--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -39,15 +39,6 @@ vweave = function(file, driver, syntax, encoding = 'UTF-8', quiet = FALSE, ...) 
 }
 
 vtangle = function(file, ..., encoding = 'UTF-8', quiet = FALSE) {
-  if (is_R_CMD_check() && !file.exists(with_ext(file, 'Rout.save'))) {
-    # Inside CMD check, and no .Rout.save file to compare with, so return an
-    # empty script to avoid errors from vignettes that won't tangle correctly.
-    # NB: This is ~equivalent to setting _R_CHECK_VIGNETTES_SKIP_RUN_MAYBE_=TRUE
-    # and if that becomes the default this is redundant.
-    file = with_ext(file, 'R')
-    file.create(file)
-    return(file)
-  }
   purl(file, encoding = encoding, quiet = quiet, ...)
 }
 


### PR DESCRIPTION
Following up on #2018, this corresponds to "Option 1" to fix #2017 (and #1093).
I think tampering with R CMD check in `vtangle()` has long been obsolete, because knitr provides

- chunk option `purl=FALSE` following #519
- *_notangle vignette engines following #784
- option "knitr.purl.inline" following #1344

to address potential (hopefully rare) issues with R code extracted from vignette sources.