### PR TITLE
Always use the `valign` argument for `tabularx` and `xltabular` tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 - User-provided background colors for code chunks in `.Rnw` documents may fail (thanks, @nielsrhansen, #2167).
 
+- `tabularx` and `xltabular` tables should work without captions (thanks, @amarakon, #2188).
+
 # CHANGES IN knitr VERSION 1.40
 
 ## NEW FEATURES

--- a/R/table.R
+++ b/R/table.R
@@ -291,8 +291,8 @@ kable_latex = function(
   }
   centering = if (centering && !is.null(caption)) '\n\\centering'
   # vertical align only if 'caption' is not NULL (may be NA) or 'valign' has
-  # been explicitly specified
-  valign = if ((!is.null(caption) || !missing(valign)) && valign != '') {
+  # been explicitly specified; tabularx and xltabular always use 'valign'
+  valign = if ((!is.null(caption) || !missing(valign) || tabular %in% c('tabularx', 'xltabular')) && valign != '') {
     if (grepl('^[[{]', valign)) valign else sprintf('[%s]', valign)
   } else ''
   if (identical(caption, NA)) caption = NULL


### PR DESCRIPTION
fix #2188