### PR TITLE
fix: file.remove() raises warning when the file is not there

### DIFF
--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -115,8 +115,7 @@ rnw2pdf = function(
   # On Windows, when tweaking the content, users may forget to close the PDF
   # file (thus can't be written). Since knitting may take quite some time, it's
   # better to check the write permission of the output file in advance.
-  file.remove(output)
-  if (xfun::file_exists(output)) stop(
+  if (xfun::file_exists(output) && !file.remove(output)) stop(
     "The file '", output, "' cannot be removed (may be locked by a PDF reader)."
   )
   old = opts_chunk$set(error = error)


### PR DESCRIPTION
A patch to #2115.

<img width="561" alt="image" src="https://user-images.githubusercontent.com/8368933/160527893-4b3a5a5a-fb1c-4a83-8313-0f8db9f3a207.png">

`file.remove()` should be only performed when the file exists, or it raises an annoying warning.

I confirm that it returns `FALSE` when the file is locked on Windows and `TRUE` if it's removable.
