### PR TITLE
Avoid using evaluate internals

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -733,8 +733,9 @@ knit_print.knit_asis_url = function(x, ...) x
 
 #' @rdname knit_print
 #' @export
-normal_print = default_handlers$value
-formals(normal_print) = alist(x = , ... = )
+normal_print = function(x, ...) {
+  if (isS4(x)) methods::show(x) else print(x)
+}
 
 #' Mark an R object with a special class
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -857,8 +857,8 @@ current_input = function(dir = FALSE) {
   if (is_abs_path(input)) input else file.path(outwd, input)
 }
 
-# import output handlers from evaluate
-default_handlers = evaluate:::default_output_handler
+# cache output handlers from evaluate; see .onLoad
+default_handlers = NULL
 # change the value handler in evaluate default handlers
 knit_handlers = function(fun, options) {
   if (!is.function(fun)) fun = function(x, ...) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,5 @@
 .onLoad = function(lib, pkg) {
   register_vignette_engines(pkg)
+  
+  default_handlers <<- evaluate::new_output_handler()
 }


### PR DESCRIPTION
In a few years, once this code is widespread in installed knitr, this will allow us to make some simplifications to evaluate