### PR TITLE
Don't fallback to parse usual R comments in Quarto

### DIFF
--- a/R/parser.R
+++ b/R/parser.R
@@ -275,7 +275,8 @@ partition_chunk = function(engine, code) {
   i1 = startsWith(code, s1)
   i2 = endsWith(trimws(code, 'right'), s2)
   # if "commentChar| " is not found, try "#| " instead
-  if (!i1[1] && !identical(s1, '#|')) {
+  # except in Quarto which expect language comment
+  if (!is_quarto() && !i1[1] && !identical(s1, '#|')) {
     s1 = '#| '; s2 = ''
     i1 = startsWith(code, s1); i2 = TRUE
   }

--- a/R/parser.R
+++ b/R/parser.R
@@ -275,8 +275,17 @@ partition_chunk = function(engine, code) {
   i1 = startsWith(code, s1)
   i2 = endsWith(trimws(code, 'right'), s2)
   # if "commentChar| " is not found, try "#| " instead
-  # except in Quarto which expect language comment
-  if (!is_quarto() && !i1[1] && !identical(s1, '#|')) {
+  if (!i1[1] && !identical(s1, '#|')) {
+    # if in quarto, stop and advice to use language option
+    if (is_quarto()) {
+      stop2(c(
+        "Non R chunk should use the comment character from the language for YAML option. ",
+        sprintf("You are using %s:\n", sQuote(engine)),
+        sprintf("  you probably should start your comment with %s", dQuote(s1)),
+        if (nzchar(s2)) sprintf(" and use %s at end of each comment line.", dQuote(s2)),
+        "\n"
+      ))
+    }
     s1 = '#| '; s2 = ''
     i1 = startsWith(code, s1); i2 = TRUE
   }


### PR DESCRIPTION
This is related to discussion in https://github.com/quarto-dev/quarto-cli/issues/4306

Making this **draft** PR to test a scenario and discuss. 

Regarding second commit, if we don't error but just don't fallback we would get this behavior with an obscure error due to in chunk content not being parsed as option

````markdown
---
title: "Example"
format: html
engine: knitr
---

```{r}
# install.packages(c("DBI", "RSQLite"))
db = DBI::dbConnect(RSQLite::SQLite(), ":memory:")
```

```{sql}
#| label: test multiqueries -5
#|  connection: db

select 1
```
````

````
processing file: test2.qmd
  |..........................................          |  80% (unnamed-chunk-2)Quitting from lines 14-18 (test2.qmd)
Error:
! The 'connection' option (DBI connection) is required for sql chunks.
Backtrace:
  1. global .main()
  2. execute(...)
  3. rmarkdown::render(...)
  4. knitr::knit(knit_input, knit_output, envir = envir, quiet = quiet)
  5. knitr:::process_file(text, output)
  8. knitr:::process_group.block(group)
  9. knitr:::call_block(x)
 10. knitr:::block_exec(params)
 13. knitr (local) engine(options)
 14. knitr:::stop2("The 'connection' option (DBI connection) is required for sql chunks.")
                                                                                                            Exécution arrêtée
````