### PR TITLE
Add `fig.asp = NULL` as default in `opts_chunks`

### DIFF
--- a/R/defaults.R
+++ b/R/defaults.R
@@ -83,7 +83,7 @@ opts_chunk = new_defaults(list(
   fig.keep = 'high', fig.show = 'asis', fig.align = 'default', fig.path = 'figure/',
   dev = NULL, dev.args = NULL, dpi = 72, fig.ext = NULL, fig.width = 7, fig.height = 7,
   fig.env = 'figure', fig.cap = NULL, fig.scap = NULL, fig.lp = 'fig:', fig.subcap = NULL,
-  fig.pos = '', out.width = NULL, out.height = NULL, out.extra = NULL, fig.retina = 1,
+  fig.pos = '', fig.asp = NULL, out.width = NULL, out.height = NULL, out.extra = NULL, fig.retina = 1,
   external = TRUE, sanitize = FALSE, interval = 1, aniopts = 'controls,loop',
 
   warning = TRUE, error = TRUE, message = TRUE,


### PR DESCRIPTION
option was added a while back in 464d4d0d0fe605dcc82bc3c5a8feb277e5f416ad


Related to https://github.com/quarto-dev/quarto-cli/pull/5670 by @mcanouil as Quarto should have probably known about this option from `opts_chunk`

@yihui any reason not to add it ? 

Thanks! 