### PR TITLE
Add a newline on empty string in `comment_out(newline = TRUE)`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -27,7 +27,7 @@ line_prompt = function(x, prompt = getOption('prompt'), continue = getOption('co
 # add a prefix to output
 comment_out = function(x, prefix = '##', which = TRUE, newline = TRUE) {
   x = gsub('[\n]{2,}$', '\n', x)
-  if (newline) x = gsub('([^\n])$', '\\1\n', x)  # add \n if not exists
+  if (newline) x = gsub('([^\n]|^)$', '\\1\n', x)  # add \n if not exists
   if (is.null(prefix) || !nzchar(prefix) || is.na(prefix)) return(x)
   prefix = paste(prefix, '')
   x = gsub(' +([\n]*)$', '\\1', x)

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -220,3 +220,16 @@ assert('pandoc_to gets the current Pandoc format', {
   (pandoc_to(c('docx', 'pptx')))
   opts_knit$set(opts)
 })
+
+assert('comment_out() add prefix and newlines if asked', {
+  (comment_out("a") %==% "## a\n")
+  (comment_out("ab cd") %==% "## ab cd\n")
+  (comment_out("ab cd\n") %==% "## ab cd\n")
+  (comment_out("") %==% "## \n")
+  (comment_out("\n") %==% "## \n")
+  (comment_out(c("a", "b")) %==% c("## a\n", "## b\n"))
+  (comment_out(c("a", "b"), which = 2) %==% c("a\n", "## b\n"))
+  (comment_out("a", newline = FALSE) %==% "## a")
+  (comment_out("a", prefix = "$") %==% "$ a\n")
+  (comment_out("a", prefix = NULL) %==% "a\n")
+})


### PR DESCRIPTION
This fixes rstudio/rmarkdown#1849

`comment_out(newline = TRUE)` also now works with an empty string. 

This PR adds some tests for `comment_out()` behavior.

Seems like a change ok to do that will fix the empty message case reported in **rmarkdown**.  Is there anything I may have missed ? 

Also, should we add NEWS here for this internal function fix ? Or a NEWS item in **rmarkdown** as the issue was reported there ? 