### PR TITLE
defer evaluation of yaml cell options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.38.1
+Version: 1.38.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - For **knitr** source documents that generate `.tex` output documents (such as `.Rnw` and `.Rtex`), the LaTeX package **xcolor** will be used instead of **color** (#2085). This may cause option clashes if **xcolor** is already loaded by users with options, e.g., `\usepackage[dvipsnames]{xcolor}`. If this happens, you may set the package option `knitr::opts_knit$set(latex.options.xcolor = 'OPTIONS')` where `OPTIONS` is the options you used for **xcolor**, e.g., `dvipsnames`.
 
+- The evaluation of chunk options written after `#|` using the YAML `!expr` syntax will be delayed until before the chunk is to be evaluated (#2120).
+
 # CHANGES IN knitr VERSION 1.38
 
 ## NEW FEATURES

--- a/R/parser.R
+++ b/R/parser.R
@@ -276,7 +276,7 @@ partition_chunk = function(engine, code) {
   meta = substr(src, nchar(s1) + 1, nchar(src) - nchar(s2))
   # see if the metadata looks like YAML or CSV
   if (grepl('^[^ :]+:($|\\s)', meta[1])) {
-    meta = yaml::yaml.load(meta, eval.expr = TRUE)
+    meta = yaml::yaml.load(meta, handlers = list(expr = function(x) parse(text = x)))
     if (!is.list(meta) || length(names(meta)) == 0) {
       warning('Invalid YAML option format in chunk: \n', one_string(meta), '\n')
       meta = list()

--- a/R/parser.R
+++ b/R/parser.R
@@ -276,7 +276,7 @@ partition_chunk = function(engine, code) {
   meta = substr(src, nchar(s1) + 1, nchar(src) - nchar(s2))
   # see if the metadata looks like YAML or CSV
   if (grepl('^[^ :]+:($|\\s)', meta[1])) {
-    meta = yaml::yaml.load(meta, handlers = list(expr = function(x) parse(text = x)))
+    meta = yaml::yaml.load(meta, handlers = list(expr = parse_only))
     if (!is.list(meta) || length(names(meta)) == 0) {
       warning('Invalid YAML option format in chunk: \n', one_string(meta), '\n')
       meta = list()


### PR DESCRIPTION
This PR makes my motivating example work correctly:

````markdown
---
title: "test"
output: html_document
---

```{r}
x <- "Air"
```

```{r}
#| label: fig-test
#| fig-cap: !expr paste(x, "Quality")
plot(mtcars)
```
````

@yihui It's definitely possible that I haven't thought of everything required here as I don't have a full picture in my mind of the parsing/options/execution pipeline.