### PR TITLE
Disallow unbalanced chunk delimiters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 - The `family` argument was not passed to the `pdf` device (thanks, @sebkopf, rstudio/rmarkdown#2526).
 
+## MAJOR CHANGES
+
+- Unbalanced chunk delimiters (fences) in R Markdown documents are no longer allowed, as announced two years ago at <https://yihui.org/en/2021/10/unbalanced-delimiters/> (#2306). This means the opening delimiter must strictly match the closing delimiter, e.g., if a code chunk starts with four backticks, it must also end with four; or if a chunk header is indented by two spaces, the closing fence must be indented by exactly two spaces. For authors who cannot update their R Markdown documents for any reason at the moment, setting `options(knitr.unbalanced.chunk = TRUE)` (e.g., in `.Rprofile`) can temporarily prevent **knitr** from throwing an error, but it is strongly recommended that you fix the problems as soon as possible, because this workaround will be removed in future.
+
 # CHANGES IN knitr VERSION 1.45
 
 ## NEW FEATURES

--- a/R/parser.R
+++ b/R/parser.R
@@ -614,16 +614,18 @@ match_chunk_end = function(pattern, line, i, b, lines) {
     if (!any(match_chunk_begin(pattern, lines[i + 1:(k - 1)], '^\\1`*\\\\{')))
       return(FALSE)
   }
-  signal = if (check_old(
+  # TODO: clean up the exceptions here (although perhaps some may never update again)
+  signal = if (getOption('knitr.unbalanced.chunk', check_old(
     c('abbyyR', 'data.table', 'ensembleR', 'FSinR', 'funmediation', 'leiden', 'liger', 'loo', 'microsamplingDesign', 'mmpf', 'rSEA', 'StructFDR', 'TRMF'),
     c('0.5.5', '1.14.8', '0.1.0', '2.0.5', '1.0.1', '0.4.3', '2.0.1', '2.6.0', '1.0.8', '0.0.5', '2.1.1', '1.3', '0.1.5')
-  )) warning2 else stop2
+  ))) warning2 else stop2
   signal(
-    'The closing backticks on line ', i, ' ("', line, '") in ', current_input(),
-    ' do not match the opening backticks "',
+    'The closing fence on line ', i, ' ("', line, '") in ', current_input(),
+    ' does not match the opening fence "',
     gsub('\\^(\\s*`+).*', '\\1', pattern), '" on line ', b, '. You are recommended to ',
-    'fix either the opening or closing delimiter of the code chunk to use exactly ',
-    'the same numbers of backticks and same level of indentation (or blockquote).'
+    'fix either the opening or closing fence of the code chunk to use exactly ',
+    'the same numbers of backticks and same level of indentation (or blockquote). ',
+    'See https://yihui.org/en/2021/10/unbalanced-delimiters/ for more info.'
   )
   TRUE
 }

