### PR TITLE
Fix the error when kable()'s caption value is of length > 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 - Trailing spaces escaped by `\` should not be trimmed in `kable()` (thanks, @mjsmith037, #2308).
 
+- `kable()` fails when the value of the `caption` argument is of length > 1 (thanks, @LeeMendelowitz, #2312).
+
 ## MAJOR CHANGES
 
 - Unbalanced chunk delimiters (fences) in R Markdown documents are no longer allowed, as announced two years ago at <https://yihui.org/en/2021/10/unbalanced-delimiters/> (#2306). This means the opening delimiter must strictly match the closing delimiter, e.g., if a code chunk starts with four backticks, it must also end with four; or if a chunk header is indented by two spaces, the closing fence must be indented by exactly two spaces. For authors who cannot update their R Markdown documents for any reason at the moment, setting `options(knitr.unbalanced.chunk = TRUE)` (e.g., in `.Rprofile`) can temporarily prevent **knitr** from throwing an error, but it is strongly recommended that you fix the problems as soon as possible, because this workaround will be removed in future.

--- a/R/table.R
+++ b/R/table.R
@@ -175,7 +175,7 @@ kable_caption = function(label, caption, format) {
   is_na = function(v) {
     length(v) == 0 || (length(v) == 1 && is.na(v))
   }
-  if (!is.null(caption) && !is_na(caption) && !is_na(label)) caption = paste0(
+  if (!is_na(caption) && !is_na(label)) caption = paste0(
     create_label(
       opts_knit$get('label.prefix')[['table']],
       label, latex = (format == 'latex')

--- a/R/table.R
+++ b/R/table.R
@@ -172,10 +172,7 @@ kable_caption = function(label, caption, format) {
   # create a label for bookdown if applicable
   if (is.null(label)) label = opts_current$get('label')
   if (is.null(label)) label = NA
-  is_na = function(v) {
-    length(v) == 0 || (length(v) == 1 && is.na(v))
-  }
-  if (!is_na(caption) && !is_na(label)) caption = paste0(
+  if (!is.null(caption) && !anyNA(caption) && !anyNA(label)) caption = paste0(
     create_label(
       opts_knit$get('label.prefix')[['table']],
       label, latex = (format == 'latex')

--- a/R/table.R
+++ b/R/table.R
@@ -172,7 +172,10 @@ kable_caption = function(label, caption, format) {
   # create a label for bookdown if applicable
   if (is.null(label)) label = opts_current$get('label')
   if (is.null(label)) label = NA
-  if (!is.null(caption) && !is.na(caption) && !is.na(label)) caption = paste0(
+  is_na = function(v) {
+    length(v) == 0 || (length(v) == 1 && is.na(v))
+  }
+  if (!is.null(caption) && !is_na(caption) && !is_na(label)) caption = paste0(
     create_label(
       opts_knit$get('label.prefix')[['table']],
       label, latex = (format == 'latex')


### PR DESCRIPTION
Fix for #2311.