### PR TITLE
don't set `vheight` for webshot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.50.3
+Version: 1.50.4
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - `hook_optipng()` now uses the `-quiet` argument of `optipng` to suppress the messages by default.
 
-- Don't set a `vheight` or `vwidth` for `webshot2::webshot()` when `out.height` or `out.width` is set in percent (%) unit. Setting `screenshot.opts` chunk option is still a way to specify `vheight` or `vwidth` specifically for `webshot()`, e.g `screenshot.opts = list(vwidth = 6 * 72, vheight = 6 * 72 * 0.618)` for 6 inches size with 72 dpi and 0.618 of aspect ratio.
+- Don't set `vheight` or `vwidth` for `webshot2::webshot()` when the chunk option `out.height` or `out.width` is a percentage (%). Setting `screenshot.opts` chunk option is still a way to specify `vheight` or `vwidth` specifically for `webshot()`, e.g., `screenshot.opts = list(vwidth = 6 * 72, vheight = 6 * 72 * 0.618)` for the width of 6 inches size with 72 dpi and 0.618 of aspect ratio.
 
 # CHANGES IN knitr VERSION 1.50
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - `hook_optipng()` now uses the `-quiet` argument of `optipng` to suppress the messages by default.
 
-- Don't set a `vheight` for `webshot2::webshot()` when `out.height` is set in percent (%) unit. Setting `screenshot.opts` chunk option is still a way to specify `vheight` or `vwidth` specifically for `webshot()`, e.g `screenshot.opts = list(vwidth = 6 * 72, vheight = 6 * 72 * 0.618)` for 6 inches size with 72 dpi and 0.618 of aspect ratio.
+- Don't set a `vheight` or `vwidth` for `webshot2::webshot()` when `out.height` or `out.width` is set in percent (%) unit. Setting `screenshot.opts` chunk option is still a way to specify `vheight` or `vwidth` specifically for `webshot()`, e.g `screenshot.opts = list(vwidth = 6 * 72, vheight = 6 * 72 * 0.618)` for 6 inches size with 72 dpi and 0.618 of aspect ratio.
 
 # CHANGES IN knitr VERSION 1.50
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - `hook_optipng()` now uses the `-quiet` argument of `optipng` to suppress the messages by default.
 
+- Don't set a `vheight` for `webshot2::webshot()` when `out.height` is set in percent (%) unit. Setting `screenshot.opts` chunk option is still a way to specify `vheight` or `vwidth` specifically for `webshot()`, e.g `screenshot.opts = list(vwidth = 6 * 72, vheight = 6 * 72 * 0.618)` for 6 inches size with 72 dpi and 0.618 of aspect ratio.
+
 # CHANGES IN knitr VERSION 1.50
 
 ## NEW FEATURES

--- a/R/plot.R
+++ b/R/plot.R
@@ -595,7 +595,7 @@ html_screenshot = function(x, options = opts_current$get(), ...) {
     switch(options$dev[1], pdf = '.pdf', jpeg = '.jpeg', '.png')
   } else '.png'
   wargs = options$screenshot.opts %n% list()
-  if (is.null(wargs$vwidth)) wargs$vwidth = options$out.width.px
+  if (is.null(wargs$vwidth) && !grepl("%$", options$out.width.px)) wargs$vwidth = options$out.width.px
   if (is.null(wargs$vheight) && !grepl("%$", options$out.height.px)) wargs$vheight = options$out.height.px
   if (is.null(wargs$delay)) wargs$delay = if (i1) 0.2 else 1
   d = tempfile()

--- a/R/plot.R
+++ b/R/plot.R
@@ -609,6 +609,10 @@ html_screenshot = function(x, options = opts_current$get(), ...) {
     if (is_quarto()) "fig-format" else "dev", "' to 'png'). ",
     "See https://github.com/yihui/knitr/issues/2276 for more information."
   )
