### PR TITLE
Support alt text for images in LaTeX output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - In-chunk references of the form `<<label>>` can be disabled via the chunk option `ref.chunk = FALSE` now (thanks, @jennybc @gadenbuie, #2360).
 
+- Added support for `fig.alt` for LaTeX output, i.e., using `\includegraphics[alt={alt text}]` (thanks, @capnrefsmmat, #2378).
+
 ## BUG FIXES
 
 - In-chunk references of the form `<<label>>` should not be resolved if `label` is not found in the document (thanks, @jennybc @gadenbuie, #2360).

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -76,7 +76,6 @@ hook_plot_tex = function(x, options) {
   a = options$fig.align
   fig.cur = options$fig.cur %n% 1L
   fig.num = options$fig.num %n% 1L
-  fig.alt = options$fig.alt
   animate = options$fig.show == 'animate'
   fig.ncol = options$fig.ncol %n% fig.num
   if (is.null(fig.sep <- options$fig.sep)) {
@@ -163,9 +162,10 @@ hook_plot_tex = function(x, options) {
   # maxwidth does not work with animations
   if (animate && identical(ow, '\\maxwidth')) ow = NULL
   if (is.numeric(ow)) ow = paste0(ow, 'px')
-  size = paste(c(sprintf('width=%s', ow),
-                 sprintf('height=%s', options$out.height),
-                 options$out.extra), collapse = ',')
+  size = paste(c(
+    sprintf('width=%s', ow), sprintf('height=%s', options$out.height),
+    sprintf('alt={%s}', escape_percent(options$fig.alt)), options$out.extra
+  ), collapse = ',')
 
   paste0(
     fig1, align1, sub1, resize1,
@@ -180,11 +180,6 @@ hook_plot_tex = function(x, options) {
       sprintf('\\animategraphics%s{%s}{%s}{%s}{%s}', size, 1 / options$interval,
               sub(sprintf('%d$', fig.num), '', sans_ext(x)), 1L, fig.num)
     } else {
-      if (!is.null(fig.alt)) {
-        size = paste(c(size, sprintf('alt={%s}', escape_percent(fig.alt))),
-                     collapse = ',')
-      }
-
       if (nzchar(size)) size = sprintf('[%s]', size)
       res = sprintf(
         '\\includegraphics%s{%s} ', size,

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -180,7 +180,7 @@ hook_plot_tex = function(x, options) {
       sprintf('\\animategraphics%s{%s}{%s}{%s}{%s}', size, 1 / options$interval,
               sub(sprintf('%d$', fig.num), '', sans_ext(x)), 1L, fig.num)
     } else {
-      if (!is.null(fig.alt) && getOption('knitr.include_graphics.alt', TRUE)) {
+      if (!is.null(fig.alt)) {
         size = paste(c(size, sprintf('alt={%s}', escape_percent(fig.alt))),
                      collapse = ',')
       }

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -76,6 +76,7 @@ hook_plot_tex = function(x, options) {
   a = options$fig.align
   fig.cur = options$fig.cur %n% 1L
   fig.num = options$fig.num %n% 1L
+  fig.alt = options$fig.alt
   animate = options$fig.show == 'animate'
   fig.ncol = options$fig.ncol %n% fig.num
   if (is.null(fig.sep <- options$fig.sep)) {
@@ -179,6 +180,11 @@ hook_plot_tex = function(x, options) {
       sprintf('\\animategraphics%s{%s}{%s}{%s}{%s}', size, 1 / options$interval,
               sub(sprintf('%d$', fig.num), '', sans_ext(x)), 1L, fig.num)
     } else {
+      if (!is.null(fig.alt) && getOption('knitr.include_graphics.alt', TRUE)) {
+        size = paste(c(size, sprintf('alt={%s}', escape_percent(fig.alt))),
+                     collapse = ',')
+      }
+
       if (nzchar(size)) size = sprintf('[%s]', size)
       res = sprintf(
         '\\includegraphics%s{%s} ', size,

--- a/tests/testit/test-hooks-latex.R
+++ b/tests/testit/test-hooks-latex.R
@@ -1,0 +1,17 @@
+library(testit)
+
+assert("alt text is included in LaTeX output", {
+  # no alt text
+  (hook_plot_tex('foo.pdf', list(fig.align = 'center', fig.show = 'asis')) %==%
+     '\n\n{\\centering \\includegraphics{foo} \n\n}\n\n')
+
+  # alt text
+  (hook_plot_tex('foo.pdf', list(fig.alt = 'Alt', fig.align = 'center',
+                                 fig.show = 'asis')) %==%
+     '\n\n{\\centering \\includegraphics[,alt={Alt}]{foo} \n\n}\n\n')
+
+  # with width
+  (hook_plot_tex('foo.pdf', list(fig.alt = 'Alt', fig.align = 'center',
+                                 fig.show = 'asis', out.width = '\\maxwidth')) %==%
+     '\n\n{\\centering \\includegraphics[width=\\maxwidth,alt={Alt}]{foo} \n\n}\n\n')
+})

--- a/tests/testit/test-hooks-latex.R
+++ b/tests/testit/test-hooks-latex.R
@@ -8,7 +8,7 @@ assert("alt text is included in LaTeX output", {
   # alt text
   (hook_plot_tex('foo.pdf', list(fig.alt = 'Alt', fig.align = 'center',
                                  fig.show = 'asis')) %==%
-     '\n\n{\\centering \\includegraphics[,alt={Alt}]{foo} \n\n}\n\n')
+     '\n\n{\\centering \\includegraphics[alt={Alt}]{foo} \n\n}\n\n')
 
   # with width
   (hook_plot_tex('foo.pdf', list(fig.alt = 'Alt', fig.align = 'center',


### PR DESCRIPTION
Since 2021, graphicx supports an alt option containing alt text. Pass `fig.alt` through unless `knitr.include_graphics.alt` is FALSE (which can be set if e.g. you're using an older TeX Live whose graphicx does not support this.)

Ongoing LaTeX work to support accessible (tagged) PDFs will eventually use this option to embed alt text in PDFs. See <https://www.latex-project.org/publications/indexbytopic/pdf/>

See also #1967.

I haven't contributed to knitr before, so not sure of a few things:

1. I didn't see tests that checked `\includegraphics` output. Are there any tests I should change/add?
2. I added the option because graphicx versions before 2021 will throw an error when they get alt text, so some users may want to turn this off. But I defaulted the option to TRUE, so the alt text is included in LaTeX output by default. Should it default to FALSE instead? The new behavior will be surprising to people with old TeX installs, but on the other hand `fig.alt` is doing nothing for them right now. At the least I could add a FAQ entry for the error they'd get.