### PR TITLE
Support for tabularx and xltabular

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Authors@R: c(
     person("Adam", "Vogt", role = "ctb"),
     person("Alastair", "Andrew", role = "ctb"),
     person("Alex", "Zvoleff", role = "ctb"),
+    person("Amar", "Al-Zubaidi", role = "ctb"),
     person("Andre", "Simon", role = "ctb", comment = "the CSS files under inst/themes/ were derived from the Highlight package http://www.andre-simon.de"),
     person("Aron", "Atkins", role = "ctb"),
     person("Aaron", "Wolen", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Per suggestion of @jakubkaczor (#2116) and discussion with @pedropark99 (#2140), the chunk option `fig.sep` can also be used to add LaTeX code before the first sub-figure now. Previously this option can only be used for adding LaTeX code *after* each sub-figure.
 
+- `knitr::kable()` supports `tabularx` and `xltabular` environments now for LaTeX tables, e.g., `knitr::kable(head(iris), format = 'latex', tabular = 'tabularx')` (thanks, @amarakon, #2138).
+
 ## MINOR CHANGES
 
 - When the inline R code cannot be correctly parsed, the error message will show the original code in addition to the parsing error, which can make it easier to identify the code error in the source document (thanks, @AlbertLei, #2141).

--- a/R/table.R
+++ b/R/table.R
@@ -274,7 +274,7 @@ knit_print.knitr_kable = function(x, ...) {
 }
 
 kable_latex = function(
-  x, booktabs = FALSE, longtable = FALSE, tabularx = FALSE, xltabular = FALSE, valign = 't', position = '', table.length = '', centering = TRUE,
+  x, booktabs = FALSE, longtable = FALSE, tabularx = FALSE, xltabular = FALSE, valign = 't', position = '', table.length = '', header = '', centering = TRUE,
   vline = getOption('knitr.table.vline', if (booktabs) '' else '|'),
   toprule = getOption('knitr.table.toprule', if (booktabs) '\\toprule' else '\\hline'),
   bottomrule = getOption('knitr.table.bottomrule', if (booktabs) '\\bottomrule' else '\\hline'),
@@ -321,7 +321,9 @@ kable_latex = function(
     sprintf('\n%s', toprule), '\n',
     if (!is.null(cn <- colnames(x))) {
       cn = escape_latex_table(cn, escape, booktabs)
-      paste0(paste(cn, collapse = ' & '), sprintf('\\\\\n%s\n', midrule))
+      paste0(paste(cn, collapse = ' & '),
+      if (header != '') sprintf('\\\\\n%s\n%s\n', header, midrule) else sprintf('\\\\\n%s\n', midrule))
+
     },
     one_string(apply(x, 1, paste, collapse = ' & '), sprintf('\\\\%s', linesep), sep = ''),
     sprintf('\n%s', bottomrule),

--- a/R/table.R
+++ b/R/table.R
@@ -274,7 +274,7 @@ knit_print.knitr_kable = function(x, ...) {
 }
 
 kable_latex = function(
-  x, booktabs = FALSE, longtable = FALSE, valign = 't', position = '', centering = TRUE,
+  x, booktabs = FALSE, longtable = FALSE, tabularx = FALSE, xltabular = FALSE, valign = 't', position = '', table.length = '', centering = TRUE,
   vline = getOption('knitr.table.vline', if (booktabs) '' else '|'),
   toprule = getOption('knitr.table.toprule', if (booktabs) '\\toprule' else '\\hline'),
   bottomrule = getOption('knitr.table.bottomrule', if (booktabs) '\\bottomrule' else '\\hline'),
@@ -310,12 +310,14 @@ kable_latex = function(
   x = escape_latex_table(x, escape, booktabs)
   if (!is.character(toprule)) toprule = NULL
   if (!is.character(bottomrule)) bottomrule = NULL
-  tabular = if (longtable) 'longtable' else 'tabular'
+  tabular = if (longtable) 'longtable' else if (tabularx) 'tabularx' else if (xltabular) 'xltabular' else 'tabular'
+  if (table.length == '') table.length = '\\linewidth'
 
   paste(c(
-    if (!longtable) c(env1, cap, centering),
-    sprintf('\n\\begin{%s}%s', tabular, valign), align,
-    if (longtable && cap != '') c(cap, '\\\\'),
+    if (!longtable & !xltabular) c(env1, cap, centering),
+    if (tabularx | xltabular) sprintf('\n\\begin{%s}{%s}', tabular, table.length) else sprintf('\n\\begin{%s}%s', tabular, valign),
+    align,
+    if (longtable | xltabular && cap != '') c(cap, '\\\\'),
     sprintf('\n%s', toprule), '\n',
     if (!is.null(cn <- colnames(x))) {
       cn = escape_latex_table(cn, escape, booktabs)
@@ -324,7 +326,7 @@ kable_latex = function(
     one_string(apply(x, 1, paste, collapse = ' & '), sprintf('\\\\%s', linesep), sep = ''),
     sprintf('\n%s', bottomrule),
     sprintf('\n\\end{%s}', tabular),
-    if (!longtable) env2
+    if (!longtable & !xltabular) env2
   ), collapse = '')
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -315,15 +315,12 @@ kable_latex = function(
 
   paste(c(
     if (cap_env <- !tabular %in% c('longtable', 'xltabular')) c(env1, cap, centering),
-    sprintf('\n\\begin{%s}%s', tabular, valign),
-    align,
+    sprintf('\n\\begin{%s}%s', tabular, valign), align,
     if (!cap_env && cap != '') c(cap, '\\\\'),
     sprintf('\n%s', toprule), '\n',
     if (!is.null(cn <- colnames(x))) {
       cn = escape_latex_table(cn, escape, booktabs)
-      paste0(paste(cn, collapse = ' & '),
-      if (header != '') sprintf('\\\\\n%s\n%s\n', header, midrule) else sprintf('\\\\\n%s\n', midrule))
-
+      paste0(paste(cn, collapse = ' & '), '\\\\\n', header, if (header != '') '\n', midrule, '\n')
     },
     one_string(apply(x, 1, paste, collapse = ' & '), sprintf('\\\\%s', linesep), sep = ''),
     sprintf('\n%s', bottomrule),

--- a/R/table.R
+++ b/R/table.R
@@ -314,7 +314,7 @@ kable_latex = function(
 
   paste(c(
     if (!tabular %in% c('longtable', 'xltabular')) c(env1, cap, centering),
-    if (tabularx | xltabular) sprintf('\n\\begin{%s}{%s}', tabular, table.length) else sprintf('\n\\begin{%s}%s', tabular, valign),
+    if (tabular %in% c('tabularx', 'xltabular')) sprintf('\n\\begin{%s}{%s}', tabular, table.length) else sprintf('\n\\begin{%s}%s', tabular, valign),
     align,
     if (longtable | xltabular && cap != '') c(cap, '\\\\'),
     sprintf('\n%s', toprule), '\n',

--- a/R/table.R
+++ b/R/table.R
@@ -310,7 +310,6 @@ kable_latex = function(
   x = escape_latex_table(x, escape, booktabs)
   if (!is.character(toprule)) toprule = NULL
   if (!is.character(bottomrule)) bottomrule = NULL
-  tabular = if (longtable) 'longtable' else if (tabularx) 'tabularx' else if (xltabular) 'xltabular' else 'tabular'
   if (table.length == '') table.length = '\\linewidth'
 
   paste(c(

--- a/R/table.R
+++ b/R/table.R
@@ -316,7 +316,7 @@ kable_latex = function(
     if (!tabular %in% c('longtable', 'xltabular')) c(env1, cap, centering),
     if (tabular %in% c('tabularx', 'xltabular')) sprintf('\n\\begin{%s}{%s}', tabular, table.length) else sprintf('\n\\begin{%s}%s', tabular, valign),
     align,
-    if (longtable | xltabular && cap != '') c(cap, '\\\\'),
+    if ((tabular %in% c('longtable', 'xltabular')) && cap != '') c(cap, '\\\\'),
     sprintf('\n%s', toprule), '\n',
     if (!is.null(cn <- colnames(x))) {
       cn = escape_latex_table(cn, escape, booktabs)

--- a/R/table.R
+++ b/R/table.R
@@ -313,7 +313,7 @@ kable_latex = function(
   if (table.length == '') table.length = '\\linewidth'
 
   paste(c(
-    if (!longtable & !xltabular) c(env1, cap, centering),
+    if (!tabular %in% c('longtable', 'xltabular')) c(env1, cap, centering),
     if (tabularx | xltabular) sprintf('\n\\begin{%s}{%s}', tabular, table.length) else sprintf('\n\\begin{%s}%s', tabular, valign),
     align,
     if (longtable | xltabular && cap != '') c(cap, '\\\\'),

--- a/R/table.R
+++ b/R/table.R
@@ -327,7 +327,7 @@ kable_latex = function(
     one_string(apply(x, 1, paste, collapse = ' & '), sprintf('\\\\%s', linesep), sep = ''),
     sprintf('\n%s', bottomrule),
     sprintf('\n\\end{%s}', tabular),
-    if (!longtable & !xltabular) env2
+    if (!tabular %in% c('longtable', 'xltabular')) env2
   ), collapse = '')
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -274,7 +274,7 @@ knit_print.knitr_kable = function(x, ...) {
 }
 
 kable_latex = function(
-  x, booktabs = FALSE, longtable = FALSE, tabularx = FALSE, xltabular = FALSE, valign = 't', position = '', table.length = '', header = '', centering = TRUE,
+  x, booktabs = FALSE, longtable = FALSE, tabular = if (longtable) 'longtable' else 'tabular', valign = 't', position = '', table.length = '', header = '', centering = TRUE,
   vline = getOption('knitr.table.vline', if (booktabs) '' else '|'),
   toprule = getOption('knitr.table.toprule', if (booktabs) '\\toprule' else '\\hline'),
   bottomrule = getOption('knitr.table.bottomrule', if (booktabs) '\\bottomrule' else '\\hline'),

--- a/R/table.R
+++ b/R/table.R
@@ -276,7 +276,7 @@ knit_print.knitr_kable = function(x, ...) {
 kable_latex = function(
   x, booktabs = FALSE, longtable = FALSE, tabular = if (longtable) 'longtable' else 'tabular',
   valign = if (tabular %in% c('tabularx', 'xltabular')) '{\\linewidth}' else '[t]',
-  position = '', header = '', centering = TRUE,
+  position = '', centering = TRUE,
   vline = getOption('knitr.table.vline', if (booktabs) '' else '|'),
   toprule = getOption('knitr.table.toprule', if (booktabs) '\\toprule' else '\\hline'),
   bottomrule = getOption('knitr.table.bottomrule', if (booktabs) '\\bottomrule' else '\\hline'),
@@ -320,7 +320,7 @@ kable_latex = function(
     sprintf('\n%s', toprule), '\n',
     if (!is.null(cn <- colnames(x))) {
       cn = escape_latex_table(cn, escape, booktabs)
-      paste0(paste(cn, collapse = ' & '), '\\\\\n', header, if (header != '') '\n', midrule, '\n')
+      paste0(paste(cn, collapse = ' & '), sprintf('\\\\\n%s\n', midrule))
     },
     one_string(apply(x, 1, paste, collapse = ' & '), sprintf('\\\\%s', linesep), sep = ''),
     sprintf('\n%s', bottomrule),

--- a/R/table.R
+++ b/R/table.R
@@ -274,7 +274,9 @@ knit_print.knitr_kable = function(x, ...) {
 }
 
 kable_latex = function(
-  x, booktabs = FALSE, longtable = FALSE, tabular = if (longtable) 'longtable' else 'tabular', valign = 't', position = '', table.length = '', header = '', centering = TRUE,
+  x, booktabs = FALSE, longtable = FALSE, tabular = if (longtable) 'longtable' else 'tabular',
+  valign = if (tabular %in% c('tabularx', 'xltabular')) '{\\linewidth}' else '[t]',
+  position = '', header = '', centering = TRUE,
   vline = getOption('knitr.table.vline', if (booktabs) '' else '|'),
   toprule = getOption('knitr.table.toprule', if (booktabs) '\\toprule' else '\\hline'),
   bottomrule = getOption('knitr.table.bottomrule', if (booktabs) '\\bottomrule' else '\\hline'),
@@ -291,7 +293,7 @@ kable_latex = function(
   # vertical align only if 'caption' is not NULL (may be NA) or 'valign' has
   # been explicitly specified
   valign = if ((!is.null(caption) || !missing(valign)) && valign != '') {
-    sprintf('[%s]', valign)
+    if (grepl('^[[{]', valign)) valign else sprintf('[%s]', valign)
   } else ''
   if (identical(caption, NA)) caption = NULL
   if (position != '') position = paste0('[', position, ']')
@@ -310,13 +312,12 @@ kable_latex = function(
   x = escape_latex_table(x, escape, booktabs)
   if (!is.character(toprule)) toprule = NULL
   if (!is.character(bottomrule)) bottomrule = NULL
-  if (table.length == '') table.length = '\\linewidth'
 
   paste(c(
-    if (!tabular %in% c('longtable', 'xltabular')) c(env1, cap, centering),
-    if (tabular %in% c('tabularx', 'xltabular')) sprintf('\n\\begin{%s}{%s}', tabular, table.length) else sprintf('\n\\begin{%s}%s', tabular, valign),
+    if (cap_env <- !tabular %in% c('longtable', 'xltabular')) c(env1, cap, centering),
+    sprintf('\n\\begin{%s}%s', tabular, valign),
     align,
-    if ((tabular %in% c('longtable', 'xltabular')) && cap != '') c(cap, '\\\\'),
+    if (!cap_env && cap != '') c(cap, '\\\\'),
     sprintf('\n%s', toprule), '\n',
     if (!is.null(cn <- colnames(x))) {
       cn = escape_latex_table(cn, escape, booktabs)
@@ -327,7 +328,7 @@ kable_latex = function(
     one_string(apply(x, 1, paste, collapse = ' & '), sprintf('\\\\%s', linesep), sep = ''),
     sprintf('\n%s', bottomrule),
     sprintf('\n\\end{%s}', tabular),
-    if (!tabular %in% c('longtable', 'xltabular')) env2
+    if (cap_env) env2
   ), collapse = '')
 }
 


### PR DESCRIPTION
So far kable only supports tabular and longtable.
But tabularx and xltabular are popular among LaTeX users.
I added support for them: all you have to do is use `tabularx = TRUE` or `xltabular = TRUE`.
I also added an option called `header`, which allows you to specify things to put before the body of the table.