### PR TITLE
Support `.qmd` in `purl()` (and `knit()`)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.41.8
+Version: 1.41.9
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## NEW FEATURES
 
+- Better `.qmd` file support: 
+  - `purl()` will keep the in-chunk YAML syntax for options in the tangled R file
+  - `knit()` will produce a `.md` file 
+
 - Users can specify a custom progress bar for `knit()` now. The default is still a text progress bar created from `utils::txtProgressBar()`. To specify a custom progress bar, set `options(knitr.progress.fun = function(total, labels) {})`. This function should take arguments `total` (the total number of chunks) and `labels` (the vector of chunk labels), create a progress bar, and return a list of two methods: `list(update = function(i) {}, done = function() {})`. The `update()` method takes `i` (index of the current chunk) as the input and updates the progress bar. The `done()` method closes the progress bar. See https://yihui.org/knitr/options/#global-r-options for documentation and examples.
 
 - The default text progress bar is still written to `stdout()` by default, but can also be written to other connections or `stderr()` now. To do so, set `options(knitr.progress.output = )` to a connection or `stderr()`.

--- a/R/block.R
+++ b/R/block.R
@@ -594,8 +594,7 @@ process_tangle.block = function(x) {
   if (isFALSE(ev)) code = comment_out(code, params$comment, newline = FALSE)
   if (opts_knit$get('documentation') == 0L) return(one_string(code))
   # e.g when documentation 1 or 2 with purl()
-  if (is_quarto()) return(one_string(options$params$yaml.code, code, ''))
-  label_code(code, x$params.src)
+  label_code(code, x)
 }
 #' @export
 process_tangle.inline = function(x) {
@@ -620,10 +619,15 @@ process_tangle.inline = function(x) {
 
 
 # add a label [and extra chunk options] to a code chunk
-label_code = function(code, label) {
+label_code = function(code, options) {
   code = one_string(c('', code, ''))
-  paste0('## ----', label, strrep('-', max(getOption('width') - 11L - nchar(label), 0L)),
-         '----', code)
+  comments = if (is_quarto())
+    one_string(options$params$yaml.code)
+  else
+    paste0('## ----', options$params.src,
+           strrep('-', max(getOption('width') - 11L - nchar(options$params.src), 0L)),
+           '----')
+  paste0(comments, code)
 }
 
 as.source = function(code) {

--- a/R/block.R
+++ b/R/block.R
@@ -594,7 +594,7 @@ process_tangle.block = function(x) {
   if (isFALSE(ev)) code = comment_out(code, params$comment, newline = FALSE)
   if (opts_knit$get('documentation') == 0L) return(one_string(code))
   # e.g when documentation 1 or 2 with purl()
-  if (.knitEnv$is_quarto) return(one_string(options$params$yaml.code, code, ''))
+  if (is_quarto()) return(one_string(options$params$yaml.code, code, ''))
   label_code(code, x$params.src)
 }
 #' @export

--- a/R/block.R
+++ b/R/block.R
@@ -593,6 +593,8 @@ process_tangle.block = function(x) {
   code = parse_chunk(code)
   if (isFALSE(ev)) code = comment_out(code, params$comment, newline = FALSE)
   if (opts_knit$get('documentation') == 0L) return(one_string(code))
+  # e.g when documentation 1 or 2 with purl()
+  if (.knitEnv$is_quarto) return(one_string(options$params$yaml.code, code, ''))
   label_code(code, x$params.src)
 }
 #' @export

--- a/R/hooks-extra.R
+++ b/R/hooks-extra.R
@@ -152,7 +152,7 @@ hook_purl = function(before, options, envir) {
   if (is.character(output)) {
     code = c(
       if (file.exists(output)) read_utf8(output),
-      label_code(code, options$params.src)
+      label_code(code, options)
     )
     write_utf8(code, output)
   }

--- a/R/output.R
+++ b/R/output.R
@@ -334,7 +334,7 @@ auto_out_name = function(input, ext = tolower(file_ext(input))) {
   base = sans_ext(input)
   name = if (opts_knit$get('tangle')) c(base, '.R') else
     if (ext %in% c('rnw', 'snw')) c(base, '.tex') else
-      if (ext %in% c('rmd', 'rmarkdown', 'rhtml', 'rhtm', 'rtex', 'stex', 'rrst', 'rtextile'))
+      if (ext %in% c('rmd', 'rmarkdown', 'qmd', 'rhtml', 'rhtm', 'rtex', 'stex', 'rrst', 'rtextile'))
         c(base, '.', substring(ext, 2L)) else
           if (grepl('_knit_', input)) sub('_knit_', '', input) else
             if (ext != 'txt') c(base, '.txt') else c(base, '-out.', ext)
@@ -346,7 +346,7 @@ ext2fmt = c(
   rnw = 'latex', snw = 'latex', tex = 'latex', rtex = 'latex', stex = 'latex',
   htm = 'html', html = 'html', rhtml = 'html', rhtm = 'html',
   md = 'markdown', markdown = 'markdown', rmd = 'markdown', rmarkdown = 'markdown',
-  brew = 'brew', rst = 'rst', rrst = 'rst'
+  qmd = 'markdown', brew = 'brew', rst = 'rst', rrst = 'rst'
 )
 
 auto_format = function(ext) {

--- a/R/output.R
+++ b/R/output.R
@@ -190,6 +190,9 @@ knit = function(
     knit_concord$set(infile = input, outfile = output)
   }
 
+  # we need some special treatment for chunks in Quarto document
+  .knitEnv$is_quarto = !is.null(opts_knit$get('quarto.version')) || tolower(ext) == "qmd"
+
   text = if (is.null(text)) xfun::read_utf8(input) else split_lines(text)
   if (!length(text)) {
     if (is.character(output)) file.create(output)

--- a/R/parser.R
+++ b/R/parser.R
@@ -90,7 +90,7 @@ parse_block = function(code, header, params.src, markdown_mode = out_format('mar
   }
 
   # for quarto, preserve the actual original params.src and do not remove the engine
-  if ( !is_quarto() ) params.src = params
+  if (!is_quarto()) params.src = params
   params = parse_params(params)
 
   # remove indent (and possibly markdown blockquote >) from code

--- a/R/parser.R
+++ b/R/parser.R
@@ -90,7 +90,7 @@ parse_block = function(code, header, params.src, markdown_mode = out_format('mar
   }
 
   # for quarto, preserve the actual original params.src and do not remove the engine
-  if ( !.knitEnv$is_quarto ) params.src = params
+  if ( !is_quarto() ) params.src = params
   params = parse_params(params)
 
   # remove indent (and possibly markdown blockquote >) from code
@@ -134,7 +134,7 @@ parse_block = function(code, header, params.src, markdown_mode = out_format('mar
   }
 
   # for quarto only
-  if (.knitEnv$is_quarto) {
+  if (is_quarto()) {
     params$original.params.src = params.src
     params$chunk.echo = isTRUE(params[['echo']])
     params$yaml.code = parts$src

--- a/R/parser.R
+++ b/R/parser.R
@@ -90,7 +90,7 @@ parse_block = function(code, header, params.src, markdown_mode = out_format('mar
   }
 
   # for quarto, preserve the actual original params.src and do not remove the engine
-  if (!(is_quarto <- !is.null(opts_knit$get('quarto.version')))) params.src = params
+  if ( !.knitEnv$is_quarto ) params.src = params
   params = parse_params(params)
 
   # remove indent (and possibly markdown blockquote >) from code
@@ -134,7 +134,7 @@ parse_block = function(code, header, params.src, markdown_mode = out_format('mar
   }
 
   # for quarto only
-  if (is_quarto) {
+  if (.knitEnv$is_quarto) {
     params$original.params.src = params.src
     params$chunk.echo = isTRUE(params[['echo']])
     params$yaml.code = parts$src

--- a/R/utils.R
+++ b/R/utils.R
@@ -1118,3 +1118,5 @@ txt_pb = function(total, labels) {
     }
   )
 }
+
+is_quarto = function() isTRUE(.knitEnv$is_quarto)

--- a/tests/testit/test-block.R
+++ b/tests/testit/test-block.R
@@ -14,3 +14,15 @@ assert('inline_exec only accept character result', {
   (res %==% "no inline")
 })
 
+assert('label_code correct adds comment on code for yaml block or parsed param', {
+  oldW = getOption('width')
+  options(width = 20)
+  old = .knitEnv$is_quarto
+  .knitEnv$is_quarto = FALSE
+  (label_code("1+1", list(params.src = "test, eval=TRUE")) %==% "## ----test, eval=TRUE----\n1+1\n")
+  options(width = oldW)
+  .knitEnv$is_quarto = TRUE
+  (label_code("1+1",
+              list(params = list(yaml.code = c("#| label: test", "#| eval: true")))
+              ) %==% "#| label: test\n#| eval: true\n1+1\n")
+})


### PR DESCRIPTION
Closes #2165

`knitr::purl("doc.qmd")` will now works and conserve in-chunk YAML options comment. 

Example
````r
#| label: test-a
#| eval: true
1+1
strsplit('hello world', ' ')


#| label: test-b
#| fig.width: 10.0
#| fig.height: 7.0
if (FALSE) plot(1:10)


#| label: test-c
#| eval: false
## paste(letters, collapse = '|')
## if (1 == 1) {
##   'Awesome!'
## }
````

Choices is to kept the in-chunk special comment as-is, meaning the output will be a bit different than when purling a Rmd file. 
I hesitated to had at least the label maybe in `## label -------------`, but I figured it would transformed to much from the input and keeping the YAML line intact seems best. 

To make this works, **knitr** need to know when we are in "quarto-like" mode meaning we will have the `params$yaml.code` available.  I adapted from existing code by explicitly checking on Quarto through the extension of input file. 

On the bonus side, I added a commit to support `knit("doc.qmd")` so that it produces a `.md` file and not a `.txt` file as of now. `markdown` mode was already known by `detect_pattern()` for `.qmd` file.

