### PR TITLE
Possible issue with is_cran()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -160,7 +160,7 @@ input_dir = function() {
 is_cran = function() {
   x = Sys.getenv('R_CRANDALF', NA)
   if (!is.na(x)) tolower(x) == 'true' else {
-    !any(tolower(Sys.getenv(c('CI', 'NOT_CRAN')))) == 'true'
+    !any(tolower(Sys.getenv(c('CI', 'NOT_CRAN'))) == 'true')
   }
 }
 


### PR DESCRIPTION
I think this could be an issue here. 

We want the parenthesis here right ? 

Saw that in some log 
````
Warning in any(tolower(Sys.getenv(c("CI", "NOT_CRAN")))) :
    coercing argument of type 'character' to logical
````

