### PR TITLE
Explicitly state implicit R version dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -114,7 +114,7 @@ Authors@R: c(
 Description: Provides a general-purpose tool for dynamic report generation in R
     using Literate Programming techniques.
 Depends:
-    R (>= 3.3.0)
+    R (>= 4.0.0)
 Imports:
     evaluate (>= 0.15),
     highr (>= 0.11),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -114,7 +114,7 @@ Authors@R: c(
 Description: Provides a general-purpose tool for dynamic report generation in R
     using Literate Programming techniques.
 Depends:
-    R (>= 4.0.0)
+    R (>= 3.6.0)
 Imports:
     evaluate (>= 0.15),
     highr (>= 0.11),


### PR DESCRIPTION
{evaluate} on CRAN now depends on R>=4.0.0. That means we can't install {knitr} on an older version of R (through normal means). I think it would be useful to state this up front rather than encounter a failure due to dependency {evaluate} being "missing".