### PR TITLE
Stata engine - more specific cleanup of files

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -87,9 +87,9 @@ engine_output = function(options, code, out, extra = NULL) {
   if (length(out) != 1L) out = one_string(out)
   out = sub('([^\n]+)$', '\\1\n', out)
   if (options$engine == 'stata') {
-    out = gsub('\n+running.*profile.do', '', out)
-    out = sub('...\n+', '', out)
-    out = sub('\n. \nend of do-file\n', '', out)
+    out = gsub('\n+running.*profile\\.do', '', out)
+    out = sub('\\.\\.\\.\n+', '', out)
+    out = sub('\n\\. \nend of do-file\n', '', out)
   }
   one_string(c(
     if (length(options$echo) > 1L || options$echo) knit_hooks$get('source')(code, options),


### PR DESCRIPTION
I would suggest the changes here, changing a few "." wildcards to "\\." literals dots.  This was code a wrote years ago, when I was new to regex!

An alternative would be to simply drop this Stata output file cleanup altogether, and allow it to be handled in the Statamarkdown package.