--- a/R/parser.R
+++ b/R/parser.R
@@ -616,8 +616,8 @@ match_chunk_end = function(pattern, line, i, b, lines) {
   }
   # TODO: clean up the exceptions here (although perhaps some may never update again)
   signal = if (getOption('knitr.unbalanced.chunk', check_old(
-    c('data.table', 'ensembleR', 'FSinR', 'funmediation', 'liger', 'loo', 'microsamplingDesign', 'mmpf', 'rSEA', 'StructFDR', 'TRMF'),
-    c('1.14.8', '0.1.0', '2.0.5', '1.0.1', '2.0.1', '2.6.0', '1.0.8', '0.0.5', '2.1.1', '1.3', '0.1.5')
+    c('ensembleR', 'FSinR', 'funmediation', 'liger', 'loo', 'microsamplingDesign', 'mmpf', 'rSEA', 'StructFDR', 'TRMF'),
+    c('0.1.0', '2.0.5', '1.0.1', '2.0.1', '2.6.0', '1.0.8', '0.0.5', '2.1.1', '1.3', '0.1.5')
   ))) warning2 else stop2
   signal(
     'The closing fence on line ', i, ' ("', line, '") in ', current_input(),

--- a/R/parser.R
+++ b/R/parser.R
@@ -616,8 +616,8 @@ match_chunk_end = function(pattern, line, i, b, lines) {
   }
   # TODO: clean up the exceptions here (although perhaps some may never update again)
   signal = if (getOption('knitr.unbalanced.chunk', check_old(
-    c('abbyyR', 'data.table', 'ensembleR', 'FSinR', 'funmediation', 'leiden', 'liger', 'loo', 'microsamplingDesign', 'mmpf', 'rSEA', 'StructFDR', 'TRMF'),
-    c('0.5.5', '1.14.8', '0.1.0', '2.0.5', '1.0.1', '0.4.3', '2.0.1', '2.6.0', '1.0.8', '0.0.5', '2.1.1', '1.3', '0.1.5')
+    c('data.table', 'ensembleR', 'FSinR', 'funmediation', 'leiden', 'liger', 'loo', 'microsamplingDesign', 'mmpf', 'rSEA', 'StructFDR', 'TRMF'),
+    c('1.14.8', '0.1.0', '2.0.5', '1.0.1', '0.4.3', '2.0.1', '2.6.0', '1.0.8', '0.0.5', '2.1.1', '1.3', '0.1.5')
   ))) warning2 else stop2
   signal(
     'The closing fence on line ', i, ' ("', line, '") in ', current_input(),

--- a/R/parser.R
+++ b/R/parser.R
@@ -614,13 +614,25 @@ match_chunk_end = function(pattern, line, i, b, lines) {
     if (!any(match_chunk_begin(pattern, lines[i + 1:(k - 1)], '^\\1`*\\\\{')))
       return(FALSE)
   }
-  stop2(
+  signal = if (check_old(
+    c('abbyyR', 'data.table', 'ensembleR', 'FSinR', 'funmediation', 'leiden', 'liger', 'loo', 'microsamplingDesign', 'mmpf', 'rSEA', 'StructFDR', 'TRMF'),
+    c('0.5.5', '1.14.8', '0.1.0', '2.0.5', '1.0.1', '0.4.3', '2.0.1', '2.6.0', '1.0.8', '0.0.5', '2.1.1', '1.3', '0.1.5')
+  )) warning2 else stop2
+  signal(
     'The closing backticks on line ', i, ' ("', line, '") in ', current_input(),
     ' do not match the opening backticks "',
     gsub('\\^(\\s*`+).*', '\\1', pattern), '" on line ', b, '. You are recommended to ',
     'fix either the opening or closing delimiter of the code chunk to use exactly ',
     'the same numbers of backticks and same level of indentation (or blockquote).'
   )
+  TRUE
+}
+
+# TODO: just use check_old_package() in xfun >= 0.42
+check_old = function(name, version) {
+  for (i in seq_along(name))
+    if (xfun::check_old_package(name[i], version[i])) return(TRUE)
+  FALSE
 }
 
 #' Get all chunk labels in a document

--- a/R/parser.R
+++ b/R/parser.R
@@ -616,8 +616,8 @@ match_chunk_end = function(pattern, line, i, b, lines) {
   }
   # TODO: clean up the exceptions here (although perhaps some may never update again)
   signal = if (getOption('knitr.unbalanced.chunk', check_old(
-    c('data.table', 'ensembleR', 'FSinR', 'funmediation', 'leiden', 'liger', 'loo', 'microsamplingDesign', 'mmpf', 'rSEA', 'StructFDR', 'TRMF'),
-    c('1.14.8', '0.1.0', '2.0.5', '1.0.1', '0.4.3', '2.0.1', '2.6.0', '1.0.8', '0.0.5', '2.1.1', '1.3', '0.1.5')
+    c('data.table', 'ensembleR', 'FSinR', 'funmediation', 'liger', 'loo', 'microsamplingDesign', 'mmpf', 'rSEA', 'StructFDR', 'TRMF'),
+    c('1.14.8', '0.1.0', '2.0.5', '1.0.1', '2.0.1', '2.6.0', '1.0.8', '0.0.5', '2.1.1', '1.3', '0.1.5')
   ))) warning2 else stop2
   signal(
     'The closing fence on line ', i, ' ("', line, '") in ', current_input(),


### PR DESCRIPTION
Notice has been given for two years: https://yihui.org/en/2021/10/unbalanced-delimiters/

From [the revdeps check](https://github.com/yihui/crandalf/actions/runs/6727705606/job/18285908675), these packages will be affected (I have notified all maintainers):

- [ ] https://github.com/Rdatatable/data.table/issues/5735
- [x] To be archived: https://cran.r-project.org/web/packages/abbyyR/index.html
- [ ] https://github.com/stan-dev/loo/pull/232
- [x] https://github.com/TomKellyGenetics/leiden/pull/16
- [ ] https://cran.r-project.org/package=ensembleR
- [ ] https://cran.r-project.org/package=FSinR
- [ ] https://cran.r-project.org/package=funmediation
- [ ] https://cran.r-project.org/package=liger
- [ ] https://cran.r-project.org/package=TRMF
- [ ] https://cran.r-project.org/package=microsamplingDesign 
- [ ] https://cran.r-project.org/package=mmpf 
- [ ] https://cran.r-project.org/package=rSEA 
- [ ] https://cran.r-project.org/package=StructFDR 