### PR TITLE
Use named extract for code content

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -55,7 +55,7 @@ call_block = function(block) {
 
   if (opts_knit$get('progress')) print(block)
 
-  params$code = parse_chunk(params$code) # parse sub-chunk references
+  params[['code']] = parse_chunk(params[['code']]) # parse sub-chunk references
 
   ohooks = opts_hooks$get()
   for (opt in names(ohooks)) {

--- a/R/parser.R
+++ b/R/parser.R
@@ -109,7 +109,7 @@ parse_block = function(code, header, params.src, markdown_mode = out_format('mar
   code = parts$code
 
   label = params$label; .knitEnv$labels = c(.knitEnv$labels, label)
-  if (length(code) || length(params$file) || length(params$code)) {
+  if (length(code) || length(params[['file']]) || length(params[['code']])) {
     if (label %in% names(knit_code$get())) {
       if (identical(getOption('knitr.duplicate.label'), 'allow')) {
         params$label = label = unnamed_chunk(label)


### PR DESCRIPTION
This is to avoid partial matching with option like `code_folding = FALSE`

Found in **distill** while it was warning for non empty chunk content while using
````markdown
```{r, child="mychild.Rmd"}
```
````

Try this without this PR to get the warning

````markdown
---
title: "reprex"
---

```{r}
knitr::opts_chunk$set(code_folding = FALSE)
```

```{r, child="test2.Rmd"}
```

````

````
Warning message:
In call_block(block) :
  The chunk 'unnamed-chunk-2' has the 'child' option, and this code chunk must be empty. Its code will be ignored.
````

This PR makes sure that `params[['code']]` does not do partial matching with `params$code`

it creates an issue with distill because `code_fold = FALSE` is an option used in the distill format,. 