### PR TITLE
feat(write_bib): escape & as much as possible (closes #2335)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## NEW FEATURES
 
 - For `kable()`, you can set the global option `knitr.kable.max_rows` to limit the number of rows to show in the table, e.g., `options(knitr.kable.max_rows = 30)`. This is a way to prevent `kable()` from generating a huge table from a large data object by accident.
+- `write_bib()` now escapes all non-escaped "&" in the bibliography by default. Formerly, it only escaped the title field of the package citation. Disable the escape by specifying `tweak = FALSE` (thanks, @atusy #2335)
 
 # CHANGES IN knitr VERSION 1.46
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## NEW FEATURES
 
 - For `kable()`, you can set the global option `knitr.kable.max_rows` to limit the number of rows to show in the table, e.g., `options(knitr.kable.max_rows = 30)`. This is a way to prevent `kable()` from generating a huge table from a large data object by accident.
-- `write_bib()` now escapes all non-escaped "&" in the bibliography by default. Formerly, it only escaped the title field of the package citation. Disable the escape by specifying `tweak = FALSE` (thanks, @atusy #2335)
+
+- `write_bib()` now escapes all non-escaped "&" in the bibliography by default. Previously, it only escaped the title field of the package citation. You can disable the escape with the argument `tweak = FALSE` (thanks, @HedvigS #2335, @atusy #2342).
 
 # CHANGES IN knitr VERSION 1.46
 

--- a/R/citation.R
+++ b/R/citation.R
@@ -102,8 +102,6 @@ write_bib = function(
     if (tweak) {
       # e.g. gpairs has "gpairs: " in the title
       cite$title = gsub(sprintf('^(%s: )(\\1)', pkg), '\\1', cite$title)
-      # e.g. KernSmooth has & in the title
-      cite$title = gsub(' & ', ' \\\\& ', cite$title)
     }
     entry = toBibtex(cite)
     entry[1] = sub('\\{,$', sprintf('{%s%s,', prefix, pkg), entry[1])
@@ -150,7 +148,12 @@ write_bib = function(
   bib = lapply(bib, function(b) {
     idx = which(names(b) == '')
     if (!is.null(width)) b[-idx] = str_wrap(b[-idx], width, 2, 4)
-    structure(c(b[idx[1L]], b[-idx], b[idx[2L]], ''), class = 'Bibtex')
+    lines = c(b[idx[1L]], b[-idx], b[idx[2L]], '')
+    if (tweak) {
+      # e.g. KernSmooth and spam has & in the title and the journal, respectively
+      lines = gsub('(?<!\\\\)&', '\\\\&', lines, perl = TRUE)
+    }
+    structure(lines, class = 'Bibtex')
   })
   if (!is.null(file) && length(x)) write_utf8(unlist(bib), file)
   invisible(bib)


### PR DESCRIPTION
In `write_bib`, apply `gsub('(?<!\\\\)&', '\\\\&', x, perl = TRUE)` to escape unespcaped ampersands.

Note that released implementation partially applies the escape.
Instead, I apply the escape as later as possible so that the escape happens widely.
