### PR TITLE
Replace instances of `stringr::str_sub()` with base R equivalent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -191,6 +191,7 @@ Collate:
     'template.R'
     'utils-conversion.R'
     'utils-rd2html.R'
+    'utils-string.R'
     'utils-sweave.R'
     'utils-upload.R'
     'utils-vignettes.R'

--- a/R/block.R
+++ b/R/block.R
@@ -551,22 +551,17 @@ inline_exec = function(
   code = block$code; input = block$input
   if ((n <- length(code)) == 0) return(input) # untouched if no code is found
 
-  loc = block$location
+  ans = character(n)
   for (i in 1:n) {
     res = hook_eval(code[i], envir)
     if (inherits(res, c('knit_asis', 'knit_asis_url'))) res = sew(res, inline = TRUE)
     tryCatch(as.character(res), error = function(e) {
       stop2("The inline value cannot be coerced to character: ", code[i])
     })
-    d = nchar(input)
-    # replace with evaluated results
-    stringr::str_sub(input, loc[i, 1], loc[i, 2]) = if (length(res)) {
-      paste(hook(res), collapse = '')
-    } else ''
-    if (i < n) loc[(i + 1):n, ] = loc[(i + 1):n, ] - (d - nchar(input))
-    # may need to move back and forth because replacement may be longer or shorter
+    if (length(res)) ans[i] = paste(hook(res), collapse = '')
   }
-  input
+  # replace with evaluated results
+  str_replace(input, block$location, ans)
 }
 
 process_tangle = function(x) {

--- a/R/block.R
+++ b/R/block.R
@@ -560,7 +560,7 @@ inline_exec = function(
     })
     d = nchar(input)
     # replace with evaluated results
-    stringr::str_sub(input, loc[i, 1], loc[i, 2]) = if (length(res)) {
+    str_substitute(input, loc[i, 1], loc[i, 2]) = if (length(res)) {
       paste(hook(res), collapse = '')
     } else ''
     if (i < n) loc[(i + 1):n, ] = loc[(i + 1):n, ] - (d - nchar(input))

--- a/R/block.R
+++ b/R/block.R
@@ -560,7 +560,7 @@ inline_exec = function(
     })
     d = nchar(input)
     # replace with evaluated results
