### PR TITLE
Add support for svglite at chunk evaluation time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.43.2
+Version: 1.43.3
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Abhraneel", "Sarma", role = "ctb"),
@@ -152,8 +152,8 @@ Suggests:
     tinytex,
     webshot,
     rstudioapi,
-    xml2 (>= 1.2.0),
-    svglite
+    svglite,
+    xml2 (>= 1.2.0)
 License: GPL
 URL: https://yihui.org/knitr/
 BugReports: https://github.com/yihui/knitr/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -152,7 +152,8 @@ Suggests:
     tinytex,
     webshot,
     rstudioapi,
-    xml2 (>= 1.2.0)
+    xml2 (>= 1.2.0),
+    svglite
 License: GPL
 URL: https://yihui.org/knitr/
 BugReports: https://github.com/yihui/knitr/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Fixed a bug in `spin(format = 'Rnw')` reported by @Tarious14 at https://github.com/yihui/yihui.org/discussions/769#discussioncomment-6587927
 
+- When the chunk option `dev = 'svglite'`, the `svglite` device should be used to record plots (thanks, @Darxor, #2272).
+
 # CHANGES IN knitr VERSION 1.43
 
 ## NEW FEATURES

--- a/R/block.R
+++ b/R/block.R
@@ -403,6 +403,10 @@ chunk_device = function(options, record = TRUE, tmp = tempfile()) {
     do.call(grDevices::svg, c(list(
       filename = tmp, width = width, height = height
     ), get_dargs(dev.args, 'svg')))
+  } else if (identical(dev, 'svglite')) {
+    do.call(svglite::svglite, c(list(
+      filename = tmp, width = width, height = height
+    ), get_dargs(dev.args, 'svglite')))
   } else if (identical(getOption('device'), pdf_null)) {
     if (!is.null(dev.args)) {
       dev.args = get_dargs(dev.args, 'pdf')


### PR DESCRIPTION
Fixes #2272

Use `svglite` device as chunk_device to support features not present in default device, like custom fonts through `{systemfonts}`.