### PR TITLE
Convert dashes in chunk option names to dots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.43.6
+Version: 1.43.7
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@
 
 - Use the correct type of progress bar when rendering Quarto documents in RStudio, which takes place in RStudio's background jobs pane or build pane (thanks, @hadley, #2271).
 
+## MAJOR CHANGES
+
+- Dashes (`-`) in the names of all chunk options are normalized to dots (`.`) now, e.g., `fig-height` will be converted to `fig.height`. This is to make **knitr** more compatible with Quarto since Quarto always use dashes in chunk option names (#2282).
+
 ## MINOR CHANGES
 
 - In-body chunk options (`#|`) are now preserved when extracting code from a document via `purl()` (thanks, @LuisLauM, #2268).

--- a/R/parser.R
+++ b/R/parser.R
@@ -314,8 +314,6 @@ partition_chunk = function(engine, code) {
   # normalize field name 'id' to 'label' if provided
   meta$label = unlist(meta[c('label', 'id')])[[1]]
   meta$id = NULL
-  # convert any option with fig- into fig. and out- to out.
-  names(meta) = sub('^(fig|out)-', '\\1.', names(meta))
 
   # extract code
   if (length(code) > 0 && is_blank(code[[1]])) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -252,6 +252,13 @@ fix_options = function(options) {
   options[gsub('-', '.', dashes)] = options[dashes]
   options[dashes] = NULL
 
+  # normalize aliases
+  aliases = c(fig.dev = 'dev', fig.dpi = 'dpi')
+  for (j in intersect(names(options), names(aliases))) {
+    options[[aliases[j]]] = options[[j]]
+    options[[j]] = NULL
+  }
+
   # if you want to use subfloats, fig.show must be 'hold'
   if (length(options$fig.subcap)) options$fig.show = 'hold'
   # if the animation hook has been set, fig.show must be 'animate'

--- a/R/utils.R
+++ b/R/utils.R
@@ -253,7 +253,7 @@ fix_options = function(options) {
   options[dashes] = NULL
 
   # normalize aliases
-  aliases = c(fig.dev = 'dev', fig.dpi = 'dpi')
+  aliases = c(fig.format = 'dev', fig.dpi = 'dpi')
   for (j in intersect(names(options), names(aliases))) {
     options[[aliases[j]]] = options[[j]]
     options[[j]] = NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -247,6 +247,10 @@ tikz_dict = function(path) {
 # but now also place to tweak default options
 fix_options = function(options) {
   options = as.strict_list(options)
+  # convert dashes in option names with dots
+  dashes = grep('-', names(options), value = TRUE)
+  options[gsub('-', '.', dashes)] = options[dashes]
+  options[dashes] = NULL
 
   # if you want to use subfloats, fig.show must be 'hold'
   if (length(options$fig.subcap)) options$fig.show = 'hold'

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -240,9 +240,11 @@ assert('remove_urls() removes the link', {
 })
 
 assert('options using `-` are converted to `.` and default value replaced', {
-  opts = opts_chunk$merge(list('fig-cap' = 'caption'))
+  opts = opts_chunk$merge(list('fig-cap' = 'caption', 'out-width' = 300))
   (is.null(fix_options(opts)[['fig-cap']]))
+  (is.null(fix_options(opts)[['out-width']]))
   (fix_options(opts)[['fig.cap']] == 'caption')
+  (fix_options(opts)[['out.width']] == 300)
   rm(opts)
 })
 

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -238,3 +238,19 @@ assert('remove_urls() removes the link', {
   (remove_urls('a [b](c) d [e f+g](h) i.') %==% 'a b d e f+g i.')
   (remove_urls('a [b](c) `[d](e)` f.') %==% 'a b `[d](e)` f.')
 })
+
+assert('options using `-` are converted to `.` and default value replaced', {
+  opts = opts_chunk$merge(list('fig-cap' = 'caption'))
+  (is.null(fix_options(opts)[['fig-cap']]))
+  (fix_options(opts)[['fig.cap']] == 'caption')
+  rm(opts)
+})
+
+assert('fig.format and fig.dpi', {
+  opts = opts_chunk$merge(list('fig-format' = 'svg', 'fig-dpi' = 750))
+  (is.null(fix_options(opts)[['fig-format']]))
+  (is.null(fix_options(opts)[['fig-dpi']]))
+  (fix_options(opts)[['dev']] == 'svg')
+  (fix_options(opts)[['dpi']] == 750)
+  rm(opts)
+})


### PR DESCRIPTION
Fix quarto-dev/quarto-cli#5852.

@cderv Instead of enumerating specific options, I'm just substituting all dashes to dots. The advantage is that we don't need to maintain a list of hard-coded option names (e.g., if we add new chunk options to **knitr** in future, we won't need to update this list). The downside is that users might really want to use dashes in option names, but I think this should be rare.

Also fix quarto-dev/quarto-cli#6576.