### PR TITLE
Replace `stringr::str_dup()` with `paste()`/`rep()`

### DIFF
--- a/R/parser.R
+++ b/R/parser.R
@@ -345,7 +345,7 @@ print.block = function(x, ...) {
     if (length(code) && !is_blank(code)) {
       cat('\n  ', stringr::str_pad(' R code chunk ', getOption('width') - 10L, 'both', '~'), '\n')
       cat(one_string('  ', code), '\n')
-      cat('  ', stringr::str_dup('~', getOption('width') - 10L), '\n')
+      cat('  ', paste(rep('~', getOption('width') - 10L), collapse = ""), '\n')
     }
     cat(paste('##------', date(), '------##'), sep = '\n')
   }
@@ -386,7 +386,7 @@ print.inline = function(x, ...) {
                   getOption('width') - 10L, 'both', '-'), '\n')
       cat(sprintf('    %s:%s %s', x$location[, 1], x$location[, 2], x$code),
           sep = '\n')
-      cat('  ', stringr::str_dup('-', getOption('width') - 10L), '\n')
+      cat('  ', paste(rep('-', getOption('width') - 10L), collapse = ""), '\n')
     } else cat('inline R code fragments\n')
   } else cat('  ordinary text without R code\n')
   cat('\n')

--- a/R/parser.R
+++ b/R/parser.R
@@ -345,7 +345,7 @@ print.block = function(x, ...) {
     if (length(code) && !is_blank(code)) {
       cat('\n  ', stringr::str_pad(' R code chunk ', getOption('width') - 10L, 'both', '~'), '\n')
       cat(one_string('  ', code), '\n')
-      cat('  ', paste(rep('~', getOption('width') - 10L), collapse = ""), '\n')
+      cat('  ', rep_str('~', getOption('width') - 10L), '\n')
     }
     cat(paste('##------', date(), '------##'), sep = '\n')
   }
@@ -386,7 +386,7 @@ print.inline = function(x, ...) {
                   getOption('width') - 10L, 'both', '-'), '\n')
       cat(sprintf('    %s:%s %s', x$location[, 1], x$location[, 2], x$code),
           sep = '\n')
-      cat('  ', paste(rep('-', getOption('width') - 10L), collapse = ""), '\n')
+      cat('  ', rep_str('-', getOption('width') - 10L), '\n')
     } else cat('inline R code fragments\n')
   } else cat('  ordinary text without R code\n')
   cat('\n')

--- a/R/utils.R
+++ b/R/utils.R
@@ -1075,3 +1075,6 @@ remove_urls = function(x) {
   # regex adapted from https://dev.to/mattkenefick/regex-convert-markdown-links-to-html-anchors-f7j
   gsub("(?<!`)\\[([^]]+)\\]\\(([^)]+)\\)(?!`)", "\\1", x, perl = TRUE)
 }
+
+# repeat a string for n times
+rep_str = function(x, n, sep = '') paste(rep(x, n), collapse = sep)


### PR DESCRIPTION
This PR replaces two uses of `stringr::str_dup()` with a base R equivalent.