### PR TITLE
Call `add_html_caption()` with two arguments instead of three in Quarto

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 ## BUG FIXES
 
+- Make the internal function `add_html_caption()` work with Quarto <= v1.3.353 (thanks, @giabaio, #2261).
+
 - Fixed a bug in `spin(format = 'Rnw')` reported by @Tarious14 at https://github.com/yihui/yihui.org/discussions/769#discussioncomment-6587927
 
 - When the chunk option `dev = 'svglite'`, the `svglite` device should be used to record plots (thanks, @Darxor, #2272).

--- a/R/output.R
+++ b/R/output.R
@@ -502,6 +502,8 @@ sew.knit_asis = function(x, options, inline = FALSE, ...) {
     if (inherits(x, 'knit_asis_htmlwidget')) {
       options$fig.cur = plot_counter()
       options = reduce_plot_opts(options)
+      # TODO: remove this when quarto > 1.3.353 is widely used
+      if (is_quarto()) return(add_html_caption(options, wrap_asis(x, options)))
       # look for attribute 'aria-labelledby="label"' in the first HTML tag and
       # use the label to provide alt text if found
       return(add_html_caption(


### PR DESCRIPTION
Fix #2261.

@cderv Do you think this would be a reasonable fix?