### PR TITLE
Drop `fix_recordedPlot()`

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -256,7 +256,7 @@ eng_r = function(options) {
   res = if (is_blank(code)) list() else if (isFALSE(ev)) {
     as.source(code)
   } else if (cache.exists && isFALSE(options$cache.rebuild)) {
-    fix_evaluate(cache$output(options$hash, 'list'), options$cache == 1)
+    cache$output(options$hash, 'list')
   } else in_input_dir(
     evaluate(
       code, envir = env, new_device = FALSE,


### PR DESCRIPTION
I'm reasonably certain that this is only required in R 3.3.0 and earlier as it was fixed in https://www.stat.auckland.ac.nz/~paul/Reports/DisplayList/dl-record.html. knitr now requires R 3.6, so this code is no longer needed.