### PR TITLE
Correctly format R in citation entry for Manual

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -4,7 +4,7 @@ if (length(year) == 0) year = format(Sys.Date(), '%Y')
 
 bibentry(
   'manual',
-  title = paste('knitr:', gsub('(^.*\\s)R(\\s*)$', '\\1{R}\\2', meta$Title)),
+  title = paste('knitr:', gsub('\\bR\\b', '{R}', meta$Title)),
   author = Filter(function(p) 'aut' %in% p$role, as.person(meta$Author)),
   year = year,
   note = vers,

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -4,7 +4,7 @@ if (length(year) == 0) year = format(Sys.Date(), '%Y')
 
 bibentry(
   'manual',
-  title = paste('knitr:', meta$Title),
+  title = paste('knitr:', gsub('(^.*\\s)R(\\s*)$', '\\1{R}\\2', meta$Title)),
   author = Filter(function(p) 'aut' %in% p$role, as.person(meta$Author)),
   year = year,
   note = vers,


### PR DESCRIPTION
So that `{R}` is in title instead of just `R`
````r
> toBibtex(citation("knitr"))
@Manual{,
  title = {knitr: A General-Purpose Package for Dynamic Report Generation in {R}},
  year = {2025},
  note = {R package version 1.49.7},
  url = {https://yihui.org/knitr/},
}
````

closes #2393 