### PR TITLE
knitr-examples checks can run on the same PR branch name

### DIFF
--- a/.github/actions/checkout-knitr-examples/action.yml
+++ b/.github/actions/checkout-knitr-examples/action.yml
@@ -1,15 +1,6 @@
 name: 'Checkout knitr-example'
 author: Christophe Dervieux
 description: 'Checkout knitr-example project on the right branch, i.e same branch name as the current PR main branch'
-# inputs:
-#   who-to-greet:  # id of input
-#     description: 'Who to greet'
-#     required: true
-#     default: 'World'
-# outputs:
-#   random-number:
-#     description: "Random number"
-#     value: ${{ steps.random-number-generator.outputs.random-id }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/checkout-knitr-examples/action.yml
+++ b/.github/actions/checkout-knitr-examples/action.yml
@@ -1,0 +1,38 @@
+name: 'Checkout knitr-example'
+author: Christophe Dervieux
+description: 'Checkout knitr-example project on the right branch, i.e same branch name as the current PR main branch'
+# inputs:
+#   who-to-greet:  # id of input
+#     description: 'Who to greet'
+#     required: true
+#     default: 'World'
+# outputs:
+#   random-number:
+#     description: "Random number"
+#     value: ${{ steps.random-number-generator.outputs.random-id }}
+runs:
+  using: "composite"
+  steps:
+      - name: Determine branch name
+        id: check-branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          headref="${{ github.head_ref }}"
+          if [ -z "$headref" ]
+          then
+            echo '::debug::Not on pull request - using main ref branch'
+            branch=''
+          else
+            echo '::debug::On pull request'
+            branch=$(gh api repos/yihui/knitr-examples/branches | jq -cr '.[] | select(.name == '\"$headref\"') | .name')
+          fi
+          echo ::set-output name=ref::$(echo $branch)
+        shell: bash
+      - name: Retrieve knitr-examples
+        uses: actions/checkout@v2
+        with:
+          repository: yihui/knitr-examples
+          path: knitr-examples
+          ref: ${{ steps.check-branch.outputs.ref }}
+          clean: false

--- a/.github/workflows/knitr-examples.yaml
+++ b/.github/workflows/knitr-examples.yaml
@@ -38,8 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      # TODO: Use next tag once this commit is in a release
-      - uses: r-lib/actions/setup-tinytex@5f1c1346f28a05c35128f89c766079a0bca8d786
+      - uses: r-lib/actions/setup-tinytex@v1
         env:
           # install full prebuilt version
           TINYTEX_INSTALLER: TinyTeX
@@ -52,11 +51,8 @@ jobs:
         shell: Rscript {0}
 
       - name: Retrieve knitr-examples
-        uses: actions/checkout@v2
-        with:
-          repository: yihui/knitr-examples
-          path: knitr-examples
-          clean: false
+        # On PR, it will checkout same branch if it exists there
+        uses: ./.github/actions/checkout-knitr-examples
 
       - name: Cache R packages
         if: runner.os != 'Windows'


### PR DESCRIPTION
Otherwise, use the main branch in knitr-examples.

This is something I wanted to do for a long time, and now it is working. 

Basically, what we do is 

* Retrieve `github.head_ref` which is only set on PR triggered workflow run.
* If not a PR run, then we will use default ref `ref: ''`
* If a PR, there will be a value and we check if there is a branch with the same in **knitr-examples** repo. 
* If there is, we will checkout this branch from the repo. 
* If not, we will checkout the main branch. 

Only limitation, this will not work (yet) for PR branches in **knitr-examples**. The branch must be a remote branch not from a fork. 

We'll improve if needed. As is, it will allow us both to make a PR in knitr-examples with the same branch name as in the PR in knitr, and the checks will run accordingly. 