### PR TITLE
add ALTER as sql statment, that is not returning anything

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 ## MINOR CHANGES
 
 - Fixed broken vignettes, improved CSS for HTML vignettes, and reduced the file sizes.
+- SQL code chunks that run `ALTER` statements are only executed and not tried to fecth a result (thanks, @maxschmi, #2330).
 
 # CHANGES IN knitr VERSION 1.45
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 ## MINOR CHANGES
 
 - Fixed broken vignettes, improved CSS for HTML vignettes, and reduced the file sizes.
+
 - SQL code chunks that run `ALTER` statements are only executed and not tried to fecth a result (thanks, @maxschmi, #2330).
 
 # CHANGES IN knitr VERSION 1.45

--- a/R/engine.R
+++ b/R/engine.R
@@ -558,7 +558,7 @@ is_sql_update_query = function(query) {
   query = gsub('^\\s*--.*\n', '', query)
   # remove multi-line comments
   if (grepl('^\\s*\\/\\*.*', query)) query = gsub('.*\\*\\/', '', query)
-  grepl('^\\s*(INSERT|UPDATE|DELETE|CREATE|DROP).*', query, ignore.case = TRUE)
+  grepl('^\\s*(INSERT|UPDATE|DELETE|CREATE|DROP|ALTER).*', query, ignore.case = TRUE)
 }
 
 # sql engine


### PR DESCRIPTION
I added the SQL `ALTER` statement to commands that should only run with dbExecute and not dbFetch as there won't be any returns from an `ALTER` statement