### PR TITLE
In `combine_words`, when words vector is length 2 and `and` is blank, use `sep`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN knitr VERSION 1.35
 
+- In `knitr::combine_words()`, when `words` is length 2 and `and = ""`, `sep` will now be used (thanks, @eitsupi, #2044).
 
 # CHANGES IN knitr VERSION 1.34
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -842,9 +842,10 @@ create_label = function(..., latex = FALSE) {
 #'
 #' If the length of the input \code{words} is smaller than or equal to 1,
 #' \code{words} is returned. When \code{words} is of length 2, the first word
-#' and second word are combined using the \code{and} string. When the length is
-#' greater than 2, \code{sep} is used to separate all words, and the \code{and}
-#' string is prepended to the last word.
+#' and second word are combined using the \code{and} string, or if blank,
+#' \code{sep} if is used. When the length is greater than 2, \code{sep} is used
+#' to separate all words, and the \code{and} string is prepended to the last
+#' word.
 #' @param words A character vector.
 #' @param sep Separator to be inserted between words.
 #' @param and Character string to be prepended to the last word.
@@ -866,7 +867,7 @@ combine_words = function(
   if (n == 0) return(words)
   words = paste0(before, words, after)
   if (n == 1) return(rs(words))
-  if (n == 2) return(rs(paste(words, collapse = and)))
+  if (n == 2) return(rs(paste(words, collapse = if (is_blank(and)) sep else and)))
   if (oxford_comma && grepl('^ ', and) && grepl(' $', sep)) and = gsub('^ ', '', and)
   words[n] = paste0(and, words[n])
   # combine the last two words directly without the comma

--- a/man/combine_words.Rd
+++ b/man/combine_words.Rd
@@ -36,9 +36,10 @@ elements, we may want to combine them into a phrase like \samp{a and b}, or
 \details{
 If the length of the input \code{words} is smaller than or equal to 1,
 \code{words} is returned. When \code{words} is of length 2, the first word
-and second word are combined using the \code{and} string. When the length is
-greater than 2, \code{sep} is used to separate all words, and the \code{and}
-string is prepended to the last word.
+and second word are combined using the \code{and} string, or if blank,
+\code{sep} if is used. When the length is greater than 2, \code{sep} is used
+to separate all words, and the \code{and} string is prepended to the last
+word.
 }
 \examples{
 combine_words("a")

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -123,6 +123,7 @@ assert('combine_words() combines multiple words into a single string', {
   (cw(NULL) %==% NULL)
   (cw(c('a')) %==% 'a')
   (cw(c('a', 'b')) %==% 'a and b')
+  (cw(c('a', 'b'), and = "") %==% 'a, b')
   (cw(c('a', 'b', 'c')) %==% 'a, b, and c')
   (cw(c('a', 'b', 'c'), and = '') %==% 'a, b, c')
   (cw(c('a', 'b', 'c'), ' / ', '') %==% 'a / b / c')


### PR DESCRIPTION
This fixes #2044

@yihui I don't know if this is the fix you were expected.

The behavior described in #2044 is currently the one documented: 
> When words is of length 2, the first word and second word are combined using the and string.

``` r
knitr::combine_words(c("a", "b"), before = "`", and = "")
#> `a``b`
knitr::combine_words(c("a", "b"), before = "`", and = " or ")
#> `a` or `b`
```

What I am proposing here is that we support a special case: When length is two AND `knitr::is_blank(and)`, then we use `sep`

``` r
knitr::combine_words(c("a", "b"), before = "`", and = "")
#> `a`, `b`
knitr::combine_words(c("a", "b"), before = "`", and = " or ")
#> `a` or `b`
```

Is that ok ? 


