### PR TITLE
Replace several stringr-based function calls with base equivalents

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -616,7 +616,7 @@ process_tangle.inline = function(x) {
 # add a label [and extra chunk options] to a code chunk
 label_code = function(code, label) {
   code = one_string(c('', code, ''))
-  paste0('## ----', stringr::str_pad(label, max(getOption('width') - 11L, 0L), 'right', '-'),
+  paste0('## ----', label, strrep('-', max(getOption('width') - 11L - nchar(label), 0L)),
          '----', code)
 }
 

--- a/R/citation.R
+++ b/R/citation.R
@@ -132,7 +132,7 @@ write_bib = function(
   bib = c(bib, unlist(bib2, recursive = FALSE))
   bib = lapply(bib, function(b) {
     idx = which(names(b) == '')
-    if (!is.null(width)) b[-idx] = stringr::str_wrap(b[-idx], width, 2, 4)
+    if (!is.null(width)) b[-idx] = strwrap(b[-idx], width, 2, 4)
     structure(c(b[idx[1L]], b[-idx], b[idx[2L]], ''), class = 'Bibtex')
   })
   if (!is.null(file) && length(x)) write_utf8(unlist(bib), file)

--- a/R/citation.R
+++ b/R/citation.R
@@ -132,7 +132,7 @@ write_bib = function(
   bib = c(bib, unlist(bib2, recursive = FALSE))
   bib = lapply(bib, function(b) {
     idx = which(names(b) == '')
-    if (!is.null(width)) b[-idx] = strwrap(b[-idx], width, 2, 4)
+    if (!is.null(width)) b[-idx] = str_wrap(b[-idx], width, 2, 4)
     structure(c(b[idx[1L]], b[-idx], b[idx[2L]], ''), class = 'Bibtex')
   })
   if (!is.null(file) && length(x)) write_utf8(unlist(bib), file)

--- a/R/output.R
+++ b/R/output.R
@@ -500,7 +500,7 @@ sew.source = function(x, options, ...) {
 msg_wrap = function(message, type, options) {
   # when the output format is LaTeX, do not wrap messages (let LaTeX deal with wrapping)
   if (!length(grep('\n', message)) && !out_format(c('latex', 'listings', 'sweave')))
-    message = strwrap(message, width = getOption('width'))
+    message = str_wrap(message, width = getOption('width'))
   knit_log$set(setNames(
     list(c(knit_log$get(type), paste0('Chunk ', options$label, ':\n  ', message))),
     type

--- a/R/output.R
+++ b/R/output.R
@@ -500,7 +500,7 @@ sew.source = function(x, options, ...) {
 msg_wrap = function(message, type, options) {
   # when the output format is LaTeX, do not wrap messages (let LaTeX deal with wrapping)
   if (!length(grep('\n', message)) && !out_format(c('latex', 'listings', 'sweave')))
-    message = stringr::str_wrap(message, width = getOption('width'))
+    message = strwrap(message, width = getOption('width'))
   knit_log$set(setNames(
     list(c(knit_log$get(type), paste0('Chunk ', options$label, ':\n  ', message))),
     type

--- a/R/pattern.R
+++ b/R/pattern.R
@@ -152,7 +152,7 @@ detect_pattern = function(text, ext) {
   for (p in names(all_patterns)) {
     for (i in c('chunk.begin', 'inline.code')) {
       pat = all_patterns[[p]][[i]]
-      if (length(pat) && any(stringr::str_detect(text, pat))) return(p)
+      if (length(pat) && any(grepl(pat, text))) return(p)
     }
   }
   # *.Rtex indicates the tex syntax in knitr, but Rnw syntax in traditional

--- a/R/pattern.R
+++ b/R/pattern.R
@@ -152,7 +152,7 @@ detect_pattern = function(text, ext) {
   for (p in names(all_patterns)) {
     for (i in c('chunk.begin', 'inline.code')) {
       pat = all_patterns[[p]][[i]]
-      if (length(pat) && any(grepl(pat, text))) return(p)
+      if (length(pat) && any(grepl(pat, text, perl = TRUE))) return(p)
     }
   }
   # *.Rtex indicates the tex syntax in knitr, but Rnw syntax in traditional

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -8,3 +8,11 @@ str_replace = function(x, pos, value) {
   y = substring(x, m[1, ], m[2, ])
   paste(rbind(y, c(value, '')), collapse = '')
 }
+
+# a wrapper function to make strwrap() return a character vector of the same
+# length as the input vector; each element of the output vector is a string
+# formed by concatenating wrapped strings by \n
+str_wrap = function(...) {
+  res = strwrap(..., simplify = FALSE)
+  unlist(lapply(res, one_string))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -580,7 +580,14 @@ print_knitlog = function() {
 }
 
 # count the number of lines
-line_count = function(x) stringr::str_count(x, '\n') + 1L
+line_count = function(x) {
+  res = gregexpr('\n', x, fixed = TRUE)
+  unlist(lapply(res, function(x) {
+    n = length(x)
+    if (n == 1 && x == -1) n = 0
+    n + 1
+  }))
+}
 
 has_package = function(pkg) loadable(pkg, FALSE)
 has_packages = function(pkgs) {


### PR DESCRIPTION
This PR replaces several uses of stringr functions with base equivalents. This is being done in order to eventually remove the dependency on the stringr package.