### PR TITLE
Add support for `# %%` for chunk demarcation in `knitr::spin`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## NEW FEATURES
 
 - Added a new chunk option `tab.cap` to specify the table caption for `kable()` (thanks, @ulyngs, #1679). Previously, the caption could only be specified via the `caption` argument of `kable()`. Now you can set it in the chunk header if you want. Please note that this chunk option only works with a single `kable()` in each code chunk, and its value must be of length 1.
+- `knitr::spin()` now recognizes `# %%` as a valid code chunk delimiter.
 
 ## BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## NEW FEATURES
 
 - Added a new chunk option `tab.cap` to specify the table caption for `kable()` (thanks, @ulyngs, #1679). Previously, the caption could only be specified via the `caption` argument of `kable()`. Now you can set it in the chunk header if you want. Please note that this chunk option only works with a single `kable()` in each code chunk, and its value must be of length 1.
-- `knitr::spin()` now recognizes `# %%` as a valid code chunk delimiter.
+
+- `knitr::spin()` now recognizes `# %%` as a valid code chunk delimiter (thanks, @kylebutts, #2307).
 
 ## BUG FIXES
 

--- a/R/spin.R
+++ b/R/spin.R
@@ -3,7 +3,7 @@
 #' This function takes a specially formatted R script and converts it to a
 #' literate programming document. By default normal text (documentation) should
 #' be written after the roxygen comment (\code{#'}) and code chunk options are
-#' written after \code{#+} or \code{# %%} or \code{#-} or \code{# ----} or 
+#' written after \code{#+} or \code{# \%\%} or \code{#-} or \code{# ----} or
 #' any of these combinations replacing \code{#} with \code{--}.
 #'
 #' Obviously the goat's hair is the original R script, and the wool is the

--- a/R/spin.R
+++ b/R/spin.R
@@ -3,8 +3,8 @@
 #' This function takes a specially formatted R script and converts it to a
 #' literate programming document. By default normal text (documentation) should
 #' be written after the roxygen comment (\code{#'}) and code chunk options are
-#' written after \code{#+} or \code{#-} or \code{# ----} or any of these
-#' combinations replacing \code{#} with \code{--}.
+#' written after \code{#+} or \code{# %%} or \code{#-} or \code{# ----} or 
+#' any of these combinations replacing \code{#} with \code{--}.
 #'
 #' Obviously the goat's hair is the original R script, and the wool is the
 #' literate programming document (ready to be knitted).
@@ -90,7 +90,8 @@ spin = function(
       # R code; #+/- indicates chunk options
       block = strip_white(block) # rm white lines in beginning and end
       if (!length(block)) next
-      if (length(opt <- grep(rc <- '^(#|--)+(\\+|-| ----+| @knitr)', block))) {
+      rc <- '^(#|--)+(\\+|-|\\s+%%| ----+| @knitr)'
+      if (length(opt <- grep(rc, block))) {
         opts = gsub(paste0(rc, '\\s*|-*\\s*$'), '', block[opt])
         opts = paste0(ifelse(opts == '', '', ' '), opts)
         block[opt] = paste0(p[1L], opts, p[2L])

--- a/man/spin.Rd
+++ b/man/spin.Rd
@@ -59,8 +59,8 @@ If \code{text} is \code{NULL}, the path of the final output document,
 This function takes a specially formatted R script and converts it to a
 literate programming document. By default normal text (documentation) should
 be written after the roxygen comment (\code{#'}) and code chunk options are
-written after \code{#+} or \code{#-} or \code{# ----} or any of these
-combinations replacing \code{#} with \code{--}.
+written after \code{#+} or \code{# \%\%} or \code{#-} or \code{# ----} or
+any of these combinations replacing \code{#} with \code{--}.
 }
 \details{
 Obviously the goat's hair is the original R script, and the wool is the


### PR DESCRIPTION
Hi,

The R VSCode extension has nice support for inline code chunks for R scripts using the `# %%` comment to separate code chunks. This small change would integrate with this and allow a seamless `.R` notebook script to report pipeline
<img style="width: 50%" src="https://github.com/yihui/knitr/assets/19961439/18b0a170-128f-4323-adbf-b16d9526634f" />

This will also help with https://github.com/quarto-dev/quarto-cli/issues/6660 allowing to render `.R` scripts with quarto
https://quarto.org/docs/prerelease/1.4/script.html

Running `knitr::spin("test.R", format = ".qmd)` on this
`````{r}
#'---
#'title: "test"
#'---

# %% setup
#| message = FALSE,
#| warning = FALSE
library(tidyverse)

v = seq(-pi, pi, 0.01)
data = data.frame(
  x = v, y = sin(v)
)

# %% 
ggplot() + 
  geom_point(
    aes(x = x, y = y),
    data = data
  )

`````
produces a valid qmd document: 
`````md
---
title: "test"
---

```{r setup}
#| message = FALSE,
#| warning = FALSE
library(tidyverse)

v = seq(-pi, pi, 0.01)
data = data.frame(
  x = v, y = sin(v)
)

```
```{r}
ggplot() + 
  geom_point(
    aes(x = x, y = y),
    data = data
  )
```
`````