### PR TITLE
Convert chunk option to YAML

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- Added a function `convert_chunk_header()` to convert the old in-header chunk options to the new in-body chunk options (#2149).
+- Added a function `convert_chunk_header()` to convert the old in-header chunk options to the new in-body chunk options (#2149 #2151).
 
 - Added support for a `php` engine like other engines for interpreted languages. It will call `php -r <code>`, with `<code>` being the chunk content (thanks, @ralmond, #2144).
 

--- a/R/parser.R
+++ b/R/parser.R
@@ -876,8 +876,7 @@ convert_chunk_header = function(
             result <- ifelse(x, "true", "false")
             class(result) <- "verbatim"
             return(result)
-          })), "\n")[[1]]
-
+          }), line.sep = "\n"), "\n")[[1]]
       params3 = paste0(prefix, params3)
     }
 

--- a/R/parser.R
+++ b/R/parser.R
@@ -858,12 +858,11 @@ convert_chunk_header = function(
     } else {
       params3 = parse_params(params2, label = FALSE)
 
-      # fix un-evaluated options for yaml
-      # by transforming to !expr val
+      # fix un-evaluated options for yaml by transforming to !expr val
       params3 = lapply(params3, function(x) {
         if (is.symbol(x) || is.language(x)) {
           x = deparse(x, 500L)
-          attr(x, "tag") <- "!expr"
+          attr(x, 'tag') = '!expr'
         }
         x
       })
@@ -872,10 +871,10 @@ convert_chunk_header = function(
         params3, handlers = list(
           # true / false instead of no
           logical = function(x) {
-            result <- ifelse(x, "true", "false")
-            class(result) <- "verbatim"
-            return(result)
-          }), line.sep = "\n"), "\n")[[1]]
+            x = tolower(x)
+            class(x) = 'verbatim'
+            x
+          }), line.sep = '\n'), '\n')[[1]]
       params3 = paste0(prefix, params3)
     }
 

