### PR TITLE
Improve support for knitr::spin(format = 'qmd')

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.45.14
+Version: 1.45.15
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - `knitr::spin()` now recognizes `# %%` as a valid code chunk delimiter (thanks, @kylebutts, #2307).
 
+- `knitr::spin()` also recognizes `#|` comments as code chunks now (thanks, @kylebutts, #2320).
+
 - Chunk hooks can have the `...` argument now. Previously, only arguments `before`, `options`, `envir`, and `name` are accepted. If a chunk hook function has the `...` argument, all the aforementioned four arguments are passed to the hook. This means the hook function no longer has to have the four arguments explicitly in its signature, e.g., `function(before, ...)` is also valid if only the `before` argument is used inside the hook. See <https://yihui.org/knitr/hooks/#chunk-hooks> for more information.
 
 - For package vignettes, PNG plots will be optimized by `optipng` and `pngquant` if they are installed and can be found from the system `PATH` variable. This can help reduce the package size if vignettes contain PNG plots (thanks, @nanxstats, <https://nanx.me/blog/post/rpkgs-pngquant-ragg/>).

--- a/R/spin.R
+++ b/R/spin.R
@@ -3,8 +3,7 @@
 #' This function takes a specially formatted R script and converts it to a
 #' literate programming document. By default normal text (documentation) should
 #' be written after the roxygen comment (\code{#'}) and code chunk options are
-#' written after \code{#+} or \code{# \%\%} or \code{#-} or \code{# ----} or
-#' any of these combinations replacing \code{#} with \code{--}.
+#' written after \code{#|} or \code{#+} or \code{# \%\%} or \code{# ----}.
 #'
 #' Obviously the goat's hair is the original R script, and the wool is the
 #' literate programming document (ready to be knitted).
@@ -90,7 +89,7 @@ spin = function(
       block = strip_white(block) # rm white lines in beginning and end
       if (!length(block)) next
 
-      rc <- '^(#|--)+(\\+|-|\\s+%%| ----+| @knitr)'
+      rc = '^(#|--)+(\\+|-|\\s+%%| ----+| @knitr)'
       opt = grep(rc, block)
       # pipe comments (#|) should start a code chunk if they are not preceded by
       # chunk opening tokens

--- a/R/spin.R
+++ b/R/spin.R
@@ -89,27 +89,20 @@ spin = function(
       block = strip_white(block) # rm white lines in beginning and end
       if (!length(block)) next
 
-      rc = '^(#|--)+(\\+|-|\\s+%%| ----+| @knitr)'
-      opt = grep(rc, block)
+      rc = '^(#|--)+(\\+|-| %%| ----+| @knitr)(.*?)\\s*-*\\s*$'
+      j1 = grep(rc, block)
       # pipe comments (#|) should start a code chunk if they are not preceded by
       # chunk opening tokens
-      j = setdiff(pipe_comment_start(block), opt + 1)
-      # add the token '# %%' before the starting pipe comment
-      block[j] = paste0('# %%\n', block[j])
-      opt = c(opt, j)
+      j2 = setdiff(pipe_comment_start(block), j1 + 1)
 
-      if (length(opt)) {
-        opts = gsub(paste0(rc, '(-*\\s*$|\n.*)'), '', block[opt])
-        opts = paste0(ifelse(opts == '', '', ' '), opts)
-        # add chunk headers with options (special case: '# %%\n#| ...')
-        block[opt] = paste0(
-          p[1L], opts, p[2L],
-          ifelse(grepl('\n', block[opt]), gsub('.*?(\n.+)', '\\1', block[opt]), '')
-        )
+      if (length(j3 <- c(j1, j2))) {
+        block[j1] = paste0(p[1], gsub(rc, '\\3', block[j1]), p[2])
+        block[j2] = paste0(p[1], p[2], '\n', block[j2])
+
         # close each chunk if there are multiple chunks in this block
-        if (any(opt > 1)) {
-          j = opt[opt > 1]
-          block[j] = paste(p[3L], block[j], sep = '\n')
+        if (any(j3 > 1)) {
+          j = j3[j3 > 1]
+          block[j] = paste0(p[3], '\n', block[j])
         }
       }
       if (!startsWith(block[1L], p[1L])) {

--- a/R/spin.R
+++ b/R/spin.R
@@ -94,12 +94,10 @@ spin = function(
       opt = grep(rc, block)
       # pipe comments (#|) should start a code chunk if they are not preceded by
       # chunk opening tokens
-      if (format == 'qmd') {
-        j = setdiff(pipe_comment_start(block), opt + 1)
-        # add the token '# %%' before the starting pipe comment
-        block[j] = paste0('# %%\n', block[j])
-        opt = c(opt, j)
-      }
+      j = setdiff(pipe_comment_start(block), opt + 1)
+      # add the token '# %%' before the starting pipe comment
+      block[j] = paste0('# %%\n', block[j])
+      opt = c(opt, j)
 
       if (length(opt)) {
         opts = gsub(paste0(rc, '(-*\\s*$|\n.*)'), '', block[opt])

--- a/man/spin.Rd
+++ b/man/spin.Rd
@@ -59,8 +59,7 @@ If \code{text} is \code{NULL}, the path of the final output document,
 This function takes a specially formatted R script and converts it to a
 literate programming document. By default normal text (documentation) should
 be written after the roxygen comment (\code{#'}) and code chunk options are
-written after \code{#+} or \code{# \%\%} or \code{#-} or \code{# ----} or
-any of these combinations replacing \code{#} with \code{--}.
+written after \code{#|} or \code{#+} or \code{# \%\%} or \code{# ----}.
 }
 \details{
 Obviously the goat's hair is the original R script, and the wool is the

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -30,3 +30,15 @@ assert("spin() uses proper number of backticks", {
   (spin_w_tempfile("x <- '", "```", "'") %==%
     c("", "````{r}", "x <- '", "```", "'", "````", ""))
 })
+
+assert("spin() works properly with quarto `#|`", {
+  (spin_w_tempfile("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text", format = "qmd") %==% 
+    c('', '```{r}', '#| echo: false', '#| message: false', '#| include: false', '1+1', '```', '```{r}', '#| eval: false', '2 + 2', '```', '', 'Text')) 
+
+  # https://github.com/yihui/knitr/issues/2314
+  (spin_w_tempfile('#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==% 
+    c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')) 
+  
+  (spin_w_tempfile('# %%', '#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==% 
+    c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')) 
+})

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -27,21 +27,21 @@ assert("spin() uses proper number of backticks", {
     c("", "````{r}", "x <- '", "```", "'", "````", ""))
 })
 
-assert("spin() works properly with quarto `#|`", {
+assert("spin() generates code chunks with pipe comments `#|`", {
   (
-    spin_text("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text", format = "qmd") %==%
+    spin_text("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text") %==%
     c('', '```{r}', '#| echo: false', '#| message: false', '#| include: false', '1+1', '```', '```{r}', '#| eval: false', '2 + 2', '```', '', 'Text')
   )
 
   # https://github.com/yihui/knitr/issues/2314
   (
-    spin_text('#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==%
+    spin_text('#| echo: false', '1+1', '#| label: test', '1+1') %==%
     c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')
   )
 
   # Has a `# %%` already
   (
-    spin_text('# %%', '#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==%
+    spin_text('# %%', '#| echo: false', '1+1', '#| label: test', '1+1') %==%
     c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')
   )
 })

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -1,47 +1,47 @@
 library(testit)
 
-spin_w_tempfile = function(..., format = "Rmd") {
+spin_text = function(..., format = "Rmd") {
   x = spin(text = c(...), knit = FALSE, format = format)
   xfun::split_lines(x)
 }
 
 assert("spin() detects lines for documentation", {
-  (spin_w_tempfile("#' test", "1 * 1", "#' test") %==%
+  (spin_text("#' test", "1 * 1", "#' test") %==%
      c("test", "", "```{r}", "1 * 1", "```", "", "test"))
   # a multiline string literal contains the pattern of doc or inline
-  (spin_w_tempfile("code <- \"", "#' test\"") %==%
+  (spin_text("code <- \"", "#' test\"") %==%
     c("", "```{r}", "code <- \"", "#' test\"", "```", ""))
-  (spin_w_tempfile("code <- \"", "{{ 1 + 1 }}", "\"") %==%
+  (spin_text("code <- \"", "{{ 1 + 1 }}", "\"") %==%
     c("", "```{r}", "code <- \"", "{{ 1 + 1 }}", "\"", "```", ""))
   # a multiline symbol contains the pattern of doc or inline
-  (spin_w_tempfile("`", "#' test", "`") %==%
+  (spin_text("`", "#' test", "`") %==%
     c("", "```{r}", "`", "#' test", "`", "```", ""))
-  (spin_w_tempfile("`", "{{ 1 + 1 }}", "`") %==%
+  (spin_text("`", "{{ 1 + 1 }}", "`") %==%
     c("", "```{r}", "`", "{{ 1 + 1 }}", "`", "```", ""))
 })
 
 assert("spin() uses proper number of backticks", {
-  (spin_w_tempfile("{{ '`' }}") %==% c("``r  '`'  ``"))
-  (spin_w_tempfile("{{`x`}}") %==% c("``r `x` ``"))
-  (spin_w_tempfile("x <- '", "```", "'") %==%
+  (spin_text("{{ '`' }}") %==% c("``r  '`'  ``"))
+  (spin_text("{{`x`}}") %==% c("``r `x` ``"))
+  (spin_text("x <- '", "```", "'") %==%
     c("", "````{r}", "x <- '", "```", "'", "````", ""))
 })
 
 assert("spin() works properly with quarto `#|`", {
   (
-    spin_w_tempfile("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text", format = "qmd") %==%
+    spin_text("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text", format = "qmd") %==%
     c('', '```{r}', '#| echo: false', '#| message: false', '#| include: false', '1+1', '```', '```{r}', '#| eval: false', '2 + 2', '```', '', 'Text')
   )
 
   # https://github.com/yihui/knitr/issues/2314
   (
-    spin_w_tempfile('#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==%
+    spin_text('#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==%
     c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')
   )
 
   # Has a `# %%` already
   (
-    spin_w_tempfile('# %%', '#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==%
+    spin_text('# %%', '#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==%
     c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')
   )
 })

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -1,12 +1,8 @@
 library(testit)
 
 spin_w_tempfile = function(..., format = "Rmd") {
-  tmp = tempfile(fileext = ".R")
-  writeLines(c(...), tmp)
-  spinned = spin(tmp, knit = FALSE, format = format)
-  result = readLines(spinned)
-  file.remove(c(tmp, spinned))
-  result
+  x = spin(text = c(...), knit = FALSE, format = format)
+  xfun::split_lines(x)
 }
 
 assert("spin() detects lines for documentation", {
@@ -33,19 +29,19 @@ assert("spin() uses proper number of backticks", {
 
 assert("spin() works properly with quarto `#|`", {
   (
-    spin_w_tempfile("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text", format = "qmd") %==% 
+    spin_w_tempfile("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text", format = "qmd") %==%
     c('', '```{r}', '#| echo: false', '#| message: false', '#| include: false', '1+1', '```', '```{r}', '#| eval: false', '2 + 2', '```', '', 'Text')
-  ) 
+  )
 
   # https://github.com/yihui/knitr/issues/2314
   (
-    spin_w_tempfile('#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==% 
+    spin_w_tempfile('#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==%
     c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')
-  ) 
-  
+  )
+
   # Has a `# %%` already
   (
-    spin_w_tempfile('# %%', '#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==% 
+    spin_w_tempfile('# %%', '#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==%
     c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')
-  ) 
+  )
 })

--- a/tests/testit/test-spin.R
+++ b/tests/testit/test-spin.R
@@ -32,13 +32,20 @@ assert("spin() uses proper number of backticks", {
 })
 
 assert("spin() works properly with quarto `#|`", {
-  (spin_w_tempfile("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text", format = "qmd") %==% 
-    c('', '```{r}', '#| echo: false', '#| message: false', '#| include: false', '1+1', '```', '```{r}', '#| eval: false', '2 + 2', '```', '', 'Text')) 
+  (
+    spin_w_tempfile("", "#| echo: false", "#| message: false", "#| include: false", "1+1", "#| eval: false", "2 + 2", "", "#' Text", format = "qmd") %==% 
+    c('', '```{r}', '#| echo: false', '#| message: false', '#| include: false', '1+1', '```', '```{r}', '#| eval: false', '2 + 2', '```', '', 'Text')
+  ) 
 
   # https://github.com/yihui/knitr/issues/2314
-  (spin_w_tempfile('#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==% 
-    c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')) 
+  (
+    spin_w_tempfile('#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==% 
+    c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')
+  ) 
   
-  (spin_w_tempfile('# %%', '#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==% 
-    c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')) 
+  # Has a `# %%` already
+  (
+    spin_w_tempfile('# %%', '#| echo: false', '1+1', '#| label: test', '1+1', format = "qmd") %==% 
+    c('', '```{r}', '#| echo: false', '1+1', '```', '```{r}', '#| label: test', '1+1', '```', '')
+  ) 
 })


### PR DESCRIPTION
The approach taken here had the goal of not touching the original spin code, so that this only impacts `format = 'qmd'` and did so as simply as possible.

To do this, I find the any code chunk that *starts* with `#|` and prepend a `# %%` for the previous line. This prevents converting each option passed with `#|` from creating a new chunk.

Perhaps this could be integrated more deeply with how knitr::spin works, but this is the simplest solution.

@cderv
