### PR TITLE
Fix how kable_mark() measures column width when there are hyperlinks

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -391,13 +391,13 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ', padding = 0
   if (sep.col == '|') for (j in seq_len(ncol(x))) {
     x[, j] = gsub('\\|', '&#124;', x[, j])
   }
-  l = if (prod(dim(x)) > 0) apply(x, 2, function(z) max(nchar(z, type = 'width'), na.rm = TRUE))
+  l = if (prod(dim(x)) > 0) apply(x, 2, function(z) max(nchar(remove_urls(z), type = 'width'), na.rm = TRUE))
   cn = colnames(x)
   if (length(cn) > 0) {
     cn[is.na(cn)] = "NA"
     if (sep.col == '|') cn = gsub('\\|', '&#124;', cn)
     if (grepl('^\\s*$', cn[1L])) cn[1L] = rownames.name  # no empty cells for reST
-    l = pmax(if (length(l) == 0) 0 else l, nchar(cn, type = 'width'))
+    l = pmax(if (length(l) == 0) 0 else l, nchar(remove_urls(cn), type = 'width'))
   }
   align = attr(x, 'align')
   padding = padding * if (length(align) == 0) 2 else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1059,3 +1059,9 @@ make_unique = function(x) {
 #' browseURL('logo.html') # you can check its HTML source
 #' }
 image_uri = function(f) xfun::base64_uri(f)
+
+# Change all "[label](url)" to "label"
+remove_urls <- function(x) {
+  # regex adapted from https://dev.to/mattkenefick/regex-convert-markdown-links-to-html-anchors-f7j
+  gsub("\\[([^\\]]+)\\]\\(([^\\)]+)\\)", "\\1", x, perl = TRUE)
+}

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -233,3 +233,9 @@ assert('comment_out() add prefix and newlines if asked', {
   (comment_out("a", prefix = "$") %==% "$ a\n")
   (comment_out("a", prefix = NULL) %==% "a\n")
 })
+
+assert('remove_urls() removes the link', {
+  (remove_urls(c('[a](b)', '[a b](c)')) %==% c('a', 'a b'))
+  (remove_urls('a [b](c) d.') %==% 'a b d.')
+  (remove_urls('a [b](c) d [e f+g](h) i.') %==% 'a b d e f+g i.')
+})


### PR DESCRIPTION
This is intended to address #2147.

Recall the code example there:

```r
very_long_url <- paste(c("a", rep("very", 20), "long-url"), collapse = "-")
tbl <- data.frame(
  flavor = sprintf("[Mint chip](%s)", very_long_url),
  description = "Of all the many flavors of ice cream, this is my favorite."
  )
knitr::kable(tbl, format = "pipe")
```

It now generates a different output:

```
|flavor    |description                                                |
|:---------|:----------------------------------------------------------|
|[Mint chip](a-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-url)|Of all the many flavors of ice cream, this is my favorite. |
```

And here's what the table in the html file now looks like:

![Screen Shot 2022-07-08 at 12 30 14 AM](https://user-images.githubusercontent.com/2008608/177940676-ad403d95-d243-4614-83d4-27c737b383de.png)

Recall that before it looked like 

![Screen Shot 2022-07-07 at 11 04 19 PM](https://user-images.githubusercontent.com/2008608/177927298-d3b62dbf-d353-4b6c-8501-6c7269bc0aed.png)
