### PR TITLE
Improve error traceback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CHANGES IN knitr VERSION 1.51
 
 - Fix issue with error traceback not correctly showing when **rlang** is available.
+- Improve error traceback when **rlang** is available and **evaluate** > 1.0.3 is used.
 
 # CHANGES IN knitr VERSION 1.50
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN knitr VERSION 1.51
 
+- Fix issue with error traceback not correctly showing when **rlang** is available.
 
 # CHANGES IN knitr VERSION 1.50
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CHANGES IN knitr VERSION 1.51
 
 - Fix issue with error traceback not correctly showing when **rlang** is available.
+
 - Improve error traceback when **rlang** is available and **evaluate** > 1.0.3 is used.
 
 # CHANGES IN knitr VERSION 1.50

--- a/R/output.R
+++ b/R/output.R
@@ -314,14 +314,7 @@ process_file = function(text, output) {
         if (tangle) process_tangle(group) else process_group(group),
         error = function(e) {
           if (progress && is.function(pb$interrupt)) pb$interrupt()
-          if (xfun::pkg_available('rlang', '1.0.0')) {
-            if (is_R_CMD_build() || is_R_CMD_check()) {
-              cnd = tryCatch(rlang::entrace(e), error = identity)
-              error <<- format(cnd)
-            } else {
-              rlang::entrace(e)
-            }
-          }
+          if (is_R_CMD_build() || is_R_CMD_check()) error <<- format(e)
         }
       ),
       function(loc) {

--- a/R/output.R
+++ b/R/output.R
@@ -727,6 +727,10 @@ add_html_caption = function(options, code, id = NULL) {
 #' # after you define and register the above method, data frames will be printed
 #' # as tables in knitr, which is different with the default print() behavior
 knit_print = function(x, ...) {
+  if (getOption('knitr.in.progress', FALSE)) {
+    current_env = parent.frame()
+    local_options(list(rlang_trace_top_env = current_env))
+  }
   if (need_screenshot(x, ...)) {
     html_screenshot(x)
   } else {

--- a/R/output.R
+++ b/R/output.R
@@ -310,12 +310,15 @@ process_file = function(text, output) {
     knit_concord$set(block = i)
     error = NULL
     res[i] = xfun:::handle_error(
-      withCallingHandlers(
-        if (tangle) process_tangle(group) else process_group(group),
-        error = function(e) {
-          if (progress && is.function(pb$interrupt)) pb$interrupt()
-          if (is_R_CMD_build() || is_R_CMD_check()) error <<- format(e)
-        }
+      with_options(
+  	    withCallingHandlers(
+          if (tangle) process_tangle(group) else process_group(group),
+          error = function(e) {
+            if (progress && is.function(pb$interrupt)) pb$interrupt()
+            if (is_R_CMD_build() || is_R_CMD_check()) error <<- format(e)
+          }
+        ),
+        list(rlang_trace_top_env = knit_global())
       ),
       function(loc) {
         setwd(wd)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1131,8 +1131,6 @@ txt_pb = function(total, labels) {
 is_quarto = function() isTRUE(.knitEnv$is_quarto)
 
 with_options = function(expr, opts_list) {
-  old <- options(opts_list)
-  defer(options(old))
   local_options(opts_list)
   expr
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -845,6 +845,8 @@ current_input = function(dir = FALSE) {
 
 # cache output handlers from evaluate; see .onLoad
 default_handlers = NULL
+# use rlang handler for error only if available; see .onLoad
+rlang_entrace_handler = NULL
 # change the value handler in evaluate default handlers
 knit_handlers = function(fun, options) {
   if (!is.function(fun)) fun = function(x, ...) {
@@ -862,7 +864,7 @@ knit_handlers = function(fun, options) {
     value = function(x, visible) {
       if (visible) fun(x, options = options)
     },
-    calling_handlers = options$calling.handlers
+    calling_handlers = c(options$calling.handlers, rlang_entrace_handler)
   ))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1129,3 +1129,14 @@ txt_pb = function(total, labels) {
 }
 
 is_quarto = function() isTRUE(.knitEnv$is_quarto)
+
+with_options = function(expr, opts_list) {
+  old <- options(opts_list)
+  defer(options(old))
+  expr
+}
+
+defer = function(expr, frame = parent.frame(), after = FALSE) {
+  thunk <- as.call(list(function() expr))
+  do.call(on.exit, list(thunk, add = TRUE, after = after), envir = frame)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1133,7 +1133,13 @@ is_quarto = function() isTRUE(.knitEnv$is_quarto)
 with_options = function(expr, opts_list) {
   old <- options(opts_list)
   defer(options(old))
+  local_options(opts_list)
   expr
+}
+
+local_options <- function(opts_list, .local_envir = parent.frame()) {
+  old <- options(opts_list)
+  defer(options(old), .local_envir)
 }
 
 defer = function(expr, frame = parent.frame(), after = FALSE) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,12 @@
+has_rlang = FALSE
+
 .onLoad = function(lib, pkg) {
   register_vignette_engines(pkg)
   
   default_handlers <<- evaluate::new_output_handler()
+
+  has_rlang <<- requireNamespace("rlang", quietly = TRUE)
+
+  if (has_rlang)
+    rlang_entrace_handler <<- list(error = function(e) rlang::entrace(e))
 }


### PR DESCRIPTION
This PR follows up on **evaluate** 1.0.3 work. 

- **knitr** does entrace all error with **rlang** when available. This is done now in the calling handler of evaluate, closest to the error being thrown

- **evaluate** does handle already trimming the backtrace for error thrown in the code evaluated. **knitr** need also to do it for error happening in its `value` handler passed to evaluate, and calling `knit_print()`
	- This is done at the `knit_print()` level directly; 
		But `options$render` could be use to change the value handler, and in that case this would not apply. So it could be done also at the value handler 
		https://github.com/yihui/knitr/blob/8a37857140a0c1a656d5ff76b9742f6a5c01933c/R/utils.R#L882-L887
	
	- Or **evaluate** could also do it so that it happens for any value handler, including knitr's one. 

## Tests 

They are added to companion PR in knitr-example 
- https://github.com/yihui/knitr-examples/pull/93

The CI check below are ran using this https://github.com/yihui/knitr-examples/pull/93 PR. 