### PR TITLE
Update required xfun version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -120,7 +120,7 @@ Imports:
     highr (>= 0.11),
     methods,
     tools,
-    xfun (>= 0.48),
+    xfun (>= 0.49),
     yaml (>= 2.1.19)
 Suggests:
     bslib,


### PR DESCRIPTION
As noted here:

35df6f8ba5b5bba75a46c91fa67e801e7b8549df

The current {knitr} test suite assumes {xfun} >= 0.49

```r
xfun::html_escape('"40"')
# [1] "&quot;40&quot;"
```

Of course this is a behavior only in tests, so we don't _technically_ need to bump the version; at a minimum we could put a branch in the test based on {xfun} version. But this approach seems fine + much simpler.