### PR TITLE
Respect the package option root.dir when looking for child documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,10 @@
   
   Note that if any line of the content to be commented out contains `N` backticks, you will have to use at least `N + 1` backticks in the chunk header and footer of the `comment` chunk.
 
+## BUG FIXES
+
+- The chunk option `child` also respects the package option `root.dir` now (thanks, @salim-b, https://community.rstudio.com/t/117563).
+
 ## MINOR CHANGES
 
 - Improved the (warning) message when unbalanced chunk delimiters are detected in R Markdown documents, to make it easier for users to fix the problem. The message now contains the line numbers of the opening fence and closing fence, as well as the opening and closing backticks. For example, the opening fence may be `````"````{r}"````` (four backticks) but the closing fence is ````"```"```` (three backticks---should also be four to match the opening fence), or the opening fence is indented ````"  ```{r}"```` but the closing fence is not ````"```"````. Note that this warning message may become an error in the future, i.e., unbalanced chunk delimiters will no longer be allowed.

--- a/R/output.R
+++ b/R/output.R
@@ -136,7 +136,7 @@ knit = function(
     # in child mode, input path needs to be adjusted
     if (in.file && !is_abs_path(input)) {
       input = paste0(opts_knit$get('child.path'), input)
-      input = file.path(input_dir(TRUE), input)
+      input = file.path(input_dir(), input)
     }
     # respect the quiet argument in child mode (#741)
     optk = opts_knit$get(); on.exit(opts_knit$set(optk), add = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -148,23 +148,11 @@ output_asis = function(x, options) {
   is_blank(x) || options$results == 'asis'
 }
 
-# path relative to dir of the input file
-input_dir = function(ignore_root = FALSE) {
+# the working directory: use root.dir if specified, otherwise the dir of the
+# input file unless knitr.use.cwd = TRUE
+input_dir = function() {
   root = opts_knit$get('root.dir')
-  # LyX is a special case: the input file is in tempdir, and we should use
-  # root.dir as the real input dir (#809)
-  if (is_lyx()) return(root)
-  if (ignore_root) {
-    .knitEnv$input.dir %n% '.'
-  } else {
-    root %n% (if (!getOption('knitr.use.cwd', FALSE)) .knitEnv$input.dir) %n% '.'
-  }
-}
-
-is_lyx = function() {
-  args = commandArgs(TRUE)
-  if (length(args) < 4) return(FALSE)
-  grepl('[.]Rnw$', args[1]) && !is.na(Sys.getenv('LyXDir', NA))
+  root %n% (if (!getOption('knitr.use.cwd', FALSE)) .knitEnv$input.dir) %n% '.'
 }
 
 # detect if running on CRAN (assuming that CRAN does not set CI or


### PR DESCRIPTION
Fixes the problem reported at https://community.rstudio.com/t/117563

Also note that the is_lyx() trick is no longer necessary since I had specified root.dir in the R script: https://github.com/yihui/lyx-R/blob/master/scripts/lyxknitr.R#L31