### PR TITLE
Add ability to pass arguments to dvisvgm through engine.opts (fixes #2038)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 - For the `tikz` engine, the class options of the `standalone` document classs can be specified via the chunk option `engine.opts$classoption` (thanks, @XiangyunHuang, #1985). The default value is `tikz`, i.e., `\documentclass[tikz]{standalone}` is used by default.
 
-- Added the ability to pass additional arguments to `dvisvgm` when using the `tikz` engine with `fig.ext="svg"` by using `dvisvgm.opts` in `engine.opts` (@andrewheiss, #2039). Recent versions of `dvisvgm` now allow you to embed fonts into SVG files as base64-encoded WOFF files, so `tikz` chunks can embed fonts using like so: ```` ```{tikz, fig.ext="svg", engine.opts=list(dvisvgm.opts = "--font-format=woff")}````.
+- Added the ability to pass additional arguments to `dvisvgm` when using the `tikz` engine with `fig.ext = "svg"` by using `dvisvgm.opts` in `engine.opts` (thanks, @andrewheiss, #2039). Recent versions of `dvisvgm` now allow you to embed fonts into SVG files as base64-encoded WOFF files, so `tikz` chunks can embed fonts using like so: ```` ```{tikz, fig.ext="svg", engine.opts=list(dvisvgm.opts = "--font-format=woff")}````.
 
 - Added a new `targets` engine (https://github.com/ropensci/targets/issues/503, @wlandau). Details: https://books.ropensci.org/targets/markdown.html.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 - For the `tikz` engine, the class options of the `standalone` document classs can be specified via the chunk option `engine.opts$classoption` (thanks, @XiangyunHuang, #1985). The default value is `tikz`, i.e., `\documentclass[tikz]{standalone}` is used by default.
 
-- Added the ability to pass additional argument to `dvisvgm` when using the `tikz` engine with `fig.ext="svg"` by using `dvisvgm.opts` in `engine.opts` (@andrewheiss, #2039). Recent versions of `dvisvgm` now allow you to embed fonts into SVG files as base64-encoded WOFF files, so `tikz` chunks can embed fonts using like so: ```` ```{tikz, fig.ext="svg", engine.opts=list(dvisvgm.opts = "--font-format=woff")}````.
+- Added the ability to pass additional arguments to `dvisvgm` when using the `tikz` engine with `fig.ext="svg"` by using `dvisvgm.opts` in `engine.opts` (@andrewheiss, #2039). Recent versions of `dvisvgm` now allow you to embed fonts into SVG files as base64-encoded WOFF files, so `tikz` chunks can embed fonts using like so: ```` ```{tikz, fig.ext="svg", engine.opts=list(dvisvgm.opts = "--font-format=woff")}````.
 
 - Added a new `targets` engine (https://github.com/ropensci/targets/issues/503, @wlandau). Details: https://books.ropensci.org/targets/markdown.html.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - For the `tikz` engine, the class options of the `standalone` document classs can be specified via the chunk option `engine.opts$classoption` (thanks, @XiangyunHuang, #1985). The default value is `tikz`, i.e., `\documentclass[tikz]{standalone}` is used by default.
 
+- Added the ability to pass additional argument to `dvisvgm` when using the `tikz` engine with `fig.ext="svg"` by using `dvisvgm.opts` in `engine.opts` (@andrewheiss, #2039). Recent versions of `dvisvgm` now allow you to embed fonts into SVG files as base64-encoded WOFF files, so `tikz` chunks can embed fonts using like so: ```` ```{tikz, fig.ext="svg", engine.opts=list(dvisvgm.opts = "--font-format=woff")}````.
+
 - Added a new `targets` engine (https://github.com/ropensci/targets/issues/503, @wlandau). Details: https://books.ropensci.org/targets/markdown.html.
 
 - The [chunk option `cache.globals`](https://yihui.org/knitr/options/) can take values `TRUE` and `FALSE` now (in addition to a character vector). When `FALSE`, it tries to find all symbols in the code chunk, no matter if they are local or global variables. When `NULL` or `TRUE`, it tries to find all global variables (thanks, @knokknok, #1898).

--- a/R/engine.R
+++ b/R/engine.R
@@ -306,7 +306,8 @@ eng_tikz = function(options) {
     # dvisvgm needs to be on the path
     # dvisvgm for windows needs ghostscript bin dir on the path also
     if (Sys.which('dvisvgm') == '') tinytex::tlmgr_install('dvisvgm')
-    if (system2('dvisvgm', c('-o', shQuote(fig2), fig)) != 0)
+    if (system2('dvisvgm', c(options$engine.opts$dvisvgm.opts,
+                             '-o', shQuote(fig2), fig)) != 0)
       stop('Failed to compile ', fig, ' to ', fig2)
   } else {
     # convert to the desired output-format using magick

--- a/R/engine.R
+++ b/R/engine.R
@@ -306,9 +306,9 @@ eng_tikz = function(options) {
     # dvisvgm needs to be on the path
     # dvisvgm for windows needs ghostscript bin dir on the path also
     if (Sys.which('dvisvgm') == '') tinytex::tlmgr_install('dvisvgm')
-    if (system2('dvisvgm', c(options$engine.opts$dvisvgm.opts,
-                             '-o', shQuote(fig2), fig)) != 0)
-      stop('Failed to compile ', fig, ' to ', fig2)
+    if (system2('dvisvgm', c(
+      options$engine.opts$dvisvgm.opts, '-o', shQuote(fig2), fig
+    )) != 0) stop('Failed to compile ', fig, ' to ', fig2)
   } else {
     # convert to the desired output-format using magick
     if (ext != 'pdf') magick::image_write(do.call(magick::image_convert, c(


### PR DESCRIPTION
When using `fig.ext="svg"` with a TikZ chunk, it is now possible to pass additional arguments and flags to the `dvisvgm` command, like `--font-format=X` for embedding fonts, or `--no-fonts` for converting all text to outlines. A chunk like this will now convert to an SVG with embedded fonts, for instance:

````
```{tikz example, fig.ext="svg", engine.opts=list(dvisvgm.opts = "--font-format=woff")}
\usetikzlibrary{positioning}
\begin{tikzpicture}
\node (X) at (0,0) {$X_{it}$};
\end{tikzpicture}
```
````