### PR TITLE
Set default `strip.white` so that we modify later conditionally

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN knitr VERSION 1.35
 
+- Fix a regression in 1.34: Blank lines are now more stripped by default when `collapse = TRUE`, only when `collapse = FALSE`. If you liked the new behavior, set `strip.white = TRUE` globally or on per chunk basis (thanks, @IndrajeetPatil, rstudio/rmarkdown#2220, #2046).
+
 - In `knitr::combine_words()`, when `words` is length 2 and `and = ""`, `sep` will now be used (thanks, @eitsupi, #2044).
 
 # CHANGES IN knitr VERSION 1.34

--- a/R/defaults.R
+++ b/R/defaults.R
@@ -67,10 +67,12 @@ new_defaults = function(value = list()) {
 #' @export
 #' @examples opts_chunk$get('prompt'); opts_chunk$get('fig.keep')
 opts_chunk = new_defaults(list(
-
   eval = TRUE, echo = TRUE, results = 'markup', tidy = FALSE, tidy.opts = NULL,
   collapse = FALSE, prompt = FALSE, comment = '##', highlight = TRUE,
-  strip.white = TRUE, size = 'normalsize', background = '#F7F7F7',
+  size = 'normalsize', background = '#F7F7F7',
+
+  # NA value means will set the default option later (e.g in fix_options)
+  strip.white = NA,
 
   cache = FALSE, cache.path = 'cache/', cache.vars = NULL, cache.lazy = TRUE,
   dependson = NULL, autodep = FALSE, cache.rebuild = FALSE,

--- a/R/defaults.R
+++ b/R/defaults.R
@@ -71,8 +71,9 @@ opts_chunk = new_defaults(list(
   collapse = FALSE, prompt = FALSE, comment = '##', highlight = TRUE,
   size = 'normalsize', background = '#F7F7F7',
 
-  # NA value means will set the default option later (e.g in fix_options)
-  strip.white = NA,
+  # value wrapped in I() means a change in default option later
+  # (e.g in fix_options, conditionally to other argument)
+  strip.white = I(TRUE),
 
   cache = FALSE, cache.path = 'cache/', cache.vars = NULL, cache.lazy = TRUE,
   dependson = NULL, autodep = FALSE, cache.rebuild = FALSE,

--- a/R/utils.R
+++ b/R/utils.R
@@ -311,11 +311,15 @@ fix_options = function(options) {
     }
   }
 
+  # Adjust some options when collapse is TRUE
   if (options$collapse) {
     options[unlist(lapply(
       c('class.', 'attr.'), paste0, c('output', 'message', 'warning', 'error')
     ))] = NULL
   }
+
+  # Change default of value conditionally
+  if (is.na(options$strip.white)) options$strip.white = !options$collapse
 
   options
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -244,7 +244,8 @@ tikz_dict = function(path) {
   paste(sans_ext(basename(path)), 'tikzDictionary', sep = '-')
 }
 
-# compatibility with Sweave and old beta versions of knitr
+# Initially for compatibility with Sweave and old beta versions of knitr
+# but now also place to tweak default options
 fix_options = function(options) {
   options = as.strict_list(options)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -320,7 +320,8 @@ fix_options = function(options) {
   }
 
   # Change default of value conditionally
-  if (is.na(options$strip.white)) options$strip.white = !options$collapse
+  if (inherits(options$strip.white, 'AsIs'))
+    options$strip.white = !options$collapse
 
   options
 }

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -186,14 +186,25 @@ assert('block_attr(x) turns a character vector into Pandoc attributes', {
 })
 
 
-keys = unlist(lapply(
-  c('class.', 'attr.'), paste0, c('source', 'output', 'message', 'warning', 'error')
-))
-keys_source = c('class.source', 'attr.source')
-opts = fix_options(opts_chunk$merge(c(setNames(as.list(keys), keys), list(collapse = TRUE))))
 assert('when collapse is TRUE, class.* and attr.* become NULL except for class.source and attr.source', {
+  keys = unlist(lapply(
+    c('class.', 'attr.'), paste0, c('source', 'output', 'message', 'warning', 'error')
+  ))
+  keys_source = c('class.source', 'attr.source')
+  opts = fix_options(opts_chunk$merge(c(setNames(as.list(keys), keys), list(collapse = TRUE))))
   (opts[keys_source] %==% as.list(setNames(keys_source, keys_source)))
   (!any(names(opts) %in% setdiff(keys, keys_source)))
+  rm(keys, keys_source, opts)
+})
+
+assert('default strip.white is conditional to collapse', {
+  opts = opts_chunk$get(default = TRUE)
+  (fix_options(opts)$strip.white %==% TRUE)
+  opts$collapse = TRUE
+  (fix_options(opts)$strip.white %==% FALSE)
+  opts$strip.white = TRUE
+  (fix_options(opts)$strip.white %==% TRUE)
+  rm(opts)
 })
 
 assert('pandoc_to gets the current Pandoc format', {


### PR DESCRIPTION
This close #2046 and fix the regression mentioned in rstudio/rmarkdown#2220

* Options is set to `NA` by default (i.e `strip.white = NA`)
* Option default is then "fixed" in `fix_options()` where we adjust according to other chunk option, global or per chunk. 

This is the first option where we set a default value that will be conditional to another one, defined by user. 

I added a unit test for this, and I guess we'll need a knitr-example test for this to have snapshot test of the output. It would have prevented the breakage in the first place. However, not as easy as with testthat snaphot test to add a new test in knitr-example synced with this PR - I need to improve the system there. 

Anyway, I think this will work ok now and don't think this change will impact other stuff.

