### PR TITLE
Replace several stringr fns with base equivalents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -118,7 +118,6 @@ Imports:
     evaluate (>= 0.15),
     highr,
     methods,
-    stringr (>= 0.6),
     yaml (>= 2.1.19),
     xfun (>= 0.34),
     tools

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - Due to a change in the **evaluate** package, the chunk options `message = FALSE` and `warning = FALSE` will completely suppress the messages/warnings now, instead of sending them to the console. To get back to the old behavior, you can use `NA` instead of `FALSE` (thanks, @gadenbuie, https://github.com/yihui/yihui.org/discussions/1458).
 
+- The **stringr** dependency has been removed. All string operations are done with base R now (thanks, @HughParsonage #1549 #1552, @rich-iannone #2174 #2177 #2186 #2187 #2195 #2202 #2205).
+
 ## MINOR CHANGES
 
 - Improved the error message when inline R code cannot be parsed (thanks, @hadley #2173, @rich-iannone #2198).

--- a/R/block.R
+++ b/R/block.R
@@ -584,7 +584,7 @@ process_tangle.block = function(x) {
   } else knit_code$get(label)
   # read external code if exists
   if (!isFALSE(ev) && length(code) && any(grepl('read_chunk\\(.+\\)', code))) {
-    eval(parse_only(unlist(str_complete_extract(code, 'read_chunk\\(([^)]+)\\)'))))
+    eval(parse_only(unlist(str_extract(code, 'read_chunk\\(([^)]+)\\)'))))
   }
   code = parse_chunk(code)
   if (isFALSE(ev)) code = comment_out(code, params$comment, newline = FALSE)

--- a/R/block.R
+++ b/R/block.R
@@ -584,7 +584,7 @@ process_tangle.block = function(x) {
   } else knit_code$get(label)
   # read external code if exists
   if (!isFALSE(ev) && length(code) && any(grepl('read_chunk\\(.+\\)', code))) {
-    eval(parse_only(unlist(stringr::str_extract_all(code, 'read_chunk\\(([^)]+)\\)'))))
+    eval(parse_only(unlist(str_complete_extract(code, 'read_chunk\\(([^)]+)\\)'))))
   }
   code = parse_chunk(code)
   if (isFALSE(ev)) code = comment_out(code, params$comment, newline = FALSE)

--- a/R/header.R
+++ b/R/header.R
@@ -55,7 +55,7 @@ insert_header_latex = function(doc, b) {
       j = j[1]
       doc[j] = sub(p, '\n\\\\IfFileExists{upquote.sty}{\\\\usepackage{upquote}}{}\n\\2', doc[j], perl = TRUE)
     }
-    i = i[1L]; l = str_single_locate(doc[i], b)
+    i = i[1L]; l = str_locate(doc[i], b, FALSE)
     tmp = substr(doc[i], l[, 1], l[, 2])
     doc[i] = str_replace(doc[i], l, paste0(tmp, make_header_latex(doc)))
   } else if (parent_mode() && !child_mode()) {
@@ -86,7 +86,7 @@ make_header_html = function() {
 insert_header_html = function(doc, b) {
   i = grep(b, doc)
   if (length(i) == 1L) {
-    l = str_single_locate(doc[i], b)
+    l = str_locate(doc[i], b, FALSE)
     tmp = substr(doc[i], l[, 1], l[, 2])
     doc[i] = str_replace(doc[i], l, paste0(tmp, '\n', make_header_html()))
   }

--- a/R/header.R
+++ b/R/header.R
@@ -55,7 +55,7 @@ insert_header_latex = function(doc, b) {
       j = j[1]
       doc[j] = sub(p, '\n\\\\IfFileExists{upquote.sty}{\\\\usepackage{upquote}}{}\n\\2', doc[j], perl = TRUE)
     }
-    i = i[1L]; l = stringr::str_locate(doc[i], b)
+    i = i[1L]; l = str_single_locate(doc[i], b)
     tmp = substr(doc[i], l[, 1], l[, 2])
     doc[i] = str_replace(doc[i], l, paste0(tmp, make_header_latex(doc)))
   } else if (parent_mode() && !child_mode()) {
@@ -86,7 +86,7 @@ make_header_html = function() {
 insert_header_html = function(doc, b) {
   i = grep(b, doc)
   if (length(i) == 1L) {
-    l = stringr::str_locate(doc[i], b)
+    l = str_single_locate(doc[i], b)
     tmp = substr(doc[i], l[, 1], l[, 2])
     doc[i] = str_replace(doc[i], l, paste0(tmp, '\n', make_header_html()))
   }

--- a/R/parser.R
+++ b/R/parser.R
@@ -355,7 +355,7 @@ parse_inline = function(input, patterns) {
   input = one_string(input) # merge into one line
 
   loc = cbind(start = numeric(0), end = numeric(0))
-  if (group_pattern(inline.code)) loc = stringr::str_locate_all(input, inline.code)[[1]]
+  if (group_pattern(inline.code)) loc = str_complete_locate(input, inline.code)[[1]]
   if (nrow(loc)) {
     code = stringr::str_match_all(input, inline.code)[[1L]]
     code = if (NCOL(code) >= 2L) {

--- a/R/parser.R
+++ b/R/parser.R
@@ -355,7 +355,7 @@ parse_inline = function(input, patterns) {
   input = one_string(input) # merge into one line
 
   loc = cbind(start = numeric(0), end = numeric(0))
-  if (group_pattern(inline.code)) loc = str_complete_locate(input, inline.code)[[1]]
+  if (group_pattern(inline.code)) loc = str_locate(input, inline.code)[[1]]
   if (nrow(loc)) {
     code = str_get_all_matches(input, inline.code)[[1L]]
     code = if (NCOL(code) >= 2L) {

--- a/R/parser.R
+++ b/R/parser.R
@@ -357,7 +357,7 @@ parse_inline = function(input, patterns) {
   loc = cbind(start = numeric(0), end = numeric(0))
   if (group_pattern(inline.code)) loc = str_complete_locate(input, inline.code)[[1]]
   if (nrow(loc)) {
-    code = stringr::str_match_all(input, inline.code)[[1L]]
+    code = str_get_all_matches(input, inline.code)[[1L]]
     code = if (NCOL(code) >= 2L) {
       code[is.na(code)] = ''
       apply(code[, -1L, drop = FALSE], 1, paste, collapse = '')

--- a/R/parser.R
+++ b/R/parser.R
@@ -357,9 +357,8 @@ parse_inline = function(input, patterns) {
   loc = cbind(start = numeric(0), end = numeric(0))
   if (group_pattern(inline.code)) loc = str_locate(input, inline.code)[[1]]
   if (nrow(loc)) {
-    code = str_get_all_matches(input, inline.code)[[1L]]
+    code = t(str_match(input, inline.code))
     code = if (NCOL(code) >= 2L) {
-      code[is.na(code)] = ''
       apply(code[, -1L, drop = FALSE], 1, paste, collapse = '')
     } else character(0)
   } else code = character(0)

--- a/R/template.R
+++ b/R/template.R
@@ -118,7 +118,7 @@ knit_expand = function(file, ..., text = read_utf8(file), delim = c('{{', '}}') 
   delim = paste0(delim[1L], '((.|\n)+?)', delim[2L])
 
   txt = one_string(text)
-  loc = stringr::str_locate_all(txt, delim)[[1L]]
+  loc = str_complete_locate(txt, delim)[[1L]]
   if (nrow(loc) == 0L) return(txt) # no match
   mat = str_complete_extract(txt, delim)[[1L]]
   mat = sub(delim, '\\1', mat)

--- a/R/template.R
+++ b/R/template.R
@@ -120,7 +120,7 @@ knit_expand = function(file, ..., text = read_utf8(file), delim = c('{{', '}}') 
   txt = one_string(text)
   loc = str_locate(txt, delim)[[1L]]
   if (nrow(loc) == 0L) return(txt) # no match
-  mat = str_complete_extract(txt, delim)[[1L]]
+  mat = str_extract(txt, delim)[[1L]]
   mat = sub(delim, '\\1', mat)
   env = list(...)
   env = if (length(env)) list2env(env, parent = parent.frame()) else parent.frame()

--- a/R/template.R
+++ b/R/template.R
@@ -118,7 +118,7 @@ knit_expand = function(file, ..., text = read_utf8(file), delim = c('{{', '}}') 
   delim = paste0(delim[1L], '((.|\n)+?)', delim[2L])
 
   txt = one_string(text)
-  loc = str_complete_locate(txt, delim)[[1L]]
+  loc = str_locate(txt, delim)[[1L]]
   if (nrow(loc) == 0L) return(txt) # no match
   mat = str_complete_extract(txt, delim)[[1L]]
   mat = sub(delim, '\\1', mat)

--- a/R/template.R
+++ b/R/template.R
@@ -120,7 +120,7 @@ knit_expand = function(file, ..., text = read_utf8(file), delim = c('{{', '}}') 
   txt = one_string(text)
   loc = stringr::str_locate_all(txt, delim)[[1L]]
   if (nrow(loc) == 0L) return(txt) # no match
-  mat = stringr::str_extract_all(txt, delim)[[1L]]
+  mat = str_complete_extract(txt, delim)[[1L]]
   mat = sub(delim, '\\1', mat)
   env = list(...)
   env = if (length(env)) list2env(env, parent = parent.frame()) else parent.frame()

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -16,3 +16,77 @@ str_wrap = function(...) {
   res = strwrap(..., simplify = FALSE)
   unlist(lapply(res, one_string))
 }
+
+# a simplified replacement for stringr::str_locate() that returns an integer
+# matrix having a row for each element of the input `string`, and two columns:
+# 'start' and 'end'. If the match is of length 0, 'end' will have one character
+# less than 'start'. Depends on the `location()` util function, also defined
+# in this file.
+str_single_locate = function(string, pattern) {
+  out = regexpr(pattern, string, perl = TRUE)
+  location(out)
+}
+
+# a simplified replacement for stringr::str_locate_all() that returns a list
+# having an element for every element of 'string'; every list element is an
+# integer matrix having a row per match, and two columns: 'start' and 'end'.
+# Depends on the location() util function, also defined in this file.
+str_complete_locate = function(string, pattern) {
+  out = gregexpr(pattern, string, perl = TRUE)
+  lapply(out, location, all = TRUE)
+}
+
+# a replacement for stringr::str_extract_all()
+str_complete_extract = function(string, pattern) {
+  loc = str_complete_locate(string, pattern)
+  lapply(seq_along(string), function(i) {
+    loc = loc[[i]]
+    str_substitute(rep(string[[i]], nrow(loc)), loc)
+  })
+}
+
+# replacement for stringr::str_match()
+str_get_match = function(string, pattern) {
+  loc = regexec(pattern, string, perl = TRUE)
+  loc = lapply(loc, location)
+  out = lapply(seq_along(string), function(i) {
+    loc = loc[[i]]
+    str_substitute(rep(string[[i]], nrow(loc)), loc)
+  })
+  do.call("rbind", out)
+}
+
+# replacement for stringr::str_sub() and used internally in other string
+# functions provided here
+str_substitute = function(string, start = 1L, end = -1L) {
+  if (is.matrix(start)) {
+    end = start[, 2]
+    start = start[, 1]
+  }
+  start = recycler(start, string)
+  end = recycler(end, string)
+  n = nchar(string)
+  start = ifelse(start < 0, start + n + 1, start)
+  end = ifelse(end < 0, end + n + 1, end)
+  substr(string, start, end)
+}
+
+location = function(x, all = FALSE) {
+  start = as.vector(x)
+  if (all && identical(start, -1L)) {
+    return(cbind(start = integer(), end = integer()))
+  }
+  end = as.vector(x) + attr(x, "match.length") - 1
+  no_match = start == -1L
+  start[no_match] = NA
+  end[no_match] = NA
+  cbind(start = start, end = end)
+}
+
+recycler = function(x, to, arg = deparse(substitute(x))) {
+  if (length(x) == length(to)) return(x)
+  if (length(x) != 1) {
+    stop("Cannot recycle `", arg, "` to length ", length(to))
+  }
+  rep(x, length(to))
+}

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -47,7 +47,7 @@ str_complete_extract = function(string, pattern) {
 
 # replacement for stringr::str_match_all()
 str_get_all_matches = function(string, pattern) {
-  res = gregexec(pattern, string, perl = TRUE)
+  res = gregexec_knitr(pattern, string, perl = TRUE)
   loc = lapply(res, FUN = function(x) {
     if (all(is.na(x))) return(list(NA_character_))
     match_attr = attr(x, "match.length")
@@ -94,6 +94,54 @@ str_get_all_matches = function(string, pattern) {
     elem
   })
   out
+}
+
+gregexec_knitr = function(pattern, text, perl = FALSE) {
+  if (is.factor(text) && length(levels(text)) < length(text)) {
+    out = gregexec_knitr(pattern, c(levels(text), NA_character_), perl)
+    outna = out[length(out)]
+    out = out[text]
+    out[is.na(text)] = outna
+    return(out)
+  }
+  dat = gregexpr(pattern = pattern, text = text, perl = perl)
+  if (perl) {
+    capt.attr = c('capture.start', 'capture.length', 'capture.names')
+    process = function(x) {
+      if (anyNA(x) || any(x < 0)) y = x
+      else {
+        y = t(cbind(x, attr(x, "capture.start")))
+        attributes(y)[names(attributes(x))] = attributes(x)
+        ml = t(cbind(attr(x, "match.length"), attr(x, "capture.length")))
+        nm = attr(x, 'capture.names')
+        dimnames(ml) = dimnames(y) = if (any(nzchar(nm))) list(c("", nm), NULL)
+        attr(y, "match.length") = ml
+        y
+      }
+      attributes(y)[capt.attr] = NULL
+      y
+    }
+    lapply(dat, process)
+  } else {
+    m1 = lapply(regmatches(text, dat), regexec, pattern = pattern, perl = perl)
+    mlen = lengths(m1)
+    res = vector("list", length(m1))
+    im = mlen > 0
+    res[!im] = dat[!im]
+    res[im] = Map(
+      function(outer, inner) {
+        tmp = do.call(cbind, inner)
+        attributes(tmp)[names(attributes(inner))] = attributes(inner)
+        attr(tmp, 'match.length') = do.call(cbind, lapply(inner, `attr`, 'match.length'))
+        attr(tmp, 'useBytes') = attr(outer, 'useBytes')
+        attr(tmp, 'index.type') = attr(outer, 'index.type')
+        tmp + rep(outer - 1L, each = nrow(tmp))
+      },
+      dat[im],
+      m1[im]
+    )
+    res
+  }
 }
 
 # replacement for stringr::str_sub() and used internally in other string

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -45,17 +45,6 @@ str_complete_extract = function(string, pattern) {
   })
 }
 
-# replacement for stringr::str_match()
-str_get_match = function(string, pattern) {
-  loc = regexec(pattern, string, perl = TRUE)
-  loc = lapply(loc, location)
-  out = lapply(seq_along(string), function(i) {
-    loc = loc[[i]]
-    str_substitute(rep(string[[i]], nrow(loc)), loc)
-  })
-  do.call("rbind", out)
-}
-
 # replacement for stringr::str_match_all()
 str_get_all_matches = function(string, pattern) {
   res = gregexec(pattern, string, perl = TRUE)

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -159,16 +159,10 @@ str_substitute = function(string, start = 1L, end = -1L) {
   substr(string, start, end)
 }
 
-location = function(x, all = FALSE) {
-  start = as.vector(x)
-  if (all && identical(start, -1L)) {
-    return(cbind(start = integer(), end = integer()))
-  }
-  end = as.vector(x) + attr(x, "match.length") - 1
-  no_match = start == -1L
-  start[no_match] = NA
-  end[no_match] = NA
-  cbind(start = start, end = end)
+location = function(x) {
+  len = attr(x, 'match.length')
+  if (length(x) == 1 && x == -1) x = integer()
+  cbind(start = x, end = x + len - 1L)
 }
 
 recycler = function(x, to, arg = deparse(substitute(x))) {

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -25,136 +25,25 @@ str_locate = function(string, pattern, all = TRUE) {
   if (all) lapply(out, location) else location(out)
 }
 
-# a replacement for stringr::str_extract_all()
-str_extract = function(string, pattern) {
-  m = gregexpr(pattern, string, perl = TRUE)
-  regmatches(string, m)
-}
-
-# replacement for stringr::str_match_all()
-str_get_all_matches = function(string, pattern) {
-  res = gregexec_knitr(pattern, string, perl = TRUE)
-  loc = lapply(res, FUN = function(x) {
-    if (all(is.na(x))) return(list(NA_character_))
-    match_attr = attr(x, "match.length")
-    if (!is.matrix(match_attr) && match_attr == -1) return(list())
-    matches = list()
-    if (!is.null(ncol(x))) {
-      for (i in seq_len(ncol(x))) {
-        start_mat = x[, i, drop = FALSE]
-        end_mat = attr(x, "match.length")[, i, drop = FALSE] + start_mat - 1
-        matches = c(matches, list(cbind(start_mat, end_mat)))
-      }
-    }
-    matches
-  })
-  out = lapply(seq_along(loc), function(i) {
-    loc = loc[[i]]
-    mat_missing = matrix(rep(NA_character_, 2), nrow = 1)
-    mat_empty = matrix(rep(NA_character_, 2), nrow = 1)[-1, ]
-    if (is.list(loc) && length(loc) > 0 && !is.matrix(loc[[1]]) && is.na(loc[[1]])) {
-      return(mat_missing)
-    }
-    if (length(loc) < 1) return(mat_empty)
-    for (j in seq_along(loc)) {
-      loc_j = loc[[j]]
-      loc_j[loc_j < 0] = NA_real_
-      subst = str_substitute(rep(string[[i]], nrow(loc_j)), loc_j)
-      if (!all(is.na(subst))) {
-        if (j == 1) {
-          mat = matrix(rep(NA_character_, nrow(loc_j)), nrow = 1)[-1, ]
-        }
-        mat_j = t(as.matrix(subst))
-        mat = rbind(mat, mat_j)
-      }
-    }
-    mat
-  })
-  cols_mat = vapply(out, FUN.VALUE = integer(1), USE.NAMES = FALSE, FUN = NCOL)
-  max_cols_mat = max(cols_mat, na.rm = TRUE)
-  out = lapply(seq_along(loc), function(i) {
-    elem = out[[i]]
-    if (ncol(elem) < max_cols_mat) {
-      return(matrix(rep(NA_character_, max_cols_mat), nrow = 1)[-1, ])
-    }
-    elem
-  })
-  out
-}
-
-gregexec_knitr = function(pattern, text, perl = FALSE) {
-  if (is.factor(text) && length(levels(text)) < length(text)) {
-    out = gregexec_knitr(pattern, c(levels(text), NA_character_), perl)
-    outna = out[length(out)]
-    out = out[text]
-    out[is.na(text)] = outna
-    return(out)
-  }
-  dat = gregexpr(pattern = pattern, text = text, perl = perl)
-  if (perl) {
-    capt.attr = c('capture.start', 'capture.length', 'capture.names')
-    process = function(x) {
-      if (anyNA(x) || any(x < 0)) y = x
-      else {
-        y = t(cbind(x, attr(x, "capture.start")))
-        attributes(y)[names(attributes(x))] = attributes(x)
-        ml = t(cbind(attr(x, "match.length"), attr(x, "capture.length")))
-        nm = attr(x, 'capture.names')
-        dimnames(ml) = dimnames(y) = if (any(nzchar(nm))) list(c("", nm), NULL)
-        attr(y, "match.length") = ml
-        y
-      }
-      attributes(y)[capt.attr] = NULL
-      y
-    }
-    lapply(dat, process)
-  } else {
-    m1 = lapply(regmatches(text, dat), regexec, pattern = pattern, perl = perl)
-    mlen = lengths(m1)
-    res = vector("list", length(m1))
-    im = mlen > 0
-    res[!im] = dat[!im]
-    res[im] = Map(
-      function(outer, inner) {
-        tmp = do.call(cbind, inner)
-        attributes(tmp)[names(attributes(inner))] = attributes(inner)
-        attr(tmp, 'match.length') = do.call(cbind, lapply(inner, `attr`, 'match.length'))
-        attr(tmp, 'useBytes') = attr(outer, 'useBytes')
-        attr(tmp, 'index.type') = attr(outer, 'index.type')
-        tmp + rep(outer - 1L, each = nrow(tmp))
-      },
-      dat[im],
-      m1[im]
-    )
-    res
-  }
-}
-
-# replacement for stringr::str_sub() and used internally in other string
-# functions provided here
-str_substitute = function(string, start = 1L, end = -1L) {
-  if (is.matrix(start)) {
-    end = start[, 2]
-    start = start[, 1]
-  }
-  start = recycler(start, string)
-  end = recycler(end, string)
-  n = nchar(string)
-  start = ifelse(start < 0, start + n + 1, start)
-  end = ifelse(end < 0, end + n + 1, end)
-  substr(string, start, end)
-}
-
 location = function(x) {
   len = attr(x, 'match.length')
   if (length(x) == 1 && x == -1) x = integer()
   cbind(start = x, end = x + len - 1L)
 }
 
-recycler = function(x, to, arg = deparse(substitute(x))) {
-  if (length(x) == length(to)) return(x)
-  if (length(x) != 1) {
-    stop("Cannot recycle `", arg, "` to length ", length(to))
+# a replacement for stringr::str_extract_all()
+str_extract = function(string, pattern) {
+  m = gregexpr(pattern, string, perl = TRUE)
+  regmatches(string, m)
+}
+
+str_match = function(string, pattern) {
+  # gregexec() was added in R 4.1.0; for lower versions of R, use fallback
+  if (is.function(gregexec <- baseenv()[['gregexec']])) {
+    m = gregexec(pattern, string, perl = TRUE)
+  } else {
+    string = unlist(str_extract(string, pattern))
+    m = regexec(pattern, string, perl = TRUE)
   }
-  rep(x, length(to))
+  do.call(cbind, regmatches(string, m))
 }

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -60,7 +60,6 @@ str_get_match = function(string, pattern) {
 str_get_all_matches = function(string, pattern) {
   res = gregexec(pattern, string, perl = TRUE)
   loc = lapply(res, FUN = function(x) {
-
     if (all(is.na(x))) return(list(NA_character_))
     match_attr = attr(x, "match.length")
     if (!is.matrix(match_attr) && match_attr == -1) return(list())
@@ -84,6 +83,7 @@ str_get_all_matches = function(string, pattern) {
     if (length(loc) < 1) return(mat_empty)
     for (j in seq_along(loc)) {
       loc_j = loc[[j]]
+      loc_j[loc_j < 0] = NA_real_
       subst = str_substitute(rep(string[[i]], nrow(loc_j)), loc_j)
       if (!all(is.na(subst))) {
         if (j == 1) {

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -17,28 +17,17 @@ str_wrap = function(...) {
   unlist(lapply(res, one_string))
 }
 
-# a simplified replacement for stringr::str_locate() that returns an integer
-# matrix having a row for each element of the input `string`, and two columns:
-# 'start' and 'end'. If the match is of length 0, 'end' will have one character
-# less than 'start'. Depends on the `location()` util function, also defined
-# in this file.
-str_single_locate = function(string, pattern) {
-  out = regexpr(pattern, string, perl = TRUE)
-  location(out)
-}
-
 # a simplified replacement for stringr::str_locate_all() that returns a list
 # having an element for every element of 'string'; every list element is an
 # integer matrix having a row per match, and two columns: 'start' and 'end'.
-# Depends on the location() util function, also defined in this file.
-str_complete_locate = function(string, pattern) {
-  out = gregexpr(pattern, string, perl = TRUE)
-  lapply(out, location, all = TRUE)
+str_locate = function(string, pattern, all = TRUE) {
+  out = (if (all) gregexpr else regexpr)(pattern, string, perl = TRUE)
+  if (all) lapply(out, location) else location(out)
 }
 
 # a replacement for stringr::str_extract_all()
 str_complete_extract = function(string, pattern) {
-  loc = str_complete_locate(string, pattern)
+  loc = str_locate(string, pattern)
   lapply(seq_along(string), function(i) {
     loc = loc[[i]]
     str_substitute(rep(string[[i]], nrow(loc)), loc)

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -20,8 +20,8 @@ str_wrap = function(...) {
 # a simplified replacement for stringr::str_locate_all() that returns a list
 # having an element for every element of 'string'; every list element is an
 # integer matrix having a row per match, and two columns: 'start' and 'end'.
-str_locate = function(string, pattern, all = TRUE) {
-  out = (if (all) gregexpr else regexpr)(pattern, string, perl = TRUE)
+str_locate = function(x, pattern, all = TRUE) {
+  out = (if (all) gregexpr else regexpr)(pattern, x, perl = TRUE)
   if (all) lapply(out, location) else location(out)
 }
 
@@ -32,18 +32,18 @@ location = function(x) {
 }
 
 # a replacement for stringr::str_extract_all()
-str_extract = function(string, pattern) {
-  m = gregexpr(pattern, string, perl = TRUE)
-  regmatches(string, m)
+str_extract = function(x, pattern) {
+  m = gregexpr(pattern, x, perl = TRUE)
+  regmatches(x, m)
 }
 
-str_match = function(string, pattern) {
+str_match = function(x, pattern) {
   # gregexec() was added in R 4.1.0; for lower versions of R, use fallback
   if (is.function(gregexec <- baseenv()[['gregexec']])) {
-    m = gregexec(pattern, string, perl = TRUE)
+    m = gregexec(pattern, x, perl = TRUE)
   } else {
-    string = unlist(str_extract(string, pattern))
-    m = regexec(pattern, string, perl = TRUE)
+    x = unlist(str_extract(x, pattern))
+    m = regexec(pattern, x, perl = TRUE)
   }
-  do.call(cbind, regmatches(string, m))
+  do.call(cbind, regmatches(x, m))
 }

--- a/R/utils-string.R
+++ b/R/utils-string.R
@@ -26,12 +26,9 @@ str_locate = function(string, pattern, all = TRUE) {
 }
 
 # a replacement for stringr::str_extract_all()
-str_complete_extract = function(string, pattern) {
-  loc = str_locate(string, pattern)
-  lapply(seq_along(string), function(i) {
-    loc = loc[[i]]
-    str_substitute(rep(string[[i]], nrow(loc)), loc)
-  })
+str_extract = function(string, pattern) {
+  m = gregexpr(pattern, string, perl = TRUE)
+  regmatches(string, m)
 }
 
 # replacement for stringr::str_match_all()

--- a/R/utils.R
+++ b/R/utils.R
@@ -91,7 +91,7 @@ set_preamble = function(input, patterns = knit_patterns$get()) {
   idx1 = grep(hb, input)[1]
   if (is.na(idx1) || idx1 >= idx2) return()
   txt = one_string(input[idx1:(idx2 - 1L)])  # rough preamble
-  idx = str_single_locate(txt, hb)  # locate documentclass
+  idx = str_locate(txt, hb, FALSE)  # locate documentclass
   options(tikzDocumentDeclaration = substr(txt, idx[, 1L], idx[, 2L]))
   preamble = pure_preamble(split_lines(substr(txt, idx[, 2L] + 1L, nchar(txt))), patterns)
   .knitEnv$tikzPackages = c(.header.sweave.cmd, preamble, '\n')

--- a/R/utils.R
+++ b/R/utils.R
@@ -91,7 +91,7 @@ set_preamble = function(input, patterns = knit_patterns$get()) {
   idx1 = grep(hb, input)[1]
   if (is.na(idx1) || idx1 >= idx2) return()
   txt = one_string(input[idx1:(idx2 - 1L)])  # rough preamble
-  idx = stringr::str_locate(txt, hb)  # locate documentclass
+  idx = str_single_locate(txt, hb)  # locate documentclass
   options(tikzDocumentDeclaration = substr(txt, idx[, 1L], idx[, 2L]))
   preamble = pure_preamble(split_lines(substr(txt, idx[, 2L] + 1L, nchar(txt))), patterns)
   .knitEnv$tikzPackages = c(.header.sweave.cmd, preamble, '\n')


### PR DESCRIPTION
This PR replaces several uses of stringr functions with base equivalents. This is being done to remove the dependency on the stringr package. The stringr functions to be replaced are `str_locate()`, `str_locate_all()`, `str_match_all()`, and `str_extract_all()`.

Fixes: https://github.com/yihui/knitr/issues/1549