### PR TITLE
Lengthen fence characters when needed (fix #1621)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
 
 - In `knitr::combine_words()`, when `words` is length 2 and `and = ""`, `sep` will now be used (thanks, @eitsupi, #2044).
 
-- When `knit()` Rmd file, chunks output sources with satisfying length of fences (thanks, @atusy, #2047).
+- For R Markdown documents, if the chunk output contains N backticks, the `output` hook will use N + 1 backticks to wrap the output, so that the N verbatim backticks can be correctly preserved (thanks, @atusy, #2047).
 
 # CHANGES IN knitr VERSION 1.34
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - In `knitr::combine_words()`, when `words` is length 2 and `and = ""`, `sep` will now be used (thanks, @eitsupi, #2044).
 
+- When `knit()` Rmd file, chunks output sources with satisfying length of fences (thanks, @atusy, #2047).
+
 # CHANGES IN knitr VERSION 1.34
 
 ## NEW FEATURES

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -152,7 +152,7 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
 #' @export
 hooks_markdown = function(strict = FALSE, fence_char = '`') {
   fence = paste(rep(fence_char, 3), collapse = '')
-  update_fence <- function(x) {
+  update_fence = function(x) {
     r = paste0('\n', fence_char, '{3,}')
     if (grepl(r, x)) {
       l = attr(gregexpr(r, x)[[1]], 'match.length')

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -153,7 +153,6 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
 hooks_markdown = function(strict = FALSE, fence_char = '`') {
   fence = paste(rep(fence_char, 3), collapse = '')
   update_fence <- function(x) {
-    x = one_string(c('', x))
     r = paste0('\n', fence_char, '{3,}')
     if (grepl(r, x)) {
       l = attr(gregexpr(r, x)[[1]], 'match.length')
@@ -168,6 +167,7 @@ hooks_markdown = function(strict = FALSE, fence_char = '`') {
     if (strict) {
       paste('\n', indent_block(x), '', sep = '\n')
     } else {
+      x = one_string(c('', x))
       fence = update_fence(x)
       paste0('\n\n', fence, block_attr(attr, class), x, fence, '\n\n')
     }
@@ -183,7 +183,7 @@ hooks_markdown = function(strict = FALSE, fence_char = '`') {
     if (language == 'node') language = 'javascript'
     if (!options$highlight) language = 'text'
     attrs = block_attr(options$attr.source, options$class.source, language)
-    fence = update_fence(x)
+    fence = update_fence(one_string(c('', x)))
     paste0('\n\n', fence, attrs, '\n', x, fence, '\n\n')
   }
   list(

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -152,19 +152,23 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
 #' @export
 hooks_markdown = function(strict = FALSE, fence_char = '`') {
   fence = paste(rep(fence_char, 3), collapse = '')
+  update_fence <- function(x) {
+    x = one_string(c('', x))
+    r = paste0('\n', fence_char, '{3,}')
+    if (grepl(r, x)) {
+      l = attr(gregexpr(r, x)[[1]], 'match.length')
+      l = max(l)
+      if (l >= 4) fence = paste(rep(fence_char, l), collapse = '')
+    }
+    fence
+  }
   # four spaces lead to <pre></pre>
   hook.t = function(x, options, attr = NULL, class = NULL) {
     # this code-block duplicated from hook.t()
     if (strict) {
       paste('\n', indent_block(x), '', sep = '\n')
     } else {
-      x = one_string(c('', x))
-      r = paste0('\n', fence_char, '{3,}')
-      if (grepl(r, x)) {
-        l = attr(gregexpr(r, x)[[1]], 'match.length')
-        l = max(l)
-        if (l >= 4) fence = paste(rep(fence_char, l), collapse = '')
-      }
+      fence = update_fence(x)
       paste0('\n\n', fence, block_attr(attr, class), x, fence, '\n\n')
     }
   }
@@ -179,6 +183,7 @@ hooks_markdown = function(strict = FALSE, fence_char = '`') {
     if (language == 'node') language = 'javascript'
     if (!options$highlight) language = 'text'
     attrs = block_attr(options$attr.source, options$class.source, language)
+    fence = update_fence(x)
     paste0('\n\n', fence, attrs, '\n', x, fence, '\n\n')
   }
   list(

--- a/R/parser.R
+++ b/R/parser.R
@@ -400,38 +400,17 @@ parse_chunk = function(x, rc = knit_patterns$get('ref.chunk')) {
 
 # filter chunk.end lines that don't actually end a chunk
 filter_chunk_end = function(chunk.begin, chunk.end, lines = NULL, patterns = NULL) {
-  keys = c('chunk.begin', 'chunk.end')
-  if (identical(patterns[keys], all_patterns[['md']][keys])) {
-    filter_chunk_end_md(chunk.begin, chunk.end, lines)
-  } else {
-    filter_chunk_end_general(chunk.begin, chunk.end)
-  }
-}
-
-filter_chunk_end_general = function(chunk.begin, chunk.end) {
   in.chunk = FALSE
-  fun = function(is.begin, is.end) {
-    if (in.chunk && is.end) {
-      in.chunk <<- FALSE
-      return(TRUE)
-    }
-    if (!in.chunk && is.begin) in.chunk <<- TRUE
-    FALSE
-  }
-  mapply(fun, chunk.begin, chunk.end)
-}
-
-filter_chunk_end_md = function(chunk.begin, chunk.end, lines) {
-  in.chunk = FALSE
-  expected_end = NA_character_
+  is.md = identical(patterns, all_patterns[['md']])
+  pattern.end = NA_character_
   fun = function(is.begin, is.end, line) {
-    if (in.chunk && is.end && grepl(expected_end, line)) {
+    if (in.chunk && is.end && (is.na(pattern.end) || grepl(pattern.end, line))) {
       in.chunk <<- FALSE
       return(TRUE)
     }
     if (!in.chunk && is.begin) {
       in.chunk <<- TRUE
-      expected_end <<- paste0(sub('(^[\t >]*```+).*', '\\1', line), "\\s*$")
+      if (is.md) pattern.end <<- paste0(sub('(^[\t >]*```+).*', '\\1', line), "\\s*$")
     }
     FALSE
   }

--- a/R/parser.R
+++ b/R/parser.R
@@ -505,10 +505,10 @@ parse_chunk = function(x, rc = knit_patterns$get('ref.chunk')) {
 }
 
 # filter chunk.end lines that don't actually end a chunk
-filter_chunk_end = function(chunk.begin, chunk.end, lines = NA_character_, patterns = NA_character_) {
+filter_chunk_end = function(chunk.begin, chunk.end, lines = NA, patterns = list()) {
   in.chunk = FALSE
   is.md = identical(patterns, all_patterns[['md']])
-  pattern.end = NA_character_
+  pattern.end = NA
   fun = function(is.begin, is.end, line) {
     if (in.chunk && is.end && (is.na(pattern.end) || grepl(pattern.end, line))) {
       in.chunk <<- FALSE
@@ -516,7 +516,7 @@ filter_chunk_end = function(chunk.begin, chunk.end, lines = NA_character_, patte
     }
     if (!in.chunk && is.begin) {
       in.chunk <<- TRUE
-      if (is.md) pattern.end <<- paste0(sub('(^[\t >]*```+).*', '\\1', line), "\\s*$")
+      if (is.md) pattern.end <<- sub('(^[\t >]*```+).*', '\\1\\\\s*$', line)
     }
     FALSE
   }

--- a/R/parser.R
+++ b/R/parser.R
@@ -399,7 +399,7 @@ parse_chunk = function(x, rc = knit_patterns$get('ref.chunk')) {
 }
 
 # filter chunk.end lines that don't actually end a chunk
-filter_chunk_end = function(chunk.begin, chunk.end, lines = NULL, patterns = NULL) {
+filter_chunk_end = function(chunk.begin, chunk.end, lines = NA_character_, patterns = NA_character_) {
   in.chunk = FALSE
   is.md = identical(patterns, all_patterns[['md']])
   pattern.end = NA_character_

--- a/R/parser.R
+++ b/R/parser.R
@@ -425,13 +425,13 @@ filter_chunk_end_md = function(chunk.begin, chunk.end, lines) {
   in.chunk = FALSE
   expected_end = NA_character_
   fun = function(is.begin, is.end, line) {
-    if (in.chunk && is.end && identical(line, expected_end)) {
+    if (in.chunk && is.end && grepl(expected_end, line)) {
       in.chunk <<- FALSE
       return(TRUE)
     }
     if (!in.chunk && is.begin) {
       in.chunk <<- TRUE
-      expected_end <<- sub('(^[\t >]*```+).*', '\\1', line)
+      expected_end <<- paste0(sub('(^[\t >]*```+).*', '\\1', line), "\\s*$")
     }
     FALSE
   }

--- a/R/parser.R
+++ b/R/parser.R
@@ -399,7 +399,7 @@ parse_chunk = function(x, rc = knit_patterns$get('ref.chunk')) {
 }
 
 # filter chunk.end lines that don't actually end a chunk
-filter_chunk_end = function(chunk.begin, chunk.end, lines, patterns) {
+filter_chunk_end = function(chunk.begin, chunk.end, lines = NULL, patterns = NULL) {
   keys = c('chunk.begin', 'chunk.end')
   if (identical(patterns[keys], all_patterns[['md']][keys])) {
     filter_chunk_end_md(chunk.begin, chunk.end, lines)

--- a/R/parser.R
+++ b/R/parser.R
@@ -13,7 +13,7 @@ split_file = function(lines, set.preamble = TRUE, patterns = knit_patterns$get()
   }
 
   blks = grepl(chunk.begin, lines)
-  txts = filter_chunk_end(blks, grepl(chunk.end, lines))
+  txts = filter_chunk_end(blks, grepl(chunk.end, lines), lines, patterns)
   # tmp marks the starting lines of a code/text chunk by TRUE
   tmp = blks | head(c(TRUE, txts), -1)
 
@@ -399,7 +399,16 @@ parse_chunk = function(x, rc = knit_patterns$get('ref.chunk')) {
 }
 
 # filter chunk.end lines that don't actually end a chunk
-filter_chunk_end = function(chunk.begin, chunk.end) {
+filter_chunk_end = function(chunk.begin, chunk.end, lines, patterns) {
+  keys = c('chunk.begin', 'chunk.end')
+  if (identical(patterns[keys], all_patterns[['md']][keys])) {
+    filter_chunk_end_md(chunk.begin, chunk.end, lines)
+  } else {
+    filter_chunk_end_general(chunk.begin, chunk.end)
+  }
+}
+
+filter_chunk_end_general = function(chunk.begin, chunk.end) {
   in.chunk = FALSE
   fun = function(is.begin, is.end) {
     if (in.chunk && is.end) {
@@ -410,6 +419,23 @@ filter_chunk_end = function(chunk.begin, chunk.end) {
     FALSE
   }
   mapply(fun, chunk.begin, chunk.end)
+}
+
+filter_chunk_end_md = function(chunk.begin, chunk.end, lines) {
+  in.chunk = FALSE
+  expected_end = NA_character_
+  fun = function(is.begin, is.end, line) {
+    if (in.chunk && is.end && identical(line, expected_end)) {
+      in.chunk <<- FALSE
+      return(TRUE)
+    }
+    if (!in.chunk && is.begin) {
+      in.chunk <<- TRUE
+      expected_end <<- sub('(^[\t >]*```+).*', '\\1', line)
+    }
+    FALSE
+  }
+  mapply(fun, chunk.begin, chunk.end, lines)
 }
 
 #' Get all chunk labels in a document

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -29,6 +29,11 @@ assert('include_graphics() includes custom images correctly', {
 hook_src = knit_hooks$get("source")
 options_ = list(engine = "r", prompt = FALSE, highlight = TRUE)
 
+assert('Lengh of fences are satisfied', {
+  (hook_src("", options_) %==% "\n\n```r\n\n```\n\n")
+  (hook_src("```", options_) %==% "\n\n````r\n```\n````\n\n")
+})
+
 assert('Attributes for source can be specified class.source and attr.source', {
   (hook_src("1", c(options_, class.source = "a b")) %==% "\n\n```{.r .a .b}\n1\n```\n\n")
   (hook_src("1", c(options_, attr.source = ".a .b")) %==% "\n\n```{.r .a .b}\n1\n```\n\n")


### PR DESCRIPTION
Fixes #1621.

- [x] Update source
- [x] Add tests
- [x] Update NEWS
- [x] pass CI

## Reprex

``` r
rmd = tempfile(fileext = ".Rmd")
c(
  "````{r}",
  "invisible('",
  "```",
  "')",
  "````"
) |> writeLines(rmd)

knitr::knit(rmd, tempfile(), quiet = TRUE) |>
  readLines() |>
  cat(sep = "\n")
```

``` #>
#> ````r
#> invisible('
#> ```
#> ')
#> ````
```

<sup>Created on 2021-09-21 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
