### PR TITLE
Use xcolor instead of color

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -15,9 +15,7 @@ insert_header = function(doc) {
 # Makes latex header with macros required for highlighting, tikz and framed
 make_header_latex = function() {
   h = one_string(c(
-    sprintf('\\usepackage[%s]{graphicx}\\usepackage[%s]{color}',
-            opts_knit$get('latex.options.graphicx') %n% '',
-            opts_knit$get('latex.options.color') %n% ''),
+    header_latex_packages(),
     .header.maxwidth, opts_knit$get('header'),
     if (getOption('OutDec') != '.') '\\usepackage{amsmath}',
     if (out_format('latex')) '\\usepackage{alltt}'
@@ -26,6 +24,20 @@ make_header_latex = function() {
     write_utf8(h, 'knitr.sty')
     '\\usepackage{knitr}'
   }
+}
+
+use_package = function(pkg) {
+  opts = opts_knit$get(paste0('latex.options.', pkg)) %n% ''
+  sprintf('\\usepackage[%s]{%s}', opts, pkg)
+}
+
+# for backward-compatibility, use xcolor package unless the latex.options.color
+# has been set; xcolor is preferred: https://github.com/latex3/latex2e/pull/719
+header_latex_packages = function() {
+  paste(c(
+    use_package('graphicx'),
+    use_package(if (is.null(opts_knit$get('latex.options.color'))) 'xcolor' else 'color')
+  ), collapse = '')
 }
 
 insert_header_latex = function(doc, b) {

--- a/R/themes.R
+++ b/R/themes.R
@@ -70,9 +70,6 @@ theme_to_header_latex = function(theme) {
 
   # write latex highlight header
   fgheader = color_def(foreground, 'fgcolor')
-  fgheader = c(fgheader, '\\makeatletter', sprintf(
-    '\\@ifundefined{AddToHook}{}{\\AddToHook{package/xcolor/after}{%s}}', fgheader
-  ), '\\makeatother')
   highlight = one_string(c(fgheader, styler_assistant_latex(css_out[-1])))
   list(highlight = highlight, background = background, foreground = foreground)
 }

--- a/inst/misc/knitr.sty
+++ b/inst/misc/knitr.sty
@@ -21,13 +21,5 @@
 \definecolor{messagecolor}{rgb}{0, 0, 0}
 \definecolor{warningcolor}{rgb}{1, 0, 1}
 \definecolor{errorcolor}{rgb}{1, 0, 0}
-\makeatletter
-\@ifundefined{AddToHook}{}{\AddToHook{package/xcolor/after}{
-\definecolor{shadecolor}{rgb}{.97, .97, .97}
-\definecolor{messagecolor}{rgb}{0, 0, 0}
-\definecolor{warningcolor}{rgb}{1, 0, 1}
-\definecolor{errorcolor}{rgb}{1, 0, 0}
-}}
-\makeatother
 \newenvironment{knitrout}{}{} % an empty environment to be redefined in TeX
 


### PR DESCRIPTION
To avoid the issue https://github.com/latex3/xcolor/issues/10 per suggestion from https://github.com/latex3/latex2e/pull/719. It reverts 4c6978ef070fb1c0a105fcce9e2265b22470692e.

This needs a news item and documentation (to explain that `xcolor` will be used by default).

This PR shouldn't be merged until after knitr 1.37 is released.