### PR TITLE
#2191 add knitr.child.warning option to hide warnings in case the there are child documents in a chunk and the chunk still contains code (which is not executed)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# CHANGES IN knitr VERSION 1.42
+
+## MINOR CHANGES
+
+- If you refer to a child document in a chunk with `child='bar.Rmd'` and still have other code in the chunk block, you can now silence the warning that indicates that this other code will not be executed when you `render` the document by specifying `options(knitr.child.warning = FALSE)`. See #2191.
+
 # CHANGES IN knitr VERSION 1.41
 
 ## NEW FEATURES

--- a/R/block.R
+++ b/R/block.R
@@ -56,7 +56,7 @@ call_block = function(block) {
   if (opts_knit$get('progress')) print(block)
 
   if (!is.null(params$child)) {
-    if (!is_blank(params[['code']]) && getOption('knitr.child.warning', default = TRUE)) warning(
+    if (!is_blank(params[['code']]) && getOption('knitr.child.warning', TRUE)) warning(
       "The chunk '", params$label, "' has the 'child' option, ",
       "and this code chunk must be empty. Its code will be ignored."
     )

--- a/R/block.R
+++ b/R/block.R
@@ -56,7 +56,7 @@ call_block = function(block) {
   if (opts_knit$get('progress')) print(block)
 
   if (!is.null(params$child)) {
-    if (!is_blank(params[['code']])) warning(
+    if (!is_blank(params[['code']]) && getOption('knitr.child.warning', default = TRUE)) warning(
       "The chunk '", params$label, "' has the 'child' option, ",
       "and this code chunk must be empty. Its code will be ignored."
     )

--- a/inst/examples/child/knitr-child2.Rmd
+++ b/inst/examples/child/knitr-child2.Rmd
@@ -1,0 +1,6 @@
+Hi, there. I'm another child.
+
+```{r test-child2}
+x <- rnorm(n = 3)
+x
+```

--- a/inst/examples/child/knitr-main.Rmd
+++ b/inst/examples/child/knitr-main.Rmd
@@ -1,4 +1,4 @@
-You can also use the `child` option to include child documents in markdown. 
+You can also use the `child` option to include child documents in markdown.
 
 ```{r test-main, child='knitr-child.Rmd'}
 ```

--- a/inst/examples/child/knitr-main.Rmd
+++ b/inst/examples/child/knitr-main.Rmd
@@ -1,4 +1,4 @@
-You can also use the `child` option to include child documents in markdown.
+You can also use the `child` option to include child documents in markdown. 
 
 ```{r test-main, child='knitr-child.Rmd'}
 ```
@@ -7,4 +7,16 @@ You can continue your main document below, of course.
 
 ```{r test-another}
 pmax(1:10, 5)
+```
+
+If you refer to a child document in a chunk, only the child document will be evaluated. 
+Other code in the chunk will not be evaluated when you `render` the document.
+
+```{r test-warning-option, include=FALSE}
+options(knitr.child.warning = FALSE)
+```
+
+```{r test-warning, child='knitr-child2.Rmd'}
+x <- "this code is not evaluated"
+x
 ```


### PR DESCRIPTION
Let me know if I need to add some tests or documentation and if so, where you want me to add it.