### PR TITLE
Set `options(htmltools.preserve.raw = FALSE)` when evaluating inline R expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN knitr VERSION 1.40
 
+## BUG FIXES
+
+- Set `options(htmltools.preserve.raw = FALSE)` when evaluating inline R expressions, to preserve inline HTML widgets correctly (thanks, @earfanfan, https://d.cosx.org/d/423180).
+
 ## MINOR CHANGES
 
 - The internal function `knitr:::wrap()` has been removed from this package. If you rely on this function, you will have to use the exported function `knitr::sew()` instead.

--- a/R/block.R
+++ b/R/block.R
@@ -546,6 +546,10 @@ inline_exec = function(
   code = block$code; input = block$input
   if ((n <- length(code)) == 0) return(input) # untouched if no code is found
 
+  # shouldn't use ```{=html} to output inline HTML widgets
+  opts = options(htmltools.preserve.raw = FALSE)
+  on.exit(options(opts), add = TRUE)
+
   loc = block$location
   for (i in 1:n) {
     res = hook_eval(code[i], envir)


### PR DESCRIPTION
Reprex:

````md
---
title: "test"
output:
  html_document:
    keep_md: true
---


```{r}
# uncomment so that widgets can be rendered inline
# options(htmltools.preserve.raw = FALSE)
xfun::pkg_attach2('sparkline')
set.seed(1234)
x = rnorm(10)
y = rnorm(10)
```


Inline line graphs `r sparkline(x)`

Bar charts  `r sparkline(abs(x), type = 'bar')`  

negative values: `r sparkline(x, type = 'bar')`


| Stock | Sparkline         | Boxplot  |
|:-----:|:-----------------:|:--------:|
| x     | `r sparkline(x)`  | `r sparkline(x, type ='box')`|
| y     | `r sparkline(y)`  | `r sparkline(y, type ='box')`|
````

Without setting `options(htmltools.preserve.raw = FALSE)`, the widgets are not rendered inline. That's because they are wrapped in ```` ```{=html} ```` blocks. After setting this option, they will work perfectly.

This is a quick fix but may not be the best fix. In theory, the widgets should be wrapped inline in `` ` `{=html}``: https://github.com/rstudio/htmltools/blob/9490b627a33ace7cf04ad1e13d2a2c165021c3e6/R/tags.R#L1516 but they are not (probably because `inline = 'auto'` is resolved to `FALSE` due to the `\n`).

@cderv If you have time, you may see if you can figure out why `inline` is not `TRUE` there.