### PR TITLE
simplify Rmd parser pattern: all_patterns$md$inline.code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - Duplicate chunk label error will now be thrown with code chunks using `code` or `file` chunk options (thanks, @mine-cetinkaya-rundel, #2126).
 
-- Simplified R Markdown's inline code parser (thanks, @atusy, #2143)
+- Simplified R Markdown's inline code parser (thanks, @atusy, #2143).
 
 # CHANGES IN knitr VERSION 1.39
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - Duplicate chunk label error will now be thrown with code chunks using `code` or `file` chunk options (thanks, @mine-cetinkaya-rundel, #2126).
 
+- Simplified R Markdown's inline code parser (thanks, @atusy, #2143)
+
 # CHANGES IN knitr VERSION 1.39
 
 ## MAJOR CHANGES

--- a/R/pattern.R
+++ b/R/pattern.R
@@ -31,7 +31,7 @@ all_patterns = list(
   `md` = list(
     chunk.begin = '^[\t >]*```+\\s*\\{([a-zA-Z0-9_]+( *[ ,].*)?)\\}\\s*$',
     chunk.end = '^[\t >]*```+\\s*$',
-    ref.chunk = '^\\s*<<(.+)>>\\s*$', inline.code = '(?<!(^|\n)``)`r[ #]([^`]+)\\s*`'),
+    ref.chunk = '^\\s*<<(.+)>>\\s*$', inline.code = '(?<!(^|\n)``)`r[ #]([^`]+)`'),
 
   `rst` = list(
     chunk.begin = '^\\s*[.][.]\\s+\\{r(.*)\\}\\s*$',


### PR DESCRIPTION
([^`]+)\\s* should be equivalent to ([^`]+)
