### PR TITLE
Add a new output format to `kable()` - Issue #2024

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,6 +83,7 @@ Authors@R: c(
     person("Noam", "Ross", role = "ctb"),
     person("Obada", "Mahdi", role = "ctb"),
     person("Pavel N.", "Krivitsky", role = "ctb", comment=c(ORCID = "0000-0002-9101-3362")),
+    person("Pedro", "Faria", role = "ctb"),
     person("Qiang", "Li", role = "ctb"),
     person("Ramnath", "Vaidyanathan", role = "ctb"),
     person("Richard", "Cotton", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN knitr VERSION 1.41
 
+## NEW FEATURES
+
+- Added support for generating Jira tables via `kable(, format = 'jira')` (thanks, @pedropark99 #2180, @mruessler #2024).
+
 ## BUG FIXES
 
 - Plot created outside of `knit()` could sneak into `knit_child()` results (thanks, @niklaswillrich, #2166).

--- a/R/table.R
+++ b/R/table.R
@@ -389,7 +389,6 @@ kable_html = function(
 kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
                       sep.head.col = NULL, padding = 0,
                       align.fun = function(s, a) s, rownames.name = '', ...) {
-
   # If user does not provide a value for `sep.head.col`, use `sep.col` value
   if (is.null(sep.head.col) || is.na(sep.head.col)) sep.head.col = sep.col
   # when the column separator is |, replace existing | with its HTML entity
@@ -417,18 +416,22 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
 }
 
 add_mark_col_sep = function(table, sep.col, sep.head.col) {
+  table_dim = dim(table)
+  if (0L %in% table_dim) {
+    return(as.character(table))
+  }
   header = table[1, ]
-  table_body = table[-1, ]
-
   header = paste(header, collapse = sep.head.col)
-  if (is.null(dim(table_body))) {
+  table_body = table[-1, ]
+  if (is.null(dim(table_body)) && table_dim[2] > 1) {
+    # When `table_dim[2] == 1`, when we extract table_body = table[-1, ]
+    # `table_body` becomes a vector of rows, and we do not want to collapse
+    # all rows together (we want to collapse a vector of cols);
     table_body = paste(table_body, collapse = sep.col)
-  } else {
+  }
+  if (!is.null(dim(table_body))) {
     table_body = apply(table_body, 1, paste, collapse = sep.col)
   }
-
-  header = paste0(sep.head.col, header, sep.head.col)
-  table_body = paste0(sep.col, table_body, sep.col)
 
   return(c(header, table_body))
 }
@@ -456,6 +459,7 @@ kable_pipe = function(x, caption = NULL, padding = 1, ...) {
     },
     ...
   )
+  res = sprintf('|%s|', res)
   kable_pandoc_caption(res, caption)
 }
 
@@ -482,6 +486,8 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
     # Remove the line that separates the table header from the table body
     tab = tab[-2]
   }
+  tab[1] = sprintf('||%s||', tab[1])
+  tab[-1] = sprintf('|%s|', tab[-1])
   kable_pandoc_caption(tab, caption)
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -478,8 +478,10 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
     sep.col = '|', sep.head.col = '||',
     padding = padding, ...
   )
-  # Remove the line that separates the table header from the table body
-  tab = tab[-2]
+  if (length(tab) >= 2) {
+    # Remove the line that separates the table header from the table body
+    tab = tab[-2]
+  }
   kable_pandoc_caption(tab, caption)
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -443,18 +443,19 @@ kable_rst = function(x, rownames.name = '\\', ...) {
 # Pandoc's pipe table
 kable_pipe = function(x, caption = NULL, padding = 1, ...) {
   if (is.null(colnames(x))) colnames(x) = rep('', ncol(x))
-  res = kable_mark(x,
-                   sep.row = c(NA, '-', NA),
-                   sep.col = '|',
-                   padding = padding,
-                   align.fun = function(s, a) {
-    if (is.null(a)) return(s)
-    r = c(l = '^.', c = '^.|.$', r = '.$')
-    for (i in seq_along(s)) {
-      s[i] = gsub(r[a[i]], ':', s[i])
-    }
-    s
-  }, ...)
+  res = kable_mark(
+    x, sep.row = c(NA, '-', NA),
+    sep.col = '|', padding = padding,
+    align.fun = function(s, a) {
+      if (is.null(a)) return(s)
+      r = c(l = '^.', c = '^.|.$', r = '.$')
+      for (i in seq_along(s)) {
+        s[i] = gsub(r[a[i]], ':', s[i])
+      }
+      return(s)
+    },
+    ...
+  )
   kable_pandoc_caption(res, caption)
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -390,7 +390,7 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
                       align.fun = function(s, a) s, rownames.name = '', ...) {
 
   # If user does not provide a value for `sep.head.col`, use `sep.col` value
-  if (is.null(sep.head.col)) sep.head.col = sep.col
+  if (is.null(sep.head.col) || is.na(sep.head.col)) sep.head.col = sep.col
   # when the column separator is |, replace existing | with its HTML entity
   if (sep.col == '|') for (j in seq_len(ncol(x))) {
     x[, j] = gsub('\\|', '&#124;', x[, j])
@@ -419,7 +419,7 @@ mark_add_col_sep = function(table, sep.col, sep.head.col) {
   header = table[1, ]
   table_body = table[-1, ]
 
-  header = base::paste(header, collapse = sep.head.col)
+  header = paste(header, collapse = sep.head.col)
   table_body = apply(table_body, 1, paste, collapse = sep.col)
 
   header = paste0(sep.head.col, header, sep.head.col)
@@ -429,6 +429,8 @@ mark_add_col_sep = function(table, sep.col, sep.head.col) {
 }
 
 
+
+
 kable_rst = function(x, rownames.name = '\\', ...) {
   kable_mark(x, rownames.name = rownames.name)
 }
@@ -436,7 +438,11 @@ kable_rst = function(x, rownames.name = '\\', ...) {
 # Pandoc's pipe table
 kable_pipe = function(x, caption = NULL, padding = 1, ...) {
   if (is.null(colnames(x))) colnames(x) = rep('', ncol(x))
-  res = kable_mark(x, c(NA, '-', NA), '|', padding, align.fun = function(s, a) {
+  res = kable_mark(x,
+                   sep.row = c(NA, '-', NA),
+                   sep.col = '|',
+                   padding = padding,
+                   align.fun = function(s, a) {
     if (is.null(a)) return(s)
     r = c(l = '^.', c = '^.|.$', r = '.$')
     for (i in seq_along(s)) {
@@ -444,7 +450,6 @@ kable_pipe = function(x, caption = NULL, padding = 1, ...) {
     }
     s
   }, ...)
-  res = sprintf('|%s|', res)
   kable_pandoc_caption(res, caption)
 }
 
@@ -461,10 +466,13 @@ kable_simple = function(x, caption = NULL, padding = 1, ...) {
 }
 
 
-kable_jira = function(x) {
-  col.names = colnames(x)
-  header = build_jira_header(col.names)
-  return(header)
+kable_jira = function(x, caption = NULL, padding = 1, ...) {
+  tab = kable_mark(
+    x, c(NA, NA, NA),
+    sep.col = '|', sep.head.col = '||',
+    padding = padding, ...
+  )
+  kable_pandoc_caption(tab, caption)
 }
 
 

--- a/R/table.R
+++ b/R/table.R
@@ -377,20 +377,20 @@ kable_html = function(
 #'
 #' This function provides the basis for Markdown and reST tables.
 #' @param x The data matrix.
-#' @param sep.row A length-3 character vector, specifying separators to be printed
-#'   before the header, after the header, and at the end of the table respectively.
+#' @param sep.row A length-3 character vector, specifying separators to be
+#'   printed before the header, after the header, and at the end of the table
+#'   respectively.
 #' @param sep.col The column separator.
-#' @param sep.head The column separator for the header of the table (i.e. the line with the column names).
+#' @param sep.head The column separator for the header of the table (i.e., the
+#'   line with the column names).
 #' @param padding Number of spaces for the table cell padding.
 #' @param align.fun A function to process the separator under the header
 #'   according to the alignment.
 #' @return A character vector of the table content.
 #' @noRd
 kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
-                      sep.head = NULL, padding = 0,
+                      sep.head = sep.col, padding = 0,
                       align.fun = function(s, a) s, rownames.name = '', ...) {
-  # If user does not provide a value for `sep.head`, use `sep.col` value
-  if (is.null(sep.head) || is.na(sep.head)) sep.head = sep.col
   # when the column separator is |, replace existing | with its HTML entity
   if (sep.col == '|') for (j in seq_len(ncol(x))) {
     x[, j] = gsub('\\|', '&#124;', x[, j])

--- a/R/table.R
+++ b/R/table.R
@@ -388,9 +388,9 @@ kable_html = function(
 #'   according to the alignment.
 #' @return A character vector of the table content.
 #' @noRd
-kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
-                      sep.head = sep.col, padding = 0,
-                      align.fun = function(s, a) s, rownames.name = '', ...) {
+kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ', padding = 0,
+                      align.fun = function(s, a) s, rownames.name = '',
+                      sep.head = sep.col, ...) {
   # when the column separator is |, replace existing | with its HTML entity
   if (sep.col == '|') for (j in seq_len(ncol(x))) {
     x[, j] = gsub('\\|', '&#124;', x[, j])
@@ -431,19 +431,14 @@ kable_rst = function(x, rownames.name = '\\', ...) {
 # Pandoc's pipe table
 kable_pipe = function(x, caption = NULL, padding = 1, ...) {
   if (is.null(colnames(x))) colnames(x) = rep('', ncol(x))
-  res = kable_mark(
-    x, sep.row = c(NA, '-', NA),
-    sep.col = '|', padding = padding,
-    align.fun = function(s, a) {
-      if (is.null(a)) return(s)
-      r = c(l = '^.', c = '^.|.$', r = '.$')
-      for (i in seq_along(s)) {
-        s[i] = gsub(r[a[i]], ':', s[i])
-      }
-      return(s)
-    },
-    ...
-  )
+  res = kable_mark(x, c(NA, '-', NA), '|', padding, align.fun = function(s, a) {
+    if (is.null(a)) return(s)
+    r = c(l = '^.', c = '^.|.$', r = '.$')
+    for (i in seq_along(s)) {
+      s[i] = gsub(r[a[i]], ':', s[i])
+    }
+    s
+  }, ...)
   res = sprintf('|%s|', res)
   kable_pandoc_caption(res, caption)
 }

--- a/R/table.R
+++ b/R/table.R
@@ -455,24 +455,15 @@ kable_simple = function(x, caption = NULL, padding = 1, ...) {
   kable_pandoc_caption(tab, caption)
 }
 
-
+# Jira table
 kable_jira = function(x, caption = NULL, padding = 1, ...) {
-  tab = kable_mark(
-    x, c(NA, NA, NA),
-    sep.col = '|', sep.head = '||',
-    padding = padding, ...
-  )
-  if (length(tab) >= 2) {
-    # Remove the line that separates the table header from the table body
-    tab = tab[-2]
-  }
+  tab = kable_mark(x, c(NA, NA, NA), '|', padding, sep.head = '||', ...)
+  # remove the line that separates the table header from the table body
+  if (length(tab) >= 2) tab = tab[-2]
   tab[1] = sprintf('||%s||', tab[1])
   tab[-1] = sprintf('|%s|', tab[-1])
   kable_pandoc_caption(tab, caption)
 }
-
-
-
 
 kable_pandoc_caption = function(x, caption) {
   if (identical(caption, NA)) caption = NULL

--- a/R/table.R
+++ b/R/table.R
@@ -458,8 +458,9 @@ kable_simple = function(x, caption = NULL, padding = 1, ...) {
 # Jira table
 kable_jira = function(x, caption = NULL, padding = 1, ...) {
   tab = kable_mark(x, c(NA, NA, NA), '|', padding, sep.head = '||', ...)
+  if ((n <- length(tab)) == 0) return(tab)
   # remove the line that separates the table header from the table body
-  if (length(tab) >= 2) tab = tab[-2]
+  if (n >= 2) tab = tab[-2]
   tab[1] = sprintf('||%s||', tab[1])
   tab[-1] = sprintf('|%s|', tab[-1])
   kable_pandoc_caption(tab, caption)

--- a/R/table.R
+++ b/R/table.R
@@ -412,15 +412,19 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
   res = rbind(if (!is.na(sep.row[1])) s, cn, align.fun(s, align),
               x, if (!is.na(sep.row[3])) s)
   res = mat_pad(res, l, align)
-  mark_add_col_sep(res, sep.col, sep.head.col)
+  add_mark_col_sep(res, sep.col, sep.head.col)
 }
 
-mark_add_col_sep = function(table, sep.col, sep.head.col) {
+add_mark_col_sep = function(table, sep.col, sep.head.col) {
   header = table[1, ]
   table_body = table[-1, ]
 
   header = paste(header, collapse = sep.head.col)
-  table_body = apply(table_body, 1, paste, collapse = sep.col)
+  if (is.null(dim(table_body))) {
+    table_body = paste(table_body, collapse = sep.col)
+  } else {
+    table_body = apply(table_body, 1, paste, collapse = sep.col)
+  }
 
   header = paste0(sep.head.col, header, sep.head.col)
   table_body = paste0(sep.col, table_body, sep.col)
@@ -472,6 +476,7 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
     sep.col = '|', sep.head.col = '||',
     padding = padding, ...
   )
+  tab = tab[-2]
   kable_pandoc_caption(tab, caption)
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -380,6 +380,7 @@ kable_html = function(
 #' @param sep.row A length-3 character vector, specifying separators to be printed
 #'   before the header, after the header, and at the end of the table respectively.
 #' @param sep.col The column separator.
+#' @param sep.head.col The column separator for the header of the table (i.e. the line with the column names).
 #' @param padding Number of spaces for the table cell padding.
 #' @param align.fun A function to process the separator under the header
 #'   according to the alignment.
@@ -476,6 +477,7 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
     sep.col = '|', sep.head.col = '||',
     padding = padding, ...
   )
+  # Remove the line that separates the table header from the table body
   tab = tab[-2]
   kable_pandoc_caption(tab, caption)
 }

--- a/R/table.R
+++ b/R/table.R
@@ -380,17 +380,17 @@ kable_html = function(
 #' @param sep.row A length-3 character vector, specifying separators to be printed
 #'   before the header, after the header, and at the end of the table respectively.
 #' @param sep.col The column separator.
-#' @param sep.head.col The column separator for the header of the table (i.e. the line with the column names).
+#' @param sep.head The column separator for the header of the table (i.e. the line with the column names).
 #' @param padding Number of spaces for the table cell padding.
 #' @param align.fun A function to process the separator under the header
 #'   according to the alignment.
 #' @return A character vector of the table content.
 #' @noRd
 kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
-                      sep.head.col = NULL, padding = 0,
+                      sep.head = NULL, padding = 0,
                       align.fun = function(s, a) s, rownames.name = '', ...) {
-  # If user does not provide a value for `sep.head.col`, use `sep.col` value
-  if (is.null(sep.head.col) || is.na(sep.head.col)) sep.head.col = sep.col
+  # If user does not provide a value for `sep.head`, use `sep.col` value
+  if (is.null(sep.head) || is.na(sep.head)) sep.head = sep.col
   # when the column separator is |, replace existing | with its HTML entity
   if (sep.col == '|') for (j in seq_len(ncol(x))) {
     x[, j] = gsub('\\|', '&#124;', x[, j])
@@ -399,7 +399,7 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
   cn = colnames(x)
   if (length(cn) > 0) {
     cn[is.na(cn)] = "NA"
-    if (sep.head.col == '|') cn = gsub('\\|', '&#124;', cn)
+    if (sep.head == '|') cn = gsub('\\|', '&#124;', cn)
     if (grepl('^\\s*$', cn[1L])) cn[1L] = rownames.name  # no empty cells for reST
     l = pmax(if (length(l) == 0) 0 else l, nchar(remove_urls(cn), type = 'width'))
   }
@@ -412,16 +412,16 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
   res = rbind(if (!is.na(sep.row[1])) s, cn, align.fun(s, align),
               x, if (!is.na(sep.row[3])) s)
   res = mat_pad(res, l, align)
-  add_mark_col_sep(res, sep.col, sep.head.col)
+  add_mark_col_sep(res, sep.col, sep.head)
 }
 
-add_mark_col_sep = function(table, sep.col, sep.head.col) {
+add_mark_col_sep = function(table, sep.col, sep.head) {
   table_dim = dim(table)
   if (0L %in% table_dim) {
     return(as.character(table))
   }
   header = table[1, ]
-  header = paste(header, collapse = sep.head.col)
+  header = paste(header, collapse = sep.head)
   table_body = table[-1, ]
   if (is.null(dim(table_body)) && table_dim[2] > 1) {
     # When `table_dim[2] == 1`, when we extract table_body = table[-1, ]
@@ -479,7 +479,7 @@ kable_simple = function(x, caption = NULL, padding = 1, ...) {
 kable_jira = function(x, caption = NULL, padding = 1, ...) {
   tab = kable_mark(
     x, c(NA, NA, NA),
-    sep.col = '|', sep.head.col = '||',
+    sep.col = '|', sep.head = '||',
     padding = padding, ...
   )
   if (length(tab) >= 2) {

--- a/R/table.R
+++ b/R/table.R
@@ -415,29 +415,14 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ',
   add_mark_col_sep(res, sep.col, sep.head)
 }
 
+# add column separators to header and body separately
 add_mark_col_sep = function(table, sep.col, sep.head) {
-  table_dim = dim(table)
-  if (0L %in% table_dim) {
-    return(as.character(table))
-  }
-  header = table[1, ]
-  header = paste(header, collapse = sep.head)
-  table_body = table[-1, ]
-  if (is.null(dim(table_body)) && table_dim[2] > 1) {
-    # When `table_dim[2] == 1`, when we extract table_body = table[-1, ]
-    # `table_body` becomes a vector of rows, and we do not want to collapse
-    # all rows together (we want to collapse a vector of cols);
-    table_body = paste(table_body, collapse = sep.col)
-  }
-  if (!is.null(dim(table_body))) {
-    table_body = apply(table_body, 1, paste, collapse = sep.col)
-  }
-
-  return(c(header, table_body))
+  if (any(dim(table) == 0)) return(table)
+  h = paste(table[1, ], collapse = sep.head)  # header
+  b = table[-1, , drop = FALSE]
+  b = apply(b, 1, paste, collapse = sep.col)  # body
+  c(h, b)
 }
-
-
-
 
 kable_rst = function(x, rownames.name = '\\', ...) {
   kable_mark(x, rownames.name = rownames.name)

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -30,6 +30,10 @@ assert("kable() works on NA's", {
      c('|x     |', '|:-----|', '|NA    |', '|FALSE |'))
 })
 
+assert('kable() works with the jira format', {
+  (kable2(m, 'jira') %==% c('||   ||  x||  y||', '|a  |  1|  2|'))
+})
+
 assert('kable() does not add extra spaces to character columns', {
   (kable2(data.frame(x = c(1.2, 4.87), y = c('fooooo', 'bar')), 'latex') %==% '
 \\begin{tabular}{r|l}
@@ -127,7 +131,7 @@ assert('kable() works on matrices with NA colname', {
 x1 = matrix(NA, 0, 0)
 x2 = matrix(NA, 0, 1)
 x3 = matrix(NA, 1, 0)
-for (f in c('simple', 'html', 'latex', 'rst')) {
+for (f in c('simple', 'html', 'latex', 'rst', 'jira')) {
   kable(x1, f)
   kable(x2, f)
   kable(x3, f)


### PR DESCRIPTION
Hello! This PR seeks to fulfill the request made in the issue #2024 . It adds a new output format to `kable()`, more specifically, a `"jira"` format. A simple example:

```r
tab = head(ggplot2::mpg)
knitr::kable(tab, format = 'jira')
```
```


||manufacturer ||model || displ|| year|| cyl||trans      ||drv || cty|| hwy||fl ||class   ||
|audi         |a4    |   1.8| 1999|   4|auto(l5)   |f   |  18|  29|p  |compact |
|audi         |a4    |   1.8| 1999|   4|manual(m5) |f   |  21|  29|p  |compact |
|audi         |a4    |   2.0| 2008|   4|manual(m6) |f   |  20|  31|p  |compact |
|audi         |a4    |   2.0| 2008|   4|auto(av)   |f   |  21|  30|p  |compact |
|audi         |a4    |   2.8| 1999|   6|auto(l5)   |f   |  16|  26|p  |compact |
|audi         |a4    |   2.8| 1999|   6|manual(m5) |f   |  18|  26|p  |compact |
```

To achieve this new functionality, a new argument called `sep.head.col` in `kable_mark()`, and a new function called `kable_jira()` were added. This argument defines the separator between each column in the header of the table (i.e. the line with the column names). With `format = "jira"`, this argument will be set to `sep.head.col = "||"`. 

If the user does not provide a value (or give a `NA` value) for the argument `sep.head.col`, it will be automatically set to the `sep.col` value. Because of this behaviour, in other output formats, like `"pipe"` or `"simple"`, the `sep.head.col` argument will be equal to `sep.col`:

https://github.com/pedropark99/knitr/blob/2024-jira-kable/R/table.R#L393-L394

So `kable_jira()` basically uses `kable_mark()` with `sep.head.col = "||"` to build the output table.  By adding this new `sep.head.col` argument to `kable_mark()`, we might create more flexibility to add new styles and formats in the future for `kable()`.

Thank you for the attention!