### PR TITLE
When caching sql engine, default to character(0) when no output.var

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -159,7 +159,8 @@ block_exec = function(options) {
     cache.exists = cache$exists(options$hash, options$cache.lazy)
     if (options$cache.rebuild || !cache.exists) block_cache(options, output, switch(
       options$engine,
-      'stan' = options$output.var, 'sql' = options$output.var, character(0)
+      'stan' = , 'sql' = options$output.var %n% character(0),
+      character(0)
     ))
   }
   if (options$include) output else ''


### PR DESCRIPTION
This fixes #1842

Small fix as it seems this is `NULL` which is causing with the lazy load db. 

If we want broader change, we can make sure that `cache_save` change `NULL` in `keys` to `character(0)` or do nothing if only `NULL` in `keys`

https://github.com/yihui/knitr/blob/039b6cfa45dea4ece31f2bcb65ed3b34b1330daa/R/cache.R#L17-L35

Or something different if you have idea. 

Though this PR fix is easy enough and should not create more issues.