--- a/R/parser.R
+++ b/R/parser.R
@@ -807,9 +807,6 @@ convert_chunk_header = function(
 ) {
 
   type = match.arg(type)
-  if (type == "yaml" && !xfun::pkg_available("yaml"))
-    stop("Converting to yaml format require the yaml R package.")
-
   # extract fenced header information
   text = xfun::read_utf8(input)
   ext  = xfun::file_ext(input)

--- a/R/parser.R
+++ b/R/parser.R
@@ -739,9 +739,8 @@ inline_expr = function(code, syntax) {
 #'   line. Long chunk option values will be wrapped onto several lines, and you
 #'   can use \code{width = 0} to keep one line per option only. \code{"wrap"}
 #'   will wrap all chunk options together using
-#'   \code{\link[base:strwrap]{base::strwrap}()}. \code{"yaml"} is currently not
-#'   implemented and here as a placeholder for future support of YAML in-chunk
-#'   syntax for options.
+#'   \code{\link[base:strwrap]{base::strwrap}()}. \code{"yaml"} will convert
+#'   chunk options to YAML.
 #' @param width An integer passed to \code{base::strwrap()} for \code{type =
 #'   "wrap"} and \code{type = "multiline"}. If set to \code{0}, deactivate the
 #'   wrapping (for \code{type = "multiline"} only).

--- a/R/parser.R
+++ b/R/parser.R
@@ -807,6 +807,8 @@ convert_chunk_header = function(
 ) {
 
   type = match.arg(type)
+  if (type == "yaml" && !xfun::pkg_available("yaml"))
+    stop("Converting to yaml format require the yaml R package.")
 
   # extract fenced header information
   text = xfun::read_utf8(input)

--- a/R/parser.R
+++ b/R/parser.R
@@ -807,7 +807,6 @@ convert_chunk_header = function(
 ) {
 
   type = match.arg(type)
-  if (type == 'yaml') stop('Convertion to YAML chunk header not implemented yet.')
 
   # extract fenced header information
   text = xfun::read_utf8(input)
@@ -858,7 +857,28 @@ convert_chunk_header = function(
         strwrap(params3, width, prefix = prefix)
       }
     } else {
-      # YAML
+      params3 = parse_params(params2, label = FALSE)
+
+      # fix un-evaluated options for yaml
+      # by transforming to !expr val
+      params3 = lapply(params3, function(x) {
+        if (is.symbol(x) || is.language(x)) {
+          x = deparse(x, 500L)
+          attr(x, "tag") <- "!expr"
+        }
+        x
+      })
+      # convert to yaml and add prefix
+      params3 = strsplit(yaml::as.yaml(
+        params3, handlers = list(
+          # true / false instead of no
+          logical = function(x) {
+            result <- ifelse(x, "true", "false")
+            class(result) <- "verbatim"
+            return(result)
+          })), "\n")[[1]]
+
+      params3 = paste0(prefix, params3)
     }
 
     if (nzchar(opt_chars$end)) params3 = paste0(params3, opt_chars$end)

--- a/R/utils.R
+++ b/R/utils.R
@@ -651,7 +651,7 @@ escape_html = highr:::escape_html
 #' @author Yihui Xie and Peter Ruckdeschel
 #' @export
 #' @examples library(knitr)
-#' \donttest{# relies on r-forge.r-project.org being accessible
+#' \dontrun{# relies on r-forge.r-project.org being accessible
 #' read_rforge('rgl/R/axes.R', project = 'rgl')
 #' read_rforge('rgl/R/axes.R', project = 'rgl', extra='&revision=519')}
 read_rforge = function(path, project, extra = '') {

--- a/R/utils.R
+++ b/R/utils.R
@@ -650,10 +650,11 @@ escape_html = highr:::escape_html
 #' @return A character vector of the source code.
 #' @author Yihui Xie and Peter Ruckdeschel
 #' @export
-#' @examples library(knitr)
-#' \dontrun{# relies on r-forge.r-project.org being accessible
+#' @examplesIf interactive()
+#' library(knitr)
+#' # relies on r-forge.r-project.org being accessible
 #' read_rforge('rgl/R/axes.R', project = 'rgl')
-#' read_rforge('rgl/R/axes.R', project = 'rgl', extra='&revision=519')}
+#' read_rforge('rgl/R/axes.R', project = 'rgl', extra='&revision=519')
 read_rforge = function(path, project, extra = '') {
   base = 'http://r-forge.r-project.org/scm/viewvc.php/*checkout*/pkg'
   read_utf8(sprintf('%s/%s?root=%s%s', base, path, project, extra))

--- a/man/convert_chunk_header.Rd
+++ b/man/convert_chunk_header.Rd
@@ -25,9 +25,8 @@ the default is \code{"yaml"}) will write each chunk option on a separate
 line. Long chunk option values will be wrapped onto several lines, and you
 can use \code{width = 0} to keep one line per option only. \code{"wrap"}
 will wrap all chunk options together using
-\code{\link[base:strwrap]{base::strwrap}()}. \code{"yaml"} is currently not
-implemented and here as a placeholder for future support of YAML in-chunk
-syntax for options.}
+\code{\link[base:strwrap]{base::strwrap}()}. \code{"yaml"} will convert
+chunk options to YAML.}
 
 \item{width}{An integer passed to \code{base::strwrap()} for \code{type =
 "wrap"} and \code{type = "multiline"}. If set to \code{0}, deactivate the

--- a/man/read_rforge.Rd
+++ b/man/read_rforge.Rd
@@ -22,7 +22,7 @@ This function reads source code from the SVN repositories on R-Forge.
 }
 \examples{
 library(knitr)
-\donttest{
+\dontrun{
 # relies on r-forge.r-project.org being accessible
 read_rforge("rgl/R/axes.R", project = "rgl")
 read_rforge("rgl/R/axes.R", project = "rgl", extra = "&revision=519")

--- a/man/read_rforge.Rd
+++ b/man/read_rforge.Rd
@@ -20,13 +20,12 @@ A character vector of the source code.
 \description{
 This function reads source code from the SVN repositories on R-Forge.
 }
-\examples{
+\examples{\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(knitr)
-\dontrun{
 # relies on r-forge.r-project.org being accessible
 read_rforge("rgl/R/axes.R", project = "rgl")
 read_rforge("rgl/R/axes.R", project = "rgl", extra = "&revision=519")
-}
+\dontshow{\}) # examplesIf}
 }
 \author{
 Yihui Xie and Peter Ruckdeschel


### PR DESCRIPTION
This close #2082 and follows #2149 

Chunk options are parsed and then written to YAML using `yaml::as.yaml()` with two tweaks to the parsed chunk options

* Logical will be `true` or `false` instead of default `yes` or `no`
* R expression or variables passed in chunk option value will be written to YAML after `!expr` to make the fact they should be evaluted before parsing. Example: 

````markdown
```{r, R.options = list(width = 80)}
names(knitr::knit_engines$get())
```
````
will be converted to 
````markdown
```{r}
#| R.options: !expr list(width = 80)
names(knitr::knit_engines$get())
```
````

Doing 
```yaml
R.options:
    width: 80
```

is a bit more complicated than the current solution, as it implies going through the all tree of expression to only find the leaf is list that are variable or expression to evaluated with `!expr`

This solution is simple enough to produce valid document, and it is easy enough for the user to reformat manually some chunk header. 

Here is how a conversion looks like on all knitr-examples: https://github.com/yihui/knitr-examples/compare/master...cderv:knitr-examples:yaml-chunk-header
Does it seems right to you ? 

It seems there is still an indent question where the chunk header is not indented, whereas the code inside is - do we want to indent the in-chunk option part too. 

Anyway, @yihui I let you review. I wanted to have something ready for the conference, so here it is.  