### PR TITLE
Engine for ditaa text diagrams

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.37.5
+Version: 1.37.6
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@
   
   We'd like to thank @TianyiShi2001 for the inspiration (#1829 #1823 #1833).
 
+- Added a new engine `ditaa` based on the `exec` engine to convert ASCII art diagrams to bitmaps (thanks, @kondziu, #2092).
+
 - Added two new chunk options, `class.chunk` and `attr.chunk`, for R Markdown output. These options can enclose the whole chunk output (source and results) in a fenced Div. Their syntax follows other chunk options with the similar names `class.*` and `attr.*` (e.g., `class.source` and `attr.source`). For example, `class.chunk = "foo"` would wrap the chunk output inside `::: {.foo}` and `:::` (thanks, @atusy, #2099).
 
 - Added a new chunk option `lang` to set the language name of a code chunk. By default, the language name is the engine name. This is primarily useful for syntax highlighting the source chunks in Markdown-based output. Previously the `lang` option was only available to a few engines such as `verbatim` and `embed`. Now it is available to all engines.

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@
   
   We'd like to thank @TianyiShi2001 for the inspiration (#1829 #1823 #1833).
 
-- Added a new engine `ditaa` based on the `exec` engine to convert ASCII art diagrams to bitmaps (thanks, @kondziu, #2092).
+- Added a new engine `ditaa` based on the `exec` engine to convert ASCII art diagrams to bitmaps via [the `ditaa` command](https://github.com/stathissideris/ditaa) (thanks, @kondziu, #2092).
 
 - Added two new chunk options, `class.chunk` and `attr.chunk`, for R Markdown output. These options can enclose the whole chunk output (source and results) in a fenced Div. Their syntax follows other chunk options with the similar names `class.*` and `attr.*` (e.g., `class.source` and `attr.source`). For example, `class.chunk = "foo"` would wrap the chunk output inside `::: {.foo}` and `:::` (thanks, @atusy, #2099).
 

--- a/R/engine.R
+++ b/R/engine.R
@@ -394,7 +394,7 @@ eng_tikz = function(options) {
   engine_output(options, options$code, '', extra)
 }
 
-## Commands that generate plots, e.g., GraphViz (dot) and Asymptote
+## Commands that generate plots, e.g., GraphViz (dot), Asymptote, and Ditaa
 eng_plot = function(options) {
   options$command = cmd = options$engine
   options$fig.ext = ext = dev2ext(options)
@@ -414,58 +414,13 @@ eng_plot = function(options) {
     },
     args = function(code, file) {
       f2 = with_ext(file, ext)
+      if (cmd == 'ditaa') return(c(file, f2))
       if (cmd %in% c('dot', 'asy')) {
         c(file, c(dot = '-T', asy = '-f')[cmd], ext, '-o', f2)
       }
     })
   options$engine.opts = merge_list(opts, options$engine.opts)
   eng_exec(options)
-}
-
-## Ditaa text diagrams
-eng_ditaa = function(options) {
-
-  # write code to a temp file, and output to another temp file
-  code_tempfile = wd_tempfile('code')
-  image_tempfile = wd_tempfile('out')
-  write_utf8(code <- options$code, code_tempfile)
-  on.exit(unlink(c(code_tempfile, image_tempfile)), add = TRUE)
-
-  # Figure out output extension
-  image_extension <- options$fig.ext %n% dev2ext(options$dev)
-  image_tempfile <- paste0(image_tempfile, '.', image_extension)
-
-  # prepare system command string
-  cmd = sprintf(
-    '%s %s -scale %i %s %s %s %s %s %s -o %s',
-    shQuote(get_engine_path(options$engine.path, options$engine)),                                   # path to ditaa
-    ifelse(is.null(options$encoding), '', paste0('--encoding ', options$encoding)),                  # encoding (none by default)
-    ifelse(is.null(options$scale), 2, as.integer(options$scale)),                                    # scale (2 by default)
-    ifelse(is.null(options$transparent) || options$transparent == TRUE, '-T', ''),                   # transparent background on/off (on by default)
-    ifelse(is.null(options$shadows) || options$shadows == FALSE, '--no-shadows', ''),                # shadows on/off (off by default)
-    ifelse(is.null(options$separation) || options$separation == FALSE, '--no-separation', ''),       # separation on/off (off by default)
-    ifelse(is.null(options$antialias) || options$antialias == TRUE, '', '--no-antialias'),           # anti-alias on/off (on by default)
-    ifelse(is.null(options$round.corners) || options$round.corners == FALSE, '', '--round-corners'), # round corners on/off (off by default)
-    shQuote(code_tempfile),                                                                          # input file
-    shQuote(image_tempfile)                                                                          # output file
-  )
-
-  # generate output
-  outf = paste(fig_path(), image_extension, sep = '.')
-  dir.create(dirname(outf), recursive = TRUE, showWarnings = FALSE)
-  unlink(outf)
-  extra = if (options$eval) {
-    if (options$message) message('running: ', cmd)
-    system(cmd)
-    file.rename(image_tempfile, outf)
-    if (!file.exists(outf)) stop('Failed to compile the ', options$engine, ' chunk')
-    options$fig.num = 1L; options$fig.cur = 1L
-    run_hook_plot(outf, options)
-  }
-
-  # wrap
-  options$engine = 'ditaa'
-  engine_output(options, code, '', extra)
 }
 
 ## Andre Simon's highlight
@@ -932,7 +887,7 @@ knit_engines$set(
   cc = eng_shlib,
   comment = eng_comment,
   css = eng_css,
-  ditaa = eng_ditaa,
+  ditaa = eng_plot,
   dot = eng_plot,
   embed = eng_embed,
   exec = eng_exec,

--- a/R/engine.R
+++ b/R/engine.R
@@ -412,6 +412,8 @@ eng_plot = function(options) {
       }
       engine_output(options, code, '', extra)
     },
+    # better default for ditaa: https://github.com/yihui/knitr/pull/2092
+    args1 = if (cmd == 'ditta') c('-s', 2, '-T', '-S', '-E'),
     args = function(code, file) {
       f2 = with_ext(file, ext)
       if (cmd == 'ditaa') return(c(file, f2))


### PR DESCRIPTION
Ditaa (https://github.com/stathissideris/ditaa) is a small command-line utility that converts ASCII art diagrams into bitmaps. It can be useful for making rough-and-ready images accompanying technical text. The pull request adds an engine to knitr to perform the conversion in place while knitting. 

Example ditaa diagram in ASCII form:

```
    +--------+--------+--------+--------+--------+--------+--=--+--------+--------+--------+--------+
    | cCCC   | cCCC   | c99C   | c99C   | cCCC   | cCCC   |     | cCCC   | cCCC   | c99C   | c99C   |
----+ R a[0] | R b[0] | W a[0] | W b[0] | R a[1] | R b[1] | ... | R a[9] | R b[9] | W a[9] | W b[9] +----
    |        |        |        |        |        |        |     |        |        |        |        |
    +--------+--------+--------+--------+--------+--------+--=--+--------+--------+--------+--------+

                                        +--------+--------+--------+--------+--------+--------+--=--+--------+--------+--------+--------+
                                        | cCCC   | cCCC   | c99C   | c99C   | cCCC   | cCCC   |     | cCCC   | cCCC   | c99C   | c99C   |
----------------------------------------+ R b[0] | R c[0] | W b[0] | W c[0] | R b[1] | R c[1] | ... | R b[9] | R c[9] | W b[9] | W c[9] +----
                                        |        |        |        |        |        |        |     |        |        |        |        |
                                        +--------+--------+--------+--------+--------+--------+--=--+--------+--------+--------+--------+
```

And an image generated from it:

![lets_have_some_fun3](https://user-images.githubusercontent.com/50334/148222716-1b14105f-b683-4882-80df-b28c934bec4f.png)

The extension is based on the Dot/Asymptote engine, extended with command line options for configuring the conversion.

