### PR TITLE
Implement class.chunk and attr.chunk option to wrap entire chunk in Pandoc's fenced div (closes #2000)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@
   
   We'd like to thank @TianyiShi2001 for the inspiration (#1829 #1823 #1833).
 
+- Markdown output allows new chunk options, `class.chunk` and `attr.chunk`, which encloses whole chunk including sources and results. Their syntax follows other chunk options with the similar names `class.*` and `attr.*` (e.g., `class.source` and `attr.source`).
+
 ## BUG FIXES
 
 - Chunk options defined in the `#|` style are not recognized when the code chunk is indented or quoted (thanks, @mine-cetinkaya-rundel, #2086).

--- a/R/block.R
+++ b/R/block.R
@@ -132,16 +132,6 @@ cache2.opts = c('fig.keep', 'fig.path', 'fig.ext', 'dev', 'dpi', 'dev.args', 'fi
 # options that should not affect cache
 cache0.opts = c('include', 'out.width.px', 'out.height.px', 'cache.rebuild')
 
-block_wrap = function(output, options) {
-  if (is.null(options$class.chunk)) return(output)
-  cls = paste(options$class.chunk, collapse = ' ')
-  paste0(
-    '<div', if (cls != '') sprintf(' class="%s"', cls), '>\n\n',
-    output,
-    '</div>\n\n'
-  )
-}
-
 block_exec = function(options) {
   if (options$engine == 'R') return(eng_r(options))
 
@@ -152,7 +142,6 @@ block_exec = function(options) {
   if (is.list(output)) output = unlist(output)
   res.after = run_hooks(before = FALSE, options)
   output = paste(c(res.before, output, res.after), collapse = '')
-  output = block_wrap(output, options)
   output = knit_hooks$get('chunk')(output, options)
   if (options$cache) {
     cache.exists = cache$exists(options$hash, options$cache.lazy)
@@ -316,7 +305,6 @@ eng_r = function(options) {
   res.after = run_hooks(before = FALSE, options, env) # run 'after' hooks
 
   output = paste(c(res.before, output, res.after), collapse = '')  # insert hook results
-  output = block_wrap(output, options)
   output = knit_hooks$get('chunk')(output, options)
 
   if (options$cache > 0) {

--- a/R/block.R
+++ b/R/block.R
@@ -132,6 +132,16 @@ cache2.opts = c('fig.keep', 'fig.path', 'fig.ext', 'dev', 'dpi', 'dev.args', 'fi
 # options that should not affect cache
 cache0.opts = c('include', 'out.width.px', 'out.height.px', 'cache.rebuild')
 
+block_wrap = function(output, options) {
+  if (is.null(options$class.chunk)) return(output)
+  cls = paste(options$class.chunk, collapse = ' ')
+  paste0(
+    '<div', if (cls != '') sprintf(' class="%s"', cls), '>\n\n',
+    output,
+    '</div>\n\n'
+  )
+}
+
 block_exec = function(options) {
   if (options$engine == 'R') return(eng_r(options))
 
@@ -142,6 +152,7 @@ block_exec = function(options) {
   if (is.list(output)) output = unlist(output)
   res.after = run_hooks(before = FALSE, options)
   output = paste(c(res.before, output, res.after), collapse = '')
+  output = block_wrap(output, options)
   output = knit_hooks$get('chunk')(output, options)
   if (options$cache) {
     cache.exists = cache$exists(options$hash, options$cache.lazy)
@@ -305,6 +316,7 @@ eng_r = function(options) {
   res.after = run_hooks(before = FALSE, options, env) # run 'after' hooks
 
   output = paste(c(res.before, output, res.after), collapse = '')  # insert hook results
+  output = block_wrap(output, options)
   output = knit_hooks$get('chunk')(output, options)
 
   if (options$cache > 0) {

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -229,13 +229,13 @@ pandoc_div = function(x, .attr = NULL, .class = NULL) {
   div = paste(rep(':', n), collapse = '')
   paste0(
     paste(div, block_attr(.attr, .class), sep = " "),
-    '\n\n',
+    '\n',
     x,
-    '\n\n',
+    '\n',
     div
   )
 }
-                     
+
 # convert some engine names to language names
 eng2lang = function(x) {
   d = c(

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -205,11 +205,35 @@ hooks_markdown = function(strict = FALSE, fence_char = '`') {
         r = sprintf('\n([%s]{3,})\n+\\1((\\{[.])?%s[^\n]*)?\n', fence_char, tolower(options$engine))
         x = gsub(r, '\n', x)
       }
+      x = pandoc_div(x, options[['attr.chunk']], options[['class.chunk']])
       if (is.null(s <- options$indent)) return(x)
       line_prompt(x, prompt = s, continue = s)
     },
     output = hook.o('output'), warning = hook.o('warning'),
     error = hook.o('error'), message = hook.o('message')
+  )
+}
+
+pandoc_div = function(x, .attr = NULL, .class = NULL) {
+  if (is.null(.attr) && is.null(.class)) return(x)
+  if (!is.character(x) || length(x) != 1L) {
+    warning('x is unprocessed because x is not a character vector of length 1.')
+    return(x)
+  }
+  n = 1L + max(
+    2L,
+    vapply(
+      gregexpr('^:{3,}', strsplit(x, '\n')[[1L]]),
+      attr, NA_integer_, 'match.length'
+    )
+  )
+  div = paste(rep(':', n), collapse = '')
+  paste0(
+    paste(div, block_attr(.attr, .class), sep = " "),
+    '\n\n',
+    x,
+    '\n\n',
+    div
   )
 }
 

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -65,6 +65,15 @@ assert('Attributes for souce can be specified class.source and attr.source', {
     "\n\n```{.a b='1'}\n1\n```\n\n")
 })
 
+hook_chunk = knit_hooks$get("chunk")
+
+assert('Chunks are enclosed by fenced divs when needed.', {
+  hook_chunk('', list(class.chunk=NULL)) %==% ''
+  hook_chunk('', list(class.chunk="")) %==% '::: \n\n\n\n:::'
+  hook_chunk('', list(class.chunk="foo")) %==% '::: {.foo}\n\n\n\n:::'
+  hook_chunk(':::', list(class.chunk="foo")) %==% ':::: {.foo}\n\n:::\n\n::::'
+})
+
 knit_hooks$restore()
 
 

--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -69,9 +69,9 @@ hook_chunk = knit_hooks$get("chunk")
 
 assert('Chunks are enclosed by fenced divs when needed.', {
   hook_chunk('', list(class.chunk=NULL)) %==% ''
-  hook_chunk('', list(class.chunk="")) %==% '::: \n\n\n\n:::'
-  hook_chunk('', list(class.chunk="foo")) %==% '::: {.foo}\n\n\n\n:::'
-  hook_chunk(':::', list(class.chunk="foo")) %==% ':::: {.foo}\n\n:::\n\n::::'
+  hook_chunk('', list(class.chunk="")) %==% '::: \n\n:::'
+  hook_chunk('', list(class.chunk="foo")) %==% '::: {.foo}\n\n:::'
+  hook_chunk(':::', list(class.chunk="foo")) %==% ':::: {.foo}\n:::\n::::'
 })
 
 knit_hooks$restore()


### PR DESCRIPTION
```` r
library(knitr)

cat(knitr::knit(quiet = TRUE, text = c(
  '```{r, class.chunk="foo"}',
  '"classed div"',
  "```",
  "",
  '```{r, class.chunk=""}',
  '"classless div"',
  "```",
  "",
  '```{r}',
  '"no div"',
  "```"
)))
#> <div class="foo">
#> 
#> ```r
#> "classed div"
#> #> [1] "classed div"
#> ```
#> 
#> </div>
#> 
#> <div>
#> 
#> ```r
#> "classless div"
#> #> [1] "classless div"
#> ```
#> 
#> </div>
#> 
#> 
#> ```r
#> "no div"
#> #> [1] "no div"
#> ```
````

<sup>Created on 2022-01-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
