### PR TITLE
Fix of check in color_def() of col being NA

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -54,7 +54,7 @@ valid_path = function(prefix, label) {
 
 # define a color variable in TeX
 color_def = function(col, variable = 'shadecolor') {
-  if (is.na(col)) return('')  # no LaTeX code when color is NA
+  if (all(is.na(col))) return('')  # no LaTeX code when color is NA
   x = if (length(col) == 1L) sc_split(col) else col
   if ((n <- length(x)) != 3L) {
     if (n == 1L) x = drop(col2rgb(x) / 255) else {


### PR DESCRIPTION
As of R 4.2.0, "Calling if() with a condition of length greater than one gives an error rather than a warning." The utility function color_def() tests if the argument col is NA by if(is.na(col)), which with R 4.2.0 or greater results in an error when e.g. supplying a user specified background color for chunks in an Rnw-file. The proposed change fixes that by converting is.na(col) to length one.