### PR TITLE
Extend class= regex in rocco to allow hyphens

### DIFF
--- a/R/rocco.R
+++ b/R/rocco.R
@@ -64,7 +64,7 @@ rocco = function(input, ...) {
   i2 = max(grep('<!--table end-->$', txt))
   x = one_string(txt[seq(i1 + 1, i2 - 1)])
   x = gsub('</pre>\\s*<pre>', '<!--ReDuNdAnTpRe-->', x)  # merge pre blocks
-  m = gregexpr('<pre><code( class="[[:alnum:]]+")?>(.|\n)*?</code></pre>', x)
+  m = gregexpr('<pre><code( class="[[:alnum:]-]+")?>(.|\n)*?</code></pre>', x)
   if (m[[1]][1] == -1) stop('No code blocks in HTML output')
 
   code = regmatches(x, m)[[1]]


### PR DESCRIPTION
As seen e.g. here:

https://github.com/cran/startup/blob/6c67c07bab3e464f2f7f10e51fb12d5d93972c25/inst/doc/startup-intro.html#L95

I'm not sure exactly what causes `"language-r"` to be generated (which makes adding a test hard, too), but I do see it in a few places.

It seems like a pretty straightforward fix, but I am treading lightly in case there are other risks I may not be aware of.