### PR TITLE
Support agg_webp() using ragg >=1.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.51.6
+Version: 1.51.7
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -138,7 +138,7 @@ Suggests:
     otel,
     otelsdk,
     png,
-    ragg,
+    ragg (>= 1.5.0),
     reticulate (>= 1.4),
     rgl (>= 0.95.1201),
     rlang,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Added support for a new input format `.Rtyp` for the [Typst](https://typst.app) typesetting system (thanks, @blset #2401, @aksigkvgithub #2283). You can use code chunks and inline R expressions in `.Rtyp` files, knit them via `knitr::knit()` to `.typ` output, or compile to PDF directly via `knit2pdf('input.Rtyp')`. See https://github.com/yihui/knitr-examples/blob/master/128-minimal.Rtyp for a minimal example.
 
+- Added support for `ragg::agg_webp()` as a graphics device for WebP output (thanks, @heavywatal, #2434). To use this device, set `dev = 'agg_webp'` in the chunk options. This device is available in **ragg** >= 1.5.0.
+
 ## BUG FIXES
 
 - The `alt` attribute of figure images now has HTML tags stripped (via `xfun::strip_html()`) and is properly escaped for use in HTML attributes (via `xfun::html_escape(attr = TRUE)`). Previously, HTML in `fig.cap` (e.g., a link) could appear verbatim in `alt`, and double quotes in captions could break the `alt` attribute value (thanks, @cderv, #2004).

--- a/R/block.R
+++ b/R/block.R
@@ -405,6 +405,10 @@ chunk_device = function(options, record = TRUE, tmp = tempfile()) {
     do.call(ragg_png_dev, c(list(
       filename = tmp, width = width, height = height, units = 'in', res = dpi
     ), get_dargs(dev.args, 'ragg_png')))
+  } else if (identical(dev, 'ragg_webp')) {
+    do.call(ragg_webp_dev, c(list(
+      filename = tmp, width = width, height = height, units = 'in', res = dpi
+    ), get_dargs(dev.args, 'ragg_webp')))
   } else if (identical(dev, 'tikz')) {
     dargs = c(list(
       file = tmp, width = width, height = height

--- a/R/plot.R
+++ b/R/plot.R
@@ -127,28 +127,18 @@ tikz_dev = function(..., engine = getOption('tikzDefaultEngine')) {
   tikzDevice::tikz(..., packages = c('\n\\nonstopmode\n', packages, .knitEnv$tikzPackages))
 }
 
-# a wrapper of the ragg::agg_png device
-ragg_png_dev = function(...) {
-  loadNamespace('ragg')
+# a wrapper of the ragg::agg_* device
+ragg_dev = function(dev) function(...) {
   args = list(...)
   # handle bg -> background gracefully
   args$background = args$background %n% args$bg
   args$bg = NULL
-  do.call(ragg::agg_png, args)
+  dev = getFromNamespace(dev, 'ragg')
+  do.call(dev, args)
 }
 
-# a wrapper of the ragg::agg_webp device
-ragg_webp_dev = function(...) {
-  ns = loadNamespace('ragg')
-  if (!exists('agg_webp', envir = ns, mode = 'function', inherits = FALSE)) {
-    stop("The 'ragg_webp' device requires ragg >= 1.5.0 with WebP support.", call. = FALSE)
-  }
-  args = list(...)
-  # handle bg -> background gracefully
-  args$background = args$background %n% args$bg
-  args$bg = NULL
-  do.call(ragg::agg_webp, args)
-}
+ragg_png_dev = ragg_dev('agg_png')
+ragg_webp_dev = ragg_dev('agg_webp')
 
 # save a recorded plot
 save_plot = function(plot, name, dev, width, height, ext, dpi, options) {

--- a/R/plot.R
+++ b/R/plot.R
@@ -139,7 +139,10 @@ ragg_png_dev = function(...) {
 
 # a wrapper of the ragg::agg_webp device
 ragg_webp_dev = function(...) {
-  loadNamespace('ragg')
+  ns = loadNamespace('ragg')
+  if (!exists('agg_webp', envir = ns, mode = 'function', inherits = FALSE)) {
+    stop("The 'ragg_webp' device requires ragg >= 1.5.0 with WebP support.", call. = FALSE)
+  }
   args = list(...)
   # handle bg -> background gracefully
   args$background = args$background %n% args$bg

--- a/R/plot.R
+++ b/R/plot.R
@@ -13,7 +13,7 @@ auto_exts = c(
 
   svglite = 'svg', gridSVG = 'svg',
 
-  ragg_png = 'png',
+  ragg_png = 'png', ragg_webp = 'webp',
 
   tikz = 'tex'
 )
@@ -92,6 +92,9 @@ dev_get = function(dev, options = opts_current$get(), dpi = options$dpi[1]) {
     ragg_png = function(...) {
       ragg_png_dev(..., res = dpi, units = 'in')
     },
+    ragg_webp = function(...) {
+      ragg_webp_dev(..., res = dpi, units = 'in')
+    },
 
     tikz = function(...) {
       tikz_dev(..., sanitize = options$sanitize, standAlone = options$external)
@@ -132,6 +135,16 @@ ragg_png_dev = function(...) {
   args$background = args$background %n% args$bg
   args$bg = NULL
   do.call(ragg::agg_png, args)
+}
+
+# a wrapper of the ragg::agg_webp device
+ragg_webp_dev = function(...) {
+  loadNamespace('ragg')
+  args = list(...)
+  # handle bg -> background gracefully
+  args$background = args$background %n% args$bg
+  args$bg = NULL
+  do.call(ragg::agg_webp, args)
 }
 
 # save a recorded plot

--- a/tests/testit/test-plot.R
+++ b/tests/testit/test-plot.R
@@ -83,6 +83,10 @@ if (requireNamespace("ragg", quietly = TRUE) &&
       TRUE
     }
   )
+}
+
+if (requireNamespace("ragg", quietly = TRUE) &&
+    !has_error({ragg::agg_webp(); dev.off()})) {
   assert(
     'ragg_webp_dev correctly handles bg dev.arg into background arg',
     {

--- a/tests/testit/test-plot.R
+++ b/tests/testit/test-plot.R
@@ -83,6 +83,17 @@ if (requireNamespace("ragg", quietly = TRUE) &&
       TRUE
     }
   )
+  assert(
+    'ragg_webp_dev correctly handles bg dev.arg into background arg',
+    {
+      chunk_device(opts_chunk$merge(list(
+        dev = 'ragg_webp', dev.args = list(bg = "grey")
+      )))
+      plot(1:10)
+      dev.off()
+      TRUE
+    }
+  )
 }
 
 # should not error (find `pdf` correctly in grDevices, instead of the one


### PR DESCRIPTION
WebP output has been supported by `ragg` since [version 1.5.0](https://ragg.r-lib.org/news/#ragg-150). This PR enables `knitr::opts_chunk$set(dev = "ragg_webp")` for using it with knitr.