### PR TITLE
Allow for column alignment for org table export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Display error traceback when vignettes fail in `R CMD build` (thanks, @hadley, #2390).
 
+- `kable()` properly supports column alignment for Org Mode tables now (thanks, @mclements, #2391).
+
 ## MINOR CHANGES
 
 - Moved implementations of `combine_words()` and `write_bib()` to the **xfun** package as `xfun::join_words()` and `xfun::pkg_bib()`, respectively, since they are not directly relevant to **knitr**. The functions `combine_words()` and `write_bib()` are still kept in **knitr**, and can continue to be used in the future.

--- a/R/table.R
+++ b/R/table.R
@@ -478,12 +478,13 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
 
 # Emacs Org-mode table
 kable_org = function(x, caption = NULL, padding = 1, caption.label = '#+CAPTION:', ...) {
+  if (length(x)==0) return("")
   is_null_colnames = is.null(colnames(x))
   if (is_null_colnames) colnames(x) = rep('', ncol(x))
   res = kable_mark(x, c(NA, "-", NA), '|', padding, align.fun = function(s, a) {
     if (is.null(a)) return(s)
     r = c(l = '<l>', c = '<c>', r = '<r>')
-    rbind(r[a],"---")
+    rbind(r[a], rep("---",length(a)))
   }, ...)
   res = sprintf('|%s|', res)
   res = gsub('[-][-][|][-]', '--+-', res)

--- a/R/table.R
+++ b/R/table.R
@@ -481,14 +481,14 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
 
 # Emacs Org-mode table
 kable_org = function(x, caption = NULL, padding = 1, caption.label = '#+CAPTION:', ...) {
-  if (no_header <- is.null(colnames(x))) colnames(x) = rep('', ncol(x))
+  has_header = !is.null(colnames(x))
   res = kable_mark(x, c(NA, '-', NA), '|', padding, align.fun = function(s, a) {
     r = c(l = '<l>', c = '<c>', r = '<r>')
-    rbind(r[a], '---')
+    rbind(r[a], if (has_header) s)
   }, ...)
+  if (!is.na(i <- grep('^(---+[|])+---+$', res)[1]))
+    res[i] = gsub('|', '+', res[i], fixed = TRUE)
   res = sprintf('|%s|', res)
-  res = gsub('[-][-][|][-]', '--+-', res)
-  if (no_header) res = res[-c(1,3)]
   kable_pandoc_caption(res, caption, caption.label)
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -484,14 +484,11 @@ kable_org = function(...) {
     i = i[1]
     # column alignment
     vb = gregexpr("[|]", res[i])[[1]] # location of the vertical bars
-    alignment = rep("", length(vb)-1)
-    for (j in 1:length(alignment)) {
-        left = substring(res[i],vb[j]+1,vb[j]+1)==":"
-        right = substring(res[i],vb[j+1]-1,vb[j+1]-1)==":"
-        if (left && right) alignment[j] = "<c>"
-        else if (left) alignment[j] = "<l>"
-        else if (right) alignment[j] = "<r>"
-    }
+    left = substring(res[i],head(vb,-1)+1,head(vb,-1)+1)==":"
+    right = substring(res[i],tail(vb,-1)-1,tail(vb,-1)-1)==":"
+    alignment = ifelse(left & right, "<c>",
+                ifelse(left, "<l>",
+                ifelse(right, "<r>", "")))
     # replace : and use + as separator
     res[i] = gsub('[:-][|][:-]', '-+-', res[i])
     res[i] = gsub('[|]:', '|-', res[i])

--- a/R/table.R
+++ b/R/table.R
@@ -417,8 +417,10 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ', padding = 0
   }
   l = pmax(l + padding, 3)  # at least of width 3 for Github Markdown
   s = strrep(sep.row[2], l)
-  res = rbind(if (!is.na(sep.row[1])) s, cn, align.fun(s, align),
-              x, if (!is.na(sep.row[3])) s)
+  res = rbind(
+    if (!is.na(sep.row[1])) s, cn, if (is.null(align)) s else align.fun(s, align),
+    x, if (!is.na(sep.row[3])) s
+  )
   res = mat_pad(res, l, align)
   res = add_mark_col_sep(res, sep.col, sep.head)
   if (is.character(newline)) res = gsub('\n', newline, res, fixed = TRUE)
@@ -442,7 +444,6 @@ kable_rst = function(x, rownames.name = '\\', ...) {
 kable_pipe = function(x, caption = NULL, padding = 1, caption.label = 'Table:', ...) {
   if (is.null(colnames(x))) colnames(x) = rep('', ncol(x))
   res = kable_mark(x, c(NA, '-', NA), '|', padding, align.fun = function(s, a) {
-    if (is.null(a)) return(s)
     r = c(l = '^.', c = '^.|.$', r = '.$')
     for (i in seq_along(s)) {
       s[i] = gsub(r[a[i]], ':', s[i])
@@ -480,7 +481,6 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
 kable_org = function(x, caption = NULL, padding = 1, caption.label = '#+CAPTION:', ...) {
   if (no_header <- is.null(colnames(x))) colnames(x) = rep('', ncol(x))
   res = kable_mark(x, c(NA, '-', NA), '|', padding, align.fun = function(s, a) {
-    if (is.null(a)) return(s)
     r = c(l = '<l>', c = '<c>', r = '<r>')
     rbind(r[a], '---')
   }, ...)

--- a/R/table.R
+++ b/R/table.R
@@ -483,17 +483,15 @@ kable_org = function(...) {
   if (length(i)) {
     i = i[1]
     # column alignment
-    alignment = rep("", length(gregexpr("[|]", res[i])[[1]])-1)
-    replace = function(alignment, row, pattern, value) {
-        vertical_bars = gregexpr("[|]", row)[[1]]
-        index = gregexpr(pattern, row)[[1]]
-        if (all(index != -1))
-            alignment[match(index,vertical_bars)] = value
-        alignment
+    vb = gregexpr("[|]", res[i])[[1]] # location of the vertical bars
+    alignment = rep("", length(vb)-1)
+    for (j in 1:length(alignment)) {
+        left = substring(res[i],vb[j]+1,vb[j]+1)==":"
+        right = substring(res[i],vb[j+1]-1,vb[j+1]-1)==":"
+        if (left && right) alignment[j] = "<c>"
+        else if (left) alignment[j] = "<l>"
+        else if (right) alignment[j] = "<r>"
     }
-    alignment = replace(alignment, res[i], "[|]:[-]*[|]",  "<l>")
-    alignment = replace(alignment, res[i], "[|][-]*:[|]",  "<r>")
-    alignment = replace(alignment, res[i], "[|]:[-]*:[|]", "<c>")
     # replace : and use + as separator
     res[i] = gsub('[:-][|][:-]', '-+-', res[i])
     res[i] = gsub('[|]:', '|-', res[i])

--- a/R/table.R
+++ b/R/table.R
@@ -478,17 +478,15 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
 
 # Emacs Org-mode table
 kable_org = function(x, caption = NULL, padding = 1, caption.label = '#+CAPTION:', ...) {
-  if (length(x)==0) return("")
-  is_null_colnames = is.null(colnames(x))
-  if (is_null_colnames) colnames(x) = rep('', ncol(x))
-  res = kable_mark(x, c(NA, "-", NA), '|', padding, align.fun = function(s, a) {
+  if (no_header <- is.null(colnames(x))) colnames(x) = rep('', ncol(x))
+  res = kable_mark(x, c(NA, '-', NA), '|', padding, align.fun = function(s, a) {
     if (is.null(a)) return(s)
     r = c(l = '<l>', c = '<c>', r = '<r>')
-    rbind(r[a], rep("---",length(a)))
+    rbind(r[a], '---')
   }, ...)
   res = sprintf('|%s|', res)
   res = gsub('[-][-][|][-]', '--+-', res)
-  if (is_null_colnames) res = res[-c(1,3)]
+  if (no_header) res = res[-c(1,3)]
   kable_pandoc_caption(res, caption, caption.label)
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -403,7 +403,9 @@ kable_mark = function(x, sep.row = c('=', '=', '='), sep.col = '  ', padding = 0
   if (sep.col == '|') for (j in seq_len(ncol(x))) {
     x[, j] = gsub('\\|', '&#124;', x[, j])
   }
-  l = if (prod(dim(x)) > 0) apply(x, 2, function(z) max(nchar(remove_urls(z), type = 'width'), na.rm = TRUE))
+  l = if (prod(dim(x)) > 0) apply(x, 2, function(z) {
+    max(nchar(remove_urls(z), type = 'width'), na.rm = TRUE)
+  }) else integer(ncol(x))
   cn = colnames(x)
   if (length(cn) > 0) {
     cn[is.na(cn)] = "NA"

--- a/R/table.R
+++ b/R/table.R
@@ -477,29 +477,18 @@ kable_jira = function(x, caption = NULL, padding = 1, ...) {
 }
 
 # Emacs Org-mode table
-kable_org = function(...) {
-  res = kable_pipe(..., caption.label = '#+CAPTION:')
-  i = grep('^[-:|]+$', res)  # find the line like |--:|---| under header
-  if (length(i)) {
-    i = i[1]
-    # column alignment
-    vb = gregexpr("[|]", res[i])[[1]] # location of the vertical bars
-    left = substring(res[i],head(vb,-1)+1,head(vb,-1)+1)==":"
-    right = substring(res[i],tail(vb,-1)-1,tail(vb,-1)-1)==":"
-    alignment = ifelse(left & right, "<c>",
-                ifelse(left, "<l>",
-                ifelse(right, "<r>", "")))
-    # replace : and use + as separator
-    res[i] = gsub('[:-][|][:-]', '-+-', res[i])
-    res[i] = gsub('[|]:', '|-', res[i])
-    res[i] = gsub(':[|]', '-|', res[i])
-    # prepend the description of the column alignment
-    if (any(alignment != ""))
-        res = c(if (i>1) res[1:(i-1)] else NULL,
-                sprintf("|%s|", paste0(alignment,collapse="|")),
-                res[i:length(res)])
-  }
-  res
+kable_org = function(x, caption = NULL, padding = 1, caption.label = '#+CAPTION:', ...) {
+  is_null_colnames = is.null(colnames(x))
+  if (is_null_colnames) colnames(x) = rep('', ncol(x))
+  res = kable_mark(x, c(NA, "-", NA), '|', padding, align.fun = function(s, a) {
+    if (is.null(a)) return(s)
+    r = c(l = '<l>', c = '<c>', r = '<r>')
+    rbind(r[a],"---")
+  }, ...)
+  res = sprintf('|%s|', res)
+  res = gsub('[-][-][|][-]', '--+-', res)
+  if (is_null_colnames) res = res[-c(1,3)]
+  kable_pandoc_caption(res, caption, caption.label)
 }
 
 kable_pandoc_caption = function(x, caption, label = 'Table:') {

--- a/R/table.R
+++ b/R/table.R
@@ -482,7 +482,26 @@ kable_org = function(...) {
   i = grep('^[-:|]+$', res)  # find the line like |--:|---| under header
   if (length(i)) {
     i = i[1]
-    res[i] = gsub('(-|:)[|](-|:)', '\\1+\\2', res[i])  # use + as separator
+    # column alignment
+    alignment = rep("", length(gregexpr("[|]", res[i])[[1]])-1)
+    replace = function(alignment, row, pattern, value) {
+        vertical_bars = gregexpr("[|]", row)[[1]]
+        index = gregexpr(pattern, row)[[1]]
+        if (all(index != -1))
+            alignment[match(index,vertical_bars)] = value
+        alignment
+    }
+    alignment = replace(alignment, res[i], "[|]:[-]*[|]",  "<l>")
+    alignment = replace(alignment, res[i], "[|][-]*:[|]",  "<r>")
+    alignment = replace(alignment, res[i], "[|]:[-]*:[|]", "<c>")
+    # replace : and use + as separator
+    res[i] = gsub('[:-][|][:-]', '-+-', res[i])
+    res[i] = gsub('[|]:', '|-', res[i])
+    res[i] = gsub(':[|]', '-|', res[i])
+    # prepend the description of the column alignment
+    res = c(if (i>1) res[1:(i-1)] else NULL,
+            sprintf("|%s|", paste0(alignment,collapse="|")),
+            res[i:length(res)])
   }
   res
 }

--- a/R/table.R
+++ b/R/table.R
@@ -497,9 +497,10 @@ kable_org = function(...) {
     res[i] = gsub('[|]:', '|-', res[i])
     res[i] = gsub(':[|]', '-|', res[i])
     # prepend the description of the column alignment
-    res = c(if (i>1) res[1:(i-1)] else NULL,
-            sprintf("|%s|", paste0(alignment,collapse="|")),
-            res[i:length(res)])
+    if (any(alignment != ""))
+        res = c(if (i>1) res[1:(i-1)] else NULL,
+                sprintf("|%s|", paste0(alignment,collapse="|")),
+                res[i:length(res)])
   }
   res
 }

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -40,8 +40,13 @@ assert('kable() works with the jira format', {
 })
 
 assert('kable() works with the org format', {
-    (kable2(m, 'org') %==% c('|   |  x|  y|', '|<l>|<r>|<r>|', '|---+---+---|',
-                             '|a  |  1|  2|'))
+  (kable2(m, 'org') %==%
+    c('|   |  x|  y|', '|<l>|<r>|<r>|', '|---+---+---|', '|a  |  1|  2|'))
+  m2 = m; colnames(m2) = NULL  # no column names
+  (kable2(m2, 'org') %==% c('|<l>|<r>|<r>|', '|a  |  1|  2|'))
+  # the case of only one column
+  (kable2(m[, 1, drop = FALSE], 'org', row.names = FALSE) %==%
+    c('|  x|', '|<r>|', '|---|', '|  1|'))
 })
 
 assert('kable() does not add extra spaces to character columns', {

--- a/tests/testit/test-table.R
+++ b/tests/testit/test-table.R
@@ -40,7 +40,8 @@ assert('kable() works with the jira format', {
 })
 
 assert('kable() works with the org format', {
-  (kable2(m, 'org') %==% c('|   |  x|  y|', '|:--+--:+--:|', '|a  |  1|  2|'))
+    (kable2(m, 'org') %==% c('|   |  x|  y|', '|<l>|<r>|<r>|', '|---+---+---|',
+                             '|a  |  1|  2|'))
 })
 
 assert('kable() does not add extra spaces to character columns', {


### PR DESCRIPTION
For table export to Org Mode, (i) the column alignment is currently lost and (ii) the output table includes colons which are not part of the Org Mode table specification. To address these issues, I have added some code to keep the column alignment and cleaned up the output table format.

I hope that this is helpful.

Sincerely, Mark.