### PR TITLE
fix: render knit2html output next to input when output dir differs (#2408)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,6 +68,7 @@ Authors@R: c(
     person(c("Kevin", "K."), "Smith", role = "ctb"),
     person("Kirill", "Mueller", role = "ctb"),
     person("Kohske", "Takahashi", role = "ctb"),
+    person("Leonidas", "Zhak", role = "ctb"),
     person("Lorenz", "Walthert", role = "ctb"),
     person("Lucas", "Gallindo", role = "ctb"),
     person("Marius", "Hofert", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - The `alt` attribute of figure images now has HTML tags stripped (via `xfun::strip_html()`) and is properly escaped for use in HTML attributes (via `xfun::html_escape(attr = TRUE)`). Previously, HTML in `fig.cap` (e.g., a link) could appear verbatim in `alt`, and double quotes in captions could break the `alt` attribute value (thanks, @cderv, #2004).
 
+- `knit2html()` now stages local figure resources when the HTML output is written to a different directory, so embedded images no longer break with warnings like `File 'figure/...png' not found` (thanks, @LeonidasZhak, #2408).
+
 - Due to a change in Asymptote, the output file may not be recognized or included correctly (thanks, @DeliciousRoastPotato @shangeconnew, #2025).
 
 - `has_crop_tools()` should not throw an error when `tlmgr` exists but cannot be executed (thanks, @lsandig, rstudio/rmarkdown#2612). It returns `FALSE` now.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 - The `alt` attribute of figure images now has HTML tags stripped (via `xfun::strip_html()`) and is properly escaped for use in HTML attributes (via `xfun::html_escape(attr = TRUE)`). Previously, HTML in `fig.cap` (e.g., a link) could appear verbatim in `alt`, and double quotes in captions could break the `alt` attribute value (thanks, @cderv, #2004).
 
-- `knit2html()` now stages local figure resources when the HTML output is written to a different directory, so embedded images no longer break with warnings like `File 'figure/...png' not found` (thanks, @LeonidasZhak, #2408).
+- `knit2html()` now renders the HTML next to the knitted Markdown and then moves it to the output location when the output is written to a different directory, so local figure resources can still be found and embedded (previously they broke with warnings like `File 'figure/...png' not found`). For more robust rendering of R Markdown to HTML, consider `litedown::fuse()` instead (thanks, @LeonidasZhak, #2408).
 
 - Due to a change in Asymptote, the output file may not be recognized or included correctly (thanks, @DeliciousRoastPotato @shangeconnew, #2025).
 

--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -142,6 +142,70 @@ rnw2pdf = function(
   output
 }
 
+markdown_resource_paths = function(text) {
+  patterns = c(
+    '!\\[[^]]*\\]\\(([^)[:space:]]+)(?:[[:space:]].*)?\\)',
+    '<(?:img|embed)\\b[^>]*\\bsrc=[\'"]([^\'"]+)[\'"]',
+    '<object\\b[^>]*\\bdata=[\'"]([^\'"]+)[\'"]'
+  )
+  paths = unlist(lapply(patterns, function(pattern) {
+    matches = regmatches(text, gregexec(pattern, text, perl = TRUE))
+    unlist(lapply(matches, function(match) {
+      if (length(match) < 2) return(character())
+      match[-1]
+    }), use.names = FALSE)
+  }), use.names = FALSE)
+  paths = sub('#.*$', '', paths)
+  paths = paths[nzchar(paths)]
+  paths = paths[!grepl('^(?:[[:alpha:]][[:alnum:]+.-]*:|//)', paths)]
+  paths = paths[!xfun::is_abs_path(paths)]
+  unique(paths)
+}
+
+stage_markdown_resources = function(input, output) {
+  input_dir = dirname(input)
+  output_dir = dirname(output)
+  if (xfun::same_path(input_dir, output_dir)) return(character())
+
+  paths = markdown_resource_paths(read_utf8(input))
+  if (!length(paths)) return(character())
+
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  staged = character()
+  for (path in paths) {
+    src = file.path(input_dir, path)
+    if (!file.exists(src)) next
+    dest = file.path(output_dir, path)
+    if (file.exists(dest)) next
+    dir.create(dirname(dest), recursive = TRUE, showWarnings = FALSE)
+    if (file.copy(src, dest, overwrite = FALSE)) staged = c(staged, dest)
+  }
+  unique(staged)
+}
+
+cleanup_markdown_resources = function(paths, root) {
+  paths = unique(paths[file.exists(paths)])
+  if (!length(paths)) return(invisible())
+
+  unlink(paths)
+
+  root = normalizePath(root, winslash = '/', mustWork = FALSE)
+  dirs = unique(dirname(paths))
+  dirs = dirs[order(nchar(dirs), decreasing = TRUE)]
+  for (dir in dirs) {
+    current = normalizePath(dir, winslash = '/', mustWork = FALSE)
+    while (!xfun::same_path(current, root)) {
+      if (length(list.files(current, all.files = TRUE, no.. = TRUE)) > 0) break
+      unlink(current, recursive = TRUE)
+      parent = dirname(current)
+      if (xfun::same_path(parent, current)) break
+      current = normalizePath(parent, winslash = '/', mustWork = FALSE)
+    }
+  }
+
+  invisible()
+}
+
 #' Convert markdown to HTML using knit() and mark_html()
 #'
 #' This is a convenience function to knit the input markdown source and call
@@ -192,6 +256,8 @@ knit2html = function(
   mark = if (is_lite) litedown::mark else markdown::mark_html
   if (is.null(text)) {
     output = with_ext(if (is.null(output) || is.na(output)) out else output, 'html')
+    staged = stage_markdown_resources(out, output)
+    on.exit(cleanup_markdown_resources(staged, dirname(output)), add = TRUE)
     mark(out, output, ...)
     invisible(output)
   } else mark(text = out, ...)

--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -142,70 +142,6 @@ rnw2pdf = function(
   output
 }
 
-markdown_resource_paths = function(text) {
-  patterns = c(
-    '!\\[[^]]*\\]\\(([^)[:space:]]+)(?:[[:space:]].*)?\\)',
-    '<(?:img|embed)\\b[^>]*\\bsrc=[\'"]([^\'"]+)[\'"]',
-    '<object\\b[^>]*\\bdata=[\'"]([^\'"]+)[\'"]'
-  )
-  paths = unlist(lapply(patterns, function(pattern) {
-    matches = regmatches(text, gregexec(pattern, text, perl = TRUE))
-    unlist(lapply(matches, function(match) {
-      if (length(match) < 2) return(character())
-      match[-1]
-    }), use.names = FALSE)
-  }), use.names = FALSE)
-  paths = sub('#.*$', '', paths)
-  paths = paths[nzchar(paths)]
-  paths = paths[!grepl('^(?:[[:alpha:]][[:alnum:]+.-]*:|//)', paths)]
-  paths = paths[!xfun::is_abs_path(paths)]
-  unique(paths)
-}
-
-stage_markdown_resources = function(input, output) {
-  input_dir = dirname(input)
-  output_dir = dirname(output)
-  if (xfun::same_path(input_dir, output_dir)) return(character())
-
-  paths = markdown_resource_paths(read_utf8(input))
-  if (!length(paths)) return(character())
-
-  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
-  staged = character()
-  for (path in paths) {
-    src = file.path(input_dir, path)
-    if (!file.exists(src)) next
-    dest = file.path(output_dir, path)
-    if (file.exists(dest)) next
-    dir.create(dirname(dest), recursive = TRUE, showWarnings = FALSE)
-    if (file.copy(src, dest, overwrite = FALSE)) staged = c(staged, dest)
-  }
-  unique(staged)
-}
-
-cleanup_markdown_resources = function(paths, root) {
-  paths = unique(paths[file.exists(paths)])
-  if (!length(paths)) return(invisible())
-
-  unlink(paths)
-
-  root = normalizePath(root, winslash = '/', mustWork = FALSE)
-  dirs = unique(dirname(paths))
-  dirs = dirs[order(nchar(dirs), decreasing = TRUE)]
-  for (dir in dirs) {
-    current = normalizePath(dir, winslash = '/', mustWork = FALSE)
-    while (!xfun::same_path(current, root)) {
-      if (length(list.files(current, all.files = TRUE, no.. = TRUE)) > 0) break
-      unlink(current, recursive = TRUE)
-      parent = dirname(current)
-      if (xfun::same_path(parent, current)) break
-      current = normalizePath(parent, winslash = '/', mustWork = FALSE)
-    }
-  }
-
-  invisible()
-}
-
 #' Convert markdown to HTML using knit() and mark_html()
 #'
 #' This is a convenience function to knit the input markdown source and call
@@ -256,9 +192,18 @@ knit2html = function(
   mark = if (is_lite) litedown::mark else markdown::mark_html
   if (is.null(text)) {
     output = with_ext(if (is.null(output) || is.na(output)) out else output, 'html')
-    staged = stage_markdown_resources(out, output)
-    on.exit(cleanup_markdown_resources(staged, dirname(output)), add = TRUE)
-    mark(out, output, ...)
+    # mark() resolves relative resource paths (e.g. figures) against the output
+    # directory, but knit() writes them next to the input; when the output goes
+    # to a different directory, render next to the input first (so resources can
+    # be found/embedded), then move the HTML to the output location (#2408)
+    if (xfun::same_path(dirname(out), dirname(output))) {
+      mark(out, output, ...)
+    } else {
+      html = with_ext(out, 'html')
+      on.exit(if (!xfun::same_path(html, output)) file.remove(html), add = TRUE)
+      mark(out, html, ...)
+      file.copy(html, output, overwrite = TRUE)
+    }
     invisible(output)
   } else mark(text = out, ...)
 }

--- a/tests/testit/test-utils-conversion.R
+++ b/tests/testit/test-utils-conversion.R
@@ -1,0 +1,43 @@
+library(testit)
+
+if (requireNamespace('markdown', quietly = TRUE)) assert(
+  'knit2html() embeds local figure resources when output is written elsewhere', {
+    td = tempfile('knit2html-')
+    dir.create(td)
+    old = setwd(td)
+    on.exit(setwd(old), add = TRUE)
+
+    writeLines(c(
+      '---',
+      'title: "test"',
+      'output: html_document',
+      '---',
+      '',
+      '```{r Graph2, fig.width=7.7, fig.height=6.8}',
+      'plot(1, 1)',
+      '```'
+    ), 'test.Rmd')
+
+    out_dir = tempfile('knit2html-out-')
+    dir.create(out_dir)
+    warnings = character()
+    out = withCallingHandlers(
+      knit2html(
+        'test.Rmd',
+        output = file.path(out_dir, 'OUT.html'),
+        quiet = TRUE,
+        force_v1 = TRUE
+      ),
+      warning = function(w) {
+        warnings <<- c(warnings, conditionMessage(w))
+        invokeRestart('muffleWarning')
+      }
+    )
+
+    html = read_utf8(out)
+    (!any(grepl('not found \\(hence cannot be embedded\\)', warnings)))
+    (any(grepl('data:image/png;base64,', html, fixed = TRUE)))
+    (!any(grepl('figure/Graph2-1.png', html, fixed = TRUE)))
+    (!file.exists(file.path(out_dir, 'figure', 'Graph2-1.png')))
+  }
+)


### PR DESCRIPTION
Summary

Stage local Markdown resources before `knit2html()` renders HTML to a different output directory, so generated figure files can still be embedded.

Thanks to maintainers

Thanks for the issue discussion and for narrowing the problem to the `knit2html()` / `mark_html()` resource handoff.

Issue or motivation

`knit2html()` can warn that files such as `figure/Graph2-1.png` cannot be embedded when the HTML output is written outside the knitted Markdown directory. This leaves broken figure references in the final HTML. The issue is reported in #2408.

Root cause

`knit()` writes the intermediate Markdown and figure files next to the input document, but `mark_html()` resolves embeddable local resources relative to the output location. When the output directory is different, the figure files are no longer available where the HTML renderer looks for them.

Change

- Detect local relative resource paths referenced by the knitted Markdown.
- Stage those files into the HTML output directory before calling `mark_html()`.
- Remove staged files and any empty staging directories after rendering.
- Add a regression test that reproduces the moved-output case and checks that the PNG is embedded instead of left as a broken relative path.

Tests

- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); source("tests/testit/test-utils-conversion.R")'`
- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); source("tests/testit/test-hooks-md.R")'`
- `Rscript -e 'testit::test_pkg("knitr")'`
- `R CMD build .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual knitr_1.51.7.tar.gz`

Scope

This stays inside `knit2html()` resource staging for moved HTML outputs. It does not change `rmarkdown::render()`, does not modify `litedown` itself, and does not alter unrelated Markdown rendering behavior.
