### PR TITLE
Remove plyr usage from example

### DIFF
--- a/inst/examples/knitr-themes.Rnw
+++ b/inst/examples/knitr-themes.Rnw
@@ -76,7 +76,6 @@ applied to R code:
 
 <<demo-code, eval = FALSE>>=
 library(XML)
-library(plyr)
 library(reshape)
 # SCRAPE THE DATA FROM WEB 
 
@@ -94,7 +93,7 @@ save_data = function(y){
   return(tab)            
 }
 	
-team.list  = llply(years, save_data);
+team.list  = lapply(years, save_data);
 mls        = merge_recurse(team.list);
 @
 

--- a/inst/examples/knitr-themes.lyx
+++ b/inst/examples/knitr-themes.lyx
@@ -398,11 +398,6 @@ library(XML)
 
 \begin_layout Plain Layout
 
-library(plyr)
-\end_layout
-
-\begin_layout Plain Layout
-
 library(reshape)
 \end_layout
 
@@ -486,7 +481,7 @@ save_data = function(y){
 
 \begin_layout Plain Layout
 
-team.list  = llply(years, save_data);
+team.list  = lapply(years, save_data);
 \end_layout
 
 \begin_layout Plain Layout


### PR DESCRIPTION
I'm going around removing old {plyr} code with regex and this came up. I'm not sure if {plyr} is even _technically_ a dependency in this case. I have no idea what `merge_recurse()` is, it's not on CRAN:

https://github.com/search?q=repo%3Acran%2Freshape%20path%3A%2FNAMESPACE%24%2F%20%2Fmerge_recurse%2F&type=code

Feel free to reject this PR, just sharing since it's done already & short.