### PR TITLE
Split up chunks with collapse = TRUE if they contain htmlwidgets output

### DIFF
--- a/tests/testit/test-hooks-md.R
+++ b/tests/testit/test-hooks-md.R
@@ -29,7 +29,7 @@ assert('include_graphics() includes custom images correctly', {
 hook_src = knit_hooks$get("source")
 options_ = list(engine = "r", prompt = FALSE, highlight = TRUE)
 
-assert('Lengh of fences are satisfied', {
+assert('Length of fences are satisfied', {
   (hook_src("", options_) %==% "\n\n```r\n\n```\n\n")
   (hook_src("```", options_) %==% "\n\n````r\n```\n````\n\n")
 })
@@ -52,9 +52,16 @@ assert('class.source and attr.source works also with collapse = TRUE', {
       "```{.r .a b=1}\n1\n1\n```")
 })
 
+assert('collapse = TRUE does not collapse htmlwidgets', {
+  hook_chunk = hooks_markdown()$chunk
+  (hook_chunk("\n```{=html}\n1\n```\n\n```r\n1\n```\n",
+              c(options_, collapse = TRUE)) %==%
+      "\n```{=html}\n1\n```\n\n```r\n1\n```")
+})
+
 hook_out = knit_hooks$get("output")
 
-assert('Attributes for souce can be specified class.source and attr.source', {
+assert('Attributes for source can be specified class.source and attr.source', {
   (hook_out("1\n", c(options_, class.output = "a b")) %==%
     "\n\n```{.a .b}\n1\n```\n\n")
   (hook_out("1\n", c(options_, attr.output = ".a .b")) %==%


### PR DESCRIPTION
This addresses my last comment in #2172, where htmlwidgets output stopped later code from getting proper formatting.