### PR TITLE
Verbatim engine using the cat engine

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -788,11 +788,11 @@ eng_verbatim = function(options) {
 
   # change default for the cat engine
   options$eval = FALSE
-  if (!is.null(options$language)) {
-    options$engine.opts$lang = options$language
-  } else if (is.null(options$engine.opts$lang) && is.null(options$class.source)) {
-    options$engine.opts$lang = 'default'
-  }
+  # specify the lang name in engine.opts = list(lang = ), or lang/language,
+  # or class.source; if all are empty, use 'default'
+  options$engine.opts$lang = options$engine.opts$lang %in%
+    unlist(options[c('lang', 'language')])[1] %n%
+    options$class.source %n% 'default'
 
   eng_cat(options)
 }

--- a/R/engine.R
+++ b/R/engine.R
@@ -791,7 +791,7 @@ eng_verbatim = function(options) {
   if (!is.null(options$language)) {
     options$engine.opts$lang = options$language
   } else if (is.null(options$engine.opts$lang) && is.null(options$class.source)) {
-    options$engine.opts$lang = ''
+    options$engine.opts$lang = 'default'
   }
 
   eng_cat(options)

--- a/R/engine.R
+++ b/R/engine.R
@@ -790,7 +790,7 @@ eng_verbatim = function(options) {
   options$eval = FALSE
   # specify the lang name in engine.opts = list(lang = ), or lang/language,
   # or class.source; if all are empty, use 'default'
-  options$engine.opts$lang = options$engine.opts$lang %in%
+  options$engine.opts$lang = options$engine.opts$lang %n%
     unlist(options[c('lang', 'language')])[1] %n%
     options$class.source %n% 'default'
 

--- a/R/engine.R
+++ b/R/engine.R
@@ -791,7 +791,7 @@ eng_verbatim = function(options) {
   if (!is.null(options$language)) {
     options$engine.opts$lang = options$language
   } else if (is.null(options$engine.opts$lang) && is.null(options$class.source)) {
-    options$engine.opts$lang = if(is.null(pandoc_to())) '' else 'default'
+    options$engine.opts$lang = 'default'
   }
 
   eng_cat(options)

--- a/R/engine.R
+++ b/R/engine.R
@@ -393,6 +393,20 @@ eng_cat = function(options) {
   engine_output(options, options$code, NULL)
 }
 
+## a verbatim engine that returns its chunk content verbatim
+eng_verbatim = function(options) {
+  if (!out_format('markdown')) {
+    warning("The 'verbatim' engine only works for Markdown output at the moment.")
+    return(one_string(options$code))
+  }
+
+  # change default for the cat engine
+  options$eval = FALSE
+  if (is.null(options$engine.opts$lang) && is.null(options$class.source))
+    options$class.source = "md"
+  eng_cat(options)
+}
+
 ## output the code without processing it
 eng_asis = function(options) {
   if (options$echo) one_string(options$code)
@@ -776,20 +790,6 @@ eng_targets = function(options) {
 
 # a comment engine to return nothing
 eng_comment = function(options) {}
-
-# a verbatim engine that returns its chunk content verbatim
-eng_verbatim = function(options) {
-  if (!out_format('markdown')) {
-    warning("The 'verbatim' engine only works for Markdown output at the moment.")
-    return(one_string(options$code))
-  }
-
-  # use the 'output' hook to wrap the chunk content (inside ````md by default)
-  lang = options$class.output %n% 'md'
-  if (is.na(lang)) lang = NULL  # set class.output = NA to disable output class
-  options = merge_list(options, list(class.output = lang, echo = FALSE, comment = ''))
-  engine_output(options, '', options$code)
-}
 
 # set engines for interpreted languages
 local({

--- a/R/engine.R
+++ b/R/engine.R
@@ -791,7 +791,7 @@ eng_verbatim = function(options) {
   if (!is.null(options$language)) {
     options$engine.opts$lang = options$language
   } else if (is.null(options$engine.opts$lang) && is.null(options$class.source)) {
-    options$engine.opts$lang = 'default'
+    options$engine.opts$lang = if(is.null(pandoc_to())) '' else 'default'
   }
 
   eng_cat(options)

--- a/R/engine.R
+++ b/R/engine.R
@@ -395,20 +395,6 @@ eng_cat = function(options) {
   engine_output(options, options$code, NULL)
 }
 
-## a verbatim engine that returns its chunk content verbatim
-eng_verbatim = function(options) {
-  if (!out_format('markdown')) {
-    warning("The 'verbatim' engine only works for Markdown output at the moment.")
-    return(one_string(options$code))
-  }
-
-  # change default for the cat engine
-  options$eval = FALSE
-  if (is.null(options$engine.opts$lang) && is.null(options$class.source))
-    options$class.source = "md"
-  eng_cat(options)
-}
-
 ## output the code without processing it
 eng_asis = function(options) {
   if (options$echo) one_string(options$code)
@@ -792,6 +778,20 @@ eng_targets = function(options) {
 
 # a comment engine to return nothing
 eng_comment = function(options) {}
+
+## a verbatim engine that returns its chunk content verbatim
+eng_verbatim = function(options) {
+  if (!out_format('markdown')) {
+    warning("The 'verbatim' engine only works for Markdown output at the moment.")
+    return(one_string(options$code))
+  }
+
+  # change default for the cat engine
+  options$eval = FALSE
+  if (is.null(options$engine.opts$lang) && is.null(options$class.source))
+    options$class.source = "md"
+  eng_cat(options)
+}
 
 # set engines for interpreted languages
 local({

--- a/R/engine.R
+++ b/R/engine.R
@@ -390,8 +390,8 @@ eng_cat = function(options) {
   if (is.null(lang <- options$engine.opts$lang) && is.null(lang <- options$class.source))
     return('')
   # Use engine to set the attribute
-  options$engine = lang
-  options$class.source = setdiff(options$class.source, lang)
+  options$engine = lang[1]
+  options$class.source = setdiff(options$class.source, lang[1])
   engine_output(options, options$code, NULL)
 }
 

--- a/R/engine.R
+++ b/R/engine.R
@@ -389,7 +389,9 @@ eng_cat = function(options) {
 
   if (is.null(lang <- options$engine.opts$lang) && is.null(lang <- options$class.source))
     return('')
+  # Use engine to set the attribute
   options$engine = lang
+  options$class.source = setdiff(options$class.source, lang)
   engine_output(options, options$code, NULL)
 }
 

--- a/R/engine.R
+++ b/R/engine.R
@@ -791,7 +791,7 @@ eng_verbatim = function(options) {
   if (!is.null(options$lang)) {
     options$engine.opts$lang = options$lang
   } else if (is.null(options$engine.opts$lang) && is.null(options$class.source)) {
-    options$class.source = "md"
+    options$engine.opts$lang = ''
   }
 
   eng_cat(options)

--- a/R/engine.R
+++ b/R/engine.R
@@ -788,8 +788,8 @@ eng_verbatim = function(options) {
 
   # change default for the cat engine
   options$eval = FALSE
-  if (!is.null(options$lang)) {
-    options$engine.opts$lang = options$lang
+  if (!is.null(options$language)) {
+    options$engine.opts$lang = options$language
   } else if (is.null(options$engine.opts$lang) && is.null(options$class.source)) {
     options$engine.opts$lang = ''
   }

--- a/R/engine.R
+++ b/R/engine.R
@@ -788,8 +788,12 @@ eng_verbatim = function(options) {
 
   # change default for the cat engine
   options$eval = FALSE
-  if (is.null(options$engine.opts$lang) && is.null(options$class.source))
+  if (!is.null(options$lang)) {
+    options$engine.opts$lang = options$lang
+  } else if (is.null(options$engine.opts$lang) && is.null(options$class.source)) {
     options$class.source = "md"
+  }
+
   eng_cat(options)
 }
 


### PR DESCRIPTION
This is another option for #2040 instead of #2060

**It is why I made it a PR again #2060 and not master to see the different between two solutions**. So if accepted, this should be merged then #2060 should be merged.

It uses the `eng_cat` implementation use source hook by changing the default of the cat engine. 

* `eval = FALSE` by default to not write to a file
* By default, language will be set to markdown (but maybe no language highglight should be the default ?)
* language attributes can be set using `options$engine.opts$lang` or a single `options$class.source` - should we simplify into `options$lang` directly ?

Example 

`````markdown
---
title: "R Notebook"
output: html_document
---

# Default to markdown

Should we use default to nothing ? 

````{verbatim}
We can output arbitrary content verbatim.
  
```{r}
1 + 1
```

The content can contain inline code like
`r pi * 5^2`, too.
````

# No highlight specifically

````{verbatim, class.source = ''}
We can output arbitrary content verbatim.
  
```{r}
1 + 1
```

The content can contain inline code like
`r pi * 5^2`, too.
````

````{verbatim, class.source = 'default'}
We can output arbitrary content verbatim.
  
```{r}
1 + 1
```

The content can contain inline code like
`r pi * 5^2`, too.
````

# Setting a language 

````{verbatim, class.source = "javascript"}
document.getElementById("demo").innerHTML = "Hello JavaScript!"
````

````{verbatim, engine.opts = list(lang = "javascript")}
document.getElementById("demo").innerHTML = "Hello JavaScript!"
````

# Setting a language and another class

````{verbatim, engine.opts = list(lang = "javascript"), class.source = "numberLines"}
document.getElementById("demo").innerHTML = "Hello JavaScript!"
````

````{verbatim, class.source = c("javascript", "numberLines")}
document.getElementById("demo").innerHTML = "Hello JavaScript!"
````
`````

This will serve as test in knitr-example repo