### PR TITLE
Add 'rows affected' output when using sql engine

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+- The `sql` engine now produces an output for update-like SQL queries, indicating the number of rows affected (as returned by DBI::dbExecute). So far, `knitr` produces a nicely formatted output for queries returning a result set (typically SELECT...), but gives no feedback at all for queries making changes to the DB (e.g. INSERT|UPDATE|DELETE|CREATE|DROP; see not exported function knitr:::is_sql_update_query). For such queries, `knitr` now shows the number of affected rows. You can also set the chunk option `output.var` to assign the number of affected rows to a variable.
+
+
+
 # CHANGES IN knitr VERSION 1.35
 
 ## BUG FIXES

--- a/R/engine.R
+++ b/R/engine.R
@@ -633,6 +633,11 @@ eng_sql = function(options) {
 
     } else print(display_data) # fallback to standard print
   })
+  if (is.numeric(data) && length(data) == 1 && is.null(varname)) {
+    options$results = 'asis'
+    # format = "fg" instead of "d". Row counts on DB may be greater than integer max value
+    output = paste0("Number of affected rows: ", formatC(data, format = "fg", big.mark = ','))
+  }
   if (options$results == 'hide') output = NULL
 
   # assign varname if requested

--- a/R/engine.R
+++ b/R/engine.R
@@ -555,8 +555,8 @@ eng_sql = function(options) {
 
   data = tryCatch({
     if (is_sql_update_query(query)) {
-      DBI::dbExecute(conn, query)
-      NULL
+      data = DBI::dbExecute(conn, query)
+      data
     } else if (is.null(varname) && max.print > 0) {
       # execute query -- when we are printing with an enforced max.print we
       # use dbFetch so as to only pull down the required number of records


### PR DESCRIPTION
Adds a default output for `sql` chunks where `is_sql_update_query` evaluates to TRUE, as proposed in #2050.

It does it simply by:
- [Commit 1](https://github.com/edalfon/knitr/commit/f78e1c60ee00920aa48d03a3d166f2b6e3947435): propagating `DBI::DBI::dbExecute`'s result to `data`, so that users can set `output.var` and get the number of affected rows assigned to a variable.
- [Commit 2](https://github.com/edalfon/knitr/commit/d1f8cbf5255473b3ff4f711abb54ce2a4d036b82): adding a default output, indicating the number of rows affected.

I included a line in `NEWS.md` describing this. However, I did not include a test. I was not familiar with `knitr`'s testing procedures, but I learned from this recent PR (#1987) that there is one major test for `knitr`'s sql engine in another repository (https://raw.githubusercontent.com/yihui/knitr-examples/master/115-engine-sql.Rmd). This already covers the changes in this PR. I used it to test the changes and everything works. So I didn't really think it was necessary to include additional tests.

A final note: as discussed in [knitr's issue #1637](https://github.com/yihui/knitr/issues/1637), I think a similar change would be needed on RStudio's side, to make it also work when running chunks interactively (RStudio's Run current chunk, Run all, etc.). I haven't looked into that, though, and I have no idea who to poke for this, but I'd be happy to take a look.

Huge thanks for `knitr` and hope this helps a tiny bit.
 