-    str_substitute(input, loc[i, 1], loc[i, 2]) = if (length(res)) {
+    stringr::str_sub(input, loc[i, 1], loc[i, 2]) = if (length(res)) {
       paste(hook(res), collapse = '')
     } else ''
     if (i < n) loc[(i + 1):n, ] = loc[(i + 1):n, ] - (d - nchar(input))

--- a/R/header.R
+++ b/R/header.R
@@ -56,7 +56,7 @@ insert_header_latex = function(doc, b) {
       doc[j] = sub(p, '\n\\\\IfFileExists{upquote.sty}{\\\\usepackage{upquote}}{}\n\\2', doc[j], perl = TRUE)
     }
     i = i[1L]; l = stringr::str_locate(doc[i], b)
-    tmp = stringr::str_sub(doc[i], l[, 1], l[, 2])
+    tmp = substr(doc[i], l[, 1], l[, 2])
     stringr::str_sub(doc[i], l[,1], l[,2]) = paste0(tmp, make_header_latex(doc))
   } else if (parent_mode() && !child_mode()) {
     # in parent mode, we fill doc to be a complete document
@@ -87,7 +87,7 @@ insert_header_html = function(doc, b) {
   i = grep(b, doc)
   if (length(i) == 1L) {
     l = stringr::str_locate(doc[i], b)
-    tmp = stringr::str_sub(doc[i], l[, 1], l[, 2])
+    tmp = substr(doc[i], l[, 1], l[, 2])
     stringr::str_sub(doc[i], l[,1], l[,2]) = paste0(tmp, '\n', make_header_html())
   }
   doc

--- a/R/header.R
+++ b/R/header.R
@@ -56,8 +56,8 @@ insert_header_latex = function(doc, b) {
       doc[j] = sub(p, '\n\\\\IfFileExists{upquote.sty}{\\\\usepackage{upquote}}{}\n\\2', doc[j], perl = TRUE)
     }
     i = i[1L]; l = stringr::str_locate(doc[i], b)
-    tmp = stringr::str_sub(doc[i], l[, 1], l[, 2])
-    stringr::str_sub(doc[i], l[,1], l[,2]) = paste0(tmp, make_header_latex(doc))
+    tmp = str_substitute(doc[i], l[, 1], l[, 2])
+    str_substitute(doc[i], l[,1], l[,2]) = paste0(tmp, make_header_latex(doc))
   } else if (parent_mode() && !child_mode()) {
     # in parent mode, we fill doc to be a complete document
     doc[1L] = one_string(c(
@@ -87,8 +87,8 @@ insert_header_html = function(doc, b) {
   i = grep(b, doc)
   if (length(i) == 1L) {
     l = stringr::str_locate(doc[i], b)
-    tmp = stringr::str_sub(doc[i], l[, 1], l[, 2])
-    stringr::str_sub(doc[i], l[,1], l[,2]) = paste0(tmp, '\n', make_header_html())
+    tmp = str_substitute(doc[i], l[, 1], l[, 2])
+    str_substitute(doc[i], l[,1], l[,2]) = paste0(tmp, '\n', make_header_html())
   }
   doc
 }

--- a/R/header.R
+++ b/R/header.R
@@ -57,7 +57,7 @@ insert_header_latex = function(doc, b) {
     }
     i = i[1L]; l = stringr::str_locate(doc[i], b)
     tmp = substr(doc[i], l[, 1], l[, 2])
-    stringr::str_sub(doc[i], l[,1], l[,2]) = paste0(tmp, make_header_latex(doc))
+    doc[i] = str_replace(doc[i], l, paste0(tmp, make_header_latex(doc)))
   } else if (parent_mode() && !child_mode()) {
     # in parent mode, we fill doc to be a complete document
     doc[1L] = one_string(c(
@@ -88,7 +88,7 @@ insert_header_html = function(doc, b) {
   if (length(i) == 1L) {
     l = stringr::str_locate(doc[i], b)
     tmp = substr(doc[i], l[, 1], l[, 2])
-    stringr::str_sub(doc[i], l[,1], l[,2]) = paste0(tmp, '\n', make_header_html())
+    doc[i] = str_replace(doc[i], l, paste0(tmp, '\n', make_header_html()))
   }
   doc
 }

--- a/R/header.R
+++ b/R/header.R
@@ -56,8 +56,8 @@ insert_header_latex = function(doc, b) {
       doc[j] = sub(p, '\n\\\\IfFileExists{upquote.sty}{\\\\usepackage{upquote}}{}\n\\2', doc[j], perl = TRUE)
     }
     i = i[1L]; l = stringr::str_locate(doc[i], b)
-    tmp = str_substitute(doc[i], l[, 1], l[, 2])
-    str_substitute(doc[i], l[,1], l[,2]) = paste0(tmp, make_header_latex(doc))
+    tmp = stringr::str_sub(doc[i], l[, 1], l[, 2])
+    stringr::str_sub(doc[i], l[,1], l[,2]) = paste0(tmp, make_header_latex(doc))
   } else if (parent_mode() && !child_mode()) {
     # in parent mode, we fill doc to be a complete document
     doc[1L] = one_string(c(
@@ -87,8 +87,8 @@ insert_header_html = function(doc, b) {
   i = grep(b, doc)
   if (length(i) == 1L) {
     l = stringr::str_locate(doc[i], b)
-    tmp = str_substitute(doc[i], l[, 1], l[, 2])
-    str_substitute(doc[i], l[,1], l[,2]) = paste0(tmp, '\n', make_header_html())
+    tmp = stringr::str_sub(doc[i], l[, 1], l[, 2])
+    stringr::str_sub(doc[i], l[,1], l[,2]) = paste0(tmp, '\n', make_header_html())
   }
   doc
 }

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -1,0 +1,10 @@
+# replace parts of a string with new values; `pos` is a matrix of positions and
+# each row is a pair of [start, end]
+str_replace = function(x, pos, value) {
+  if (length(x) != 1) stop("Only a character scalar is supported.")
+  # extract parts of the string that are outside [start, end]
+  m = rbind(pos[, 1] - 1, pos[, 2] + 1)
+  m = matrix(c(1, m, nchar(x)), nrow = 2)
+  y = substring(x, m[1, ], m[2, ])
+  paste(rbind(y, c(value, '')), collapse = '')
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,8 +89,8 @@ set_preamble = function(input, patterns = knit_patterns$get()) {
   if (is.na(idx1) || idx1 >= idx2) return()
   txt = one_string(input[idx1:(idx2 - 1L)])  # rough preamble
   idx = stringr::str_locate(txt, hb)  # locate documentclass
-  options(tikzDocumentDeclaration = stringr::str_sub(txt, idx[, 1L], idx[, 2L]))
-  preamble = pure_preamble(split_lines(stringr::str_sub(txt, idx[, 2L] + 1L)), patterns)
+  options(tikzDocumentDeclaration = substr(txt, idx[, 1L], idx[, 2L]))
+  preamble = pure_preamble(split_lines(substr(txt, idx[, 2L] + 1L, nchar(txt))), patterns)
   .knitEnv$tikzPackages = c(.header.sweave.cmd, preamble, '\n')
   .knitEnv$bibliography = grep('^\\\\bibliography.+', input, value = TRUE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,8 +89,8 @@ set_preamble = function(input, patterns = knit_patterns$get()) {
   if (is.na(idx1) || idx1 >= idx2) return()
   txt = one_string(input[idx1:(idx2 - 1L)])  # rough preamble
   idx = stringr::str_locate(txt, hb)  # locate documentclass
-  options(tikzDocumentDeclaration = str_substitute(txt, idx[, 1L], idx[, 2L]))
-  preamble = pure_preamble(split_lines(str_substitute(txt, idx[, 2L] + 1L)), patterns)
+  options(tikzDocumentDeclaration = stringr::str_sub(txt, idx[, 1L], idx[, 2L]))
+  preamble = pure_preamble(split_lines(stringr::str_sub(txt, idx[, 2L] + 1L)), patterns)
   .knitEnv$tikzPackages = c(.header.sweave.cmd, preamble, '\n')
   .knitEnv$bibliography = grep('^\\\\bibliography.+', input, value = TRUE)
 }
@@ -1085,34 +1085,3 @@ str_split = function(x, split, ...) {
   y[x == ''] = list('')
   y
 }
-
-str_substitute = function(string, start = 1L, end = -1L) {
-
-  if (is.matrix(start)) {
-    end = start[, 2]
-    start = start[, 1]
-  }
-
-  start = recycler(start, string)
-  end = recycler(end, string)
-
-  n = nchar(string)
-  start = ifelse(start < 0, start + n + 1, start)
-  end = ifelse(end < 0, end + n + 1, end)
-
-  substr(string, start, end)
-}
-
-recycler = function(x, to, arg = deparse(substitute(x))) {
-
-  if (length(x) == length(to)) {
-    return(x)
-  }
-
-  if (length(x) != 1) {
-    stop("Can't recycle `", arg, "` to length ", length(to), call. = FALSE)
-  }
-
-  rep(x, length(to))
-}
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,8 +89,8 @@ set_preamble = function(input, patterns = knit_patterns$get()) {
   if (is.na(idx1) || idx1 >= idx2) return()
   txt = one_string(input[idx1:(idx2 - 1L)])  # rough preamble
   idx = stringr::str_locate(txt, hb)  # locate documentclass
-  options(tikzDocumentDeclaration = stringr::str_sub(txt, idx[, 1L], idx[, 2L]))
-  preamble = pure_preamble(split_lines(stringr::str_sub(txt, idx[, 2L] + 1L)), patterns)
+  options(tikzDocumentDeclaration = str_substitute(txt, idx[, 1L], idx[, 2L]))
+  preamble = pure_preamble(split_lines(str_substitute(txt, idx[, 2L] + 1L)), patterns)
   .knitEnv$tikzPackages = c(.header.sweave.cmd, preamble, '\n')
   .knitEnv$bibliography = grep('^\\\\bibliography.+', input, value = TRUE)
 }
@@ -1085,3 +1085,34 @@ str_split = function(x, split, ...) {
   y[x == ''] = list('')
   y
 }
+
+str_substitute = function(string, start = 1L, end = -1L) {
+
+  if (is.matrix(start)) {
+    end = start[, 2]
+    start = start[, 1]
+  }
+
+  start = recycler(start, string)
+  end = recycler(end, string)
+
+  n = nchar(string)
+  start = ifelse(start < 0, start + n + 1, start)
+  end = ifelse(end < 0, end + n + 1, end)
+
+  substr(string, start, end)
+}
+
+recycler = function(x, to, arg = deparse(substitute(x))) {
+
+  if (length(x) == length(to)) {
+    return(x)
+  }
+
+  if (length(x) != 1) {
+    stop("Can't recycle `", arg, "` to length ", length(to), call. = FALSE)
+  }
+
+  rep(x, length(to))
+}
+


### PR DESCRIPTION
This replaces all instances of `stringr::str_sub()` with the base R equivalent `str_substitute()`.