### PR TITLE
Support space between fences and language in fenced code block when applying collapse option

### DIFF
--- a/.github/actions/checkout-knitr-examples/action.yml
+++ b/.github/actions/checkout-knitr-examples/action.yml
@@ -18,7 +18,7 @@ runs:
             echo '::debug::On pull request'
             branch=$(gh api repos/yihui/knitr-examples/branches | jq -cr '.[] | select(.name == '\"$headref\"') | .name')
           fi
-          echo ::set-output name=ref::$(echo $branch)
+          echo "ref=$(echo $branch)" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Retrieve knitr-examples
         uses: actions/checkout@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.47.1
+Version: 1.47.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN knitr VERSION 1.48
 
+## BUG FIXES
+
+- Fix regression from 1.46 with `collapse = TRUE` option not correctly collapsing source code and output into one when code chunk returns multiple outputs (thanks, @jennybc, @florisvdh, tidyverse/reprex#463).
 
 # CHANGES IN knitr VERSION 1.47
 

--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -199,7 +199,7 @@ hooks_markdown = function(strict = FALSE, fence_char = '`') {
       x = gsub('[\n]+$', '', x)
       x = gsub('^[\n]+', '\n', x)
       if (isTRUE(options$collapse)) {
-        r = sprintf('\n([%s]{3,})\n+\\1((\\{[.])?%s[^\n]*)?\n', fence_char, tolower(options$engine))
+        r = sprintf('\n([%s]{3,})\n+\\1((\\{[.]| )?%s[^\n]*)?\n', fence_char, tolower(options$engine))
         x = gsub(r, '\n', x)
         x = gsub(asis_token, '', x, fixed = TRUE)
       }


### PR DESCRIPTION
fixes #2346

A regression was introduced in https://github.com/yihui/knitr/commit/5435c52469af3781541ef0708bb9fcd7dced3d45 which has broken knitr-example, because of space introduced. 

Though the collapse problem has not been identified as the example doc as been modified with the breakage
https://github.com/yihui/knitr-examples/commit/931e0a2a4e273dcdc13902291b6c6b6e448658cb?diff=split&w=1#diff-2994208929b9d915ac06ca8f58fc66dd26248db5d78be71762508c666e106848

So https://github.com/yihui/knitr-examples/pull/91 fix this, and will be tested with this PR. 