+  # set quiet opions for webshot2::webshot()
+  local_options(list(
+    webshot.quiet = getOption("webshot.quiet", TRUE)
+  ))
   f = in_dir(d, {
     if (i1 || i3) {
       if (i1) {

--- a/R/plot.R
+++ b/R/plot.R
@@ -596,7 +596,7 @@ html_screenshot = function(x, options = opts_current$get(), ...) {
   } else '.png'
   wargs = options$screenshot.opts %n% list()
   if (is.null(wargs$vwidth)) wargs$vwidth = options$out.width.px
-  if (is.null(wargs$vheight)) wargs$vheight = options$out.height.px
+  if (is.null(wargs$vheight) && !grepl("%$", options$out.height.px)) wargs$vheight = options$out.height.px
   if (is.null(wargs$delay)) wargs$delay = if (i1) 0.2 else 1
   d = tempfile()
   dir.create(d); on.exit(unlink(d, recursive = TRUE), add = TRUE)

--- a/R/plot.R
+++ b/R/plot.R
@@ -595,8 +595,8 @@ html_screenshot = function(x, options = opts_current$get(), ...) {
     switch(options$dev[1], pdf = '.pdf', jpeg = '.jpeg', '.png')
   } else '.png'
   wargs = options$screenshot.opts %n% list()
-  if (is.null(wargs$vwidth) && !grepl("%$", options$out.width.px)) wargs$vwidth = options$out.width.px
-  if (is.null(wargs$vheight) && !grepl("%$", options$out.height.px)) wargs$vheight = options$out.height.px
+  if (is.null(wargs$vwidth) && !grepl("%$", W <- options$out.width.px)) wargs$vwidth = W
+  if (is.null(wargs$vheight) && !grepl("%$", H <- options$out.height.px)) wargs$vheight = H
   if (is.null(wargs$delay)) wargs$delay = if (i1) 0.2 else 1
   d = tempfile()
   dir.create(d); on.exit(unlink(d, recursive = TRUE), add = TRUE)
@@ -610,9 +610,7 @@ html_screenshot = function(x, options = opts_current$get(), ...) {
     "See https://github.com/yihui/knitr/issues/2276 for more information."
   )
   # set quiet opions for webshot2::webshot()
-  local_options(list(
-    webshot.quiet = getOption("webshot.quiet", TRUE)
-  ))
+  local_options(list(webshot.quiet = getOption('webshot.quiet', TRUE)))
   f = in_dir(d, {
     if (i1 || i3) {
       if (i1) {


### PR DESCRIPTION
> [!NOTE]
> This PR is an idea on what we could try do to use webshot2 default 

fixes https://github.com/rstudio/rmarkdown/issues/2460

This PR will ignore `out.height.px` when set in % unit as it is not support by `webshot()`. 
In this case the screenshot will be done using standard viewport height. 

The `out.width = '50%'` would still apply in the output 

 ````markdown
---
title: "Min example"
date: "`r format(Sys.time(), '%d %B, %Y')`"
output:
  pdf_document: 
    keep_md: true
  html_document: default
---

```{r message=FALSE, warning = FALSE}
library(plotly)
```

```{r}
#| out.height="50%"
library(plotly)
p <- plot_ly(economics, x = ~date, y = ~unemploy / pop)
p
```

```{r}
#| out.height="80%"
library(plotly)
p <- plot_ly(economics, x = ~date, y = ~unemploy / pop)
p
```

```{r}
#| out.height="10%"
library(plotly)
p <- plot_ly(economics, x = ~date, y = ~unemploy / pop)
p
```

````

<table>
<tr>
<td> First chunk
<td> Second chunk
<td> Third chunk
<tr>
<td>

![image](https://github.com/user-attachments/assets/1e31f30f-1c8f-4f58-abbf-8d203ae85c3e)


<td>

![image](https://github.com/user-attachments/assets/c72bb363-2889-4076-9cd5-7c4615784767)

<td>

![image](https://github.com/user-attachments/assets/67ed6881-ff6a-4f68-a9ef-576b0ec6803b)

</table>