### PR TITLE
bug fix in group_indices()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - Chunk options defined in the `#|` style are not recognized when the code chunk is indented or quoted (thanks, @mine-cetinkaya-rundel, #2086).
 
+- Fixed a bug in `Sweave2knitr()` #2097 (thanks, @chroetz).
+
 # CHANGES IN knitr VERSION 1.37
 
 ## NEW FEATURES

--- a/R/parser.R
+++ b/R/parser.R
@@ -566,7 +566,7 @@ group_indices = function(chunk.begin, chunk.end, lines = NA, is.md = FALSE) {
     }
     g
   }
-  mapply(fun, chunk.begin, chunk.end, lines, seq_along(lines))
+  mapply(fun, chunk.begin, chunk.end, lines, seq_along(chunk.begin))
 }
 
 match_chunk_begin = function(pattern.end, x, pattern = '^\\1\\\\{') {


### PR DESCRIPTION
`knitr::Sweave2knitr(text = c("<<>>=", "0", "@"))` wrongly removes the "@". This is due to a bug in `knitr:::group_indices()`. Try `knitr:::group_indices(c(F,T,F,F,F),c(F,F,F,T,F))`. This results in `1 0 1 1 1` instead of `1 2 2 2 3`. The reason for the bug is the last line of `group_indices()`:
```
mapply(fun, chunk.begin, chunk.end, lines, seq_along(lines))
```
`lines` is an argument of `group_indices()` with default value `NA`. Thus, in the default case, `fun()` is always called with the 4th argument equal to 1, which indicates that the processed line is the first line of a document. Hence, the function always returns a vector consisting only of 1s and 0s. Changing this line to 
```
mapply(fun, chunk.begin, chunk.end, lines, seq_along(chunk.begin))
```
solves the problem.