### PR TITLE
feat: let `animation.hook` generate LaTeX code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.51.13
+Version: 1.51.14
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
     person("Abhraneel", "Sarma", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,7 @@ Authors@R: c(
     person("Jeremy", "Stephens", role = "ctb"),
     person("Jim", "Hester", role = "ctb"),
     person("Joe", "Cheng", role = "ctb"),
+    person("Johan", "Larsson", role = "ctb"),
     person("Johannes", "Ranke", role = "ctb"),
     person("John", "Honaker", role = "ctb"),
     person("John", "Muschelli", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## NEW FEATURES
 
+- `hook_plot_tex()` now respects the chunk option `animation.hook` (or the package option `animation.fun`) when it is set to a function of your own, and calls it to generate the LaTeX code for a chunk with `fig.show = 'animate'` instead of the default `\animategraphics{}`. This makes the LaTeX plot hook extensible in the same way as `hook_plot_html()`, which has always supported these options, and allows for LaTeX packages other than **animate** to be used for animations, e.g. **xmpmulti** for beamer overlays. The built-in hooks such as `hook_ffmpeg_html()` generate HTML and continue to be ignored for LaTeX output, so this does not change the output of existing documents (thanks, @jolars #2452).
+
 - Added support for a new input format `.Rtyp` for the [Typst](https://typst.app) typesetting system (thanks, @blset #2401, @aksigkvgithub #2283). You can use code chunks and inline R expressions in `.Rtyp` files, knit them via `knitr::knit()` to `.typ` output, or compile to PDF directly via `knit2pdf('input.Rtyp')`. See https://github.com/yihui/knitr-examples/blob/master/128-minimal.Rtyp for a minimal example.
 
 - Added a `knitr::rtyp` vignette engine to build `.Rtyp` vignettes to PDF via Typst, so packages no longer need to register their own engine for this purpose (thanks, @ggrothendieck, #2447).

--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -100,6 +100,11 @@ hook_animation = function(options) {
 #'
 #' These hooks are mainly for the package option \code{animation.fun}, e.g. you
 #' can set \code{opts_knit$set(animation.fun = hook_scianimator)}.
+#'
+#' Note that these hooks generate HTML code. For LaTeX output, you can set the
+#' chunk option \code{animation.hook} (or the package option
+#' \code{animation.fun}) to a function that generates LaTeX code; see
+#' \code{\link{hook_plot_tex}}.
 #' @inheritParams hook_plot_tex
 #' @rdname hook_animation
 #' @export

--- a/R/hooks-html.R
+++ b/R/hooks-html.R
@@ -22,13 +22,21 @@ hook_plot_html = function(x, options) {
   )
 }
 
+# the built-in animation hooks, which generate HTML (and are ignored for LaTeX
+# output); keyed by the character values allowed for the chunk option
+# animation.hook
+.animation_hooks = function() list(
+  ffmpeg = hook_ffmpeg_html, gifski = hook_gifski,
+  scianimator = hook_scianimator, r2swf = hook_r2swf
+)
+
 hook_animation = function(options) {
   if (is.function(fun <- options$animation.hook)) return(fun)
-  if (is.character(fun)) return(switch(
-    fun, ffmpeg = hook_ffmpeg_html, gifski = hook_gifski,
-    scianimator = hook_scianimator, r2swf = hook_r2swf,
-    stop2('Invalid value for the chunk option animation.hook: ', fun)
-  ))
+  if (is.character(fun)) {
+    if (is.null(hook <- .animation_hooks()[[fun]]))
+      stop2('Invalid value for the chunk option animation.hook: ', fun)
+    return(hook)
+  }
   if (is.function(fun <- opts_knit$get('animation.fun'))) return(fun)
   hook_ffmpeg_html
 }

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -11,6 +11,14 @@
 #' \code{hook_plot_rst} return character strings which are HTML, Markdown, reST
 #' code.
 #'
+#' For animations (i.e. when the chunk option \code{fig.show} is \code{'animate'}),
+#' \code{hook_plot_tex} generates \samp{\\animategraphics{}} unless a hook function
+#' has been provided via the chunk option \code{animation.hook} or the package option
+#' \code{animation.fun}, in which case that function generates the LaTeX code instead.
+#' It is called only once per chunk, with the filename of the last plot. The
+#' built-in hooks (e.g. \code{\link{hook_ffmpeg_html}}) generate HTML, and are
+#' ignored for LaTeX output.
+#'
 #' In most cases we do not need to call these hooks explicitly, and they were
 #' designed to be used internally. Sometimes we may not be able to record R
 #' plots using \code{grDevices::\link{recordPlot}()}, and we can make use of
@@ -172,13 +180,15 @@ hook_plot_tex = function(x, options) {
     if (tikz) {
       sprintf('\\input{%s}', x)
     } else if (animate) {
-      # \animategraphics{} should be inserted only *once*!
-      aniopts = options$aniopts
-      aniopts = if (is.na(aniopts)) NULL else gsub(';', ',', aniopts)
-      size = paste(c(size, sprintf('%s', aniopts)), collapse = ',')
-      if (nzchar(size)) size = sprintf('[%s]', size)
-      sprintf('\\animategraphics%s{%s}{%s}{%s}{%s}', size, 1 / options$interval,
-              sub(sprintf('%d$', fig.num), '', sans_ext(x)), 1L, fig.num)
+      if (is.function(fun <- animation_hook_tex(options))) fun(x, options) else {
+        # \animategraphics{} should be inserted only *once*!
+        aniopts = options$aniopts
+        aniopts = if (is.na(aniopts)) NULL else gsub(';', ',', aniopts)
+        size = paste(c(size, sprintf('%s', aniopts)), collapse = ',')
+        if (nzchar(size)) size = sprintf('[%s]', size)
+        sprintf('\\animategraphics%s{%s}{%s}{%s}{%s}', size, 1 / options$interval,
+                sub(sprintf('%d$', fig.num), '', sans_ext(x)), 1L, fig.num)
+      }
     } else {
       if (nzchar(size)) size = sprintf('[%s]', size)
       res = sprintf(
@@ -191,6 +201,20 @@ hook_plot_tex = function(x, options) {
 
     resize2, sub2, sep.cur, align2, fig2
   )
+}
+
+# Find the animation hook to be used for LaTeX output. Contrary to
+# hook_animation(), this returns NULL unless the user has provided a hook
+# function of their own, in which case hook_plot_tex() falls back to
+# \animategraphics{}. The built-in hooks generate HTML, and used to be ignored
+# for LaTeX output, so they must keep being ignored here.
+animation_hook_tex = function(options) {
+  fun = options$animation.hook
+  if (!is.function(fun)) fun = opts_knit$get('animation.fun')
+  if (!is.function(fun)) return()
+  for (h in list(hook_ffmpeg_html, hook_gifski, hook_scianimator, hook_r2swf))
+    if (identical(fun, h)) return()
+  fun
 }
 
 # % -> \%, but do not touch \%

--- a/R/hooks-latex.R
+++ b/R/hooks-latex.R
@@ -180,7 +180,7 @@ hook_plot_tex = function(x, options) {
     if (tikz) {
       sprintf('\\input{%s}', x)
     } else if (animate) {
-      if (is.function(fun <- animation_hook_tex(options))) fun(x, options) else {
+      if (!is.null(fun <- animation_hook_tex(options))) fun(x, options) else {
         # \animategraphics{} should be inserted only *once*!
         aniopts = options$aniopts
         aniopts = if (is.na(aniopts)) NULL else gsub(';', ',', aniopts)
@@ -212,8 +212,7 @@ animation_hook_tex = function(options) {
   fun = options$animation.hook
   if (!is.function(fun)) fun = opts_knit$get('animation.fun')
   if (!is.function(fun)) return()
-  for (h in list(hook_ffmpeg_html, hook_gifski, hook_scianimator, hook_r2swf))
-    if (identical(fun, h)) return()
+  for (h in .animation_hooks()) if (identical(fun, h)) return()
   fun
 }
 

--- a/man/hook_animation.Rd
+++ b/man/hook_animation.Rd
@@ -29,4 +29,9 @@ to create animations; \code{hook_r2swf()} uses the \pkg{R2SWF} package.
 \details{
 These hooks are mainly for the package option \code{animation.fun}, e.g. you
 can set \code{opts_knit$set(animation.fun = hook_scianimator)}.
+
+Note that these hooks generate HTML code. For LaTeX output, you can set the
+chunk option \code{animation.hook} (or the package option
+\code{animation.fun}) to a function that generates LaTeX code; see
+\code{\link{hook_plot_tex}}.
 }

--- a/man/hook_plot.Rd
+++ b/man/hook_plot.Rd
@@ -47,6 +47,14 @@ Similarly, \code{hook_plot_html}, \code{hook_plot_md} and
 \code{hook_plot_rst} return character strings which are HTML, Markdown, reST
 code.
 
+For animations (i.e. when the chunk option \code{fig.show} is \code{'animate'}),
+\code{hook_plot_tex} generates \samp{\\animategraphics{}} unless a hook function
+has been provided via the chunk option \code{animation.hook} or the package option
+\code{animation.fun}, in which case that function generates the LaTeX code instead.
+It is called only once per chunk, with the filename of the last plot. The
+built-in hooks (e.g. \code{\link{hook_ffmpeg_html}}) generate HTML, and are
+ignored for LaTeX output.
+
 In most cases we do not need to call these hooks explicitly, and they were
 designed to be used internally. Sometimes we may not be able to record R
 plots using \code{grDevices::\link{recordPlot}()}, and we can make use of

--- a/tests/testit/test-hooks-latex.R
+++ b/tests/testit/test-hooks-latex.R
@@ -24,3 +24,42 @@ assert("alt text is included in LaTeX output", {
                                  fig.show = 'asis', out.width = '\\maxwidth')) %==%
      '\n\n{\\centering \\includegraphics[width=\\maxwidth,alt={Alt}]{foo} \n\n}\n\n')
 })
+
+assert("a user-provided animation hook generates the LaTeX code for animations", {
+  hook = function(x, options) sprintf('<%s|%d>', x, options$fig.num)
+  opts = function(...) opts_chunk$merge(list(fig.show = 'animate', ...))
+
+  # the hook is called only once, for the last plot of the chunk
+  (hook_plot_tex('foo-1.pdf', opts(animation.hook = hook, fig.cur = 1, fig.num = 3)) %==% '')
+
+  # the hook output replaces \animategraphics{} but keeps the surrounding markup
+  (hook_plot_tex(
+    'foo-3.pdf', opts(animation.hook = hook, fig.cur = 3, fig.num = 3, fig.align = 'center')
+  ) %==% '\n\n{\\centering <foo-3.pdf|3>\n\n}\n\n')
+
+  # the package option animation.fun is respected as well
+  opts_knit$set(animation.fun = hook)
+  (hook_plot_tex('foo-3.pdf', opts(fig.cur = 3, fig.num = 3)) %==% '\n<foo-3.pdf|3>')
+  opts_knit$set(animation.fun = NULL)
+
+  # the built-in hooks generate HTML instead of LaTeX, so they must not be used
+  # here, no matter how they are provided
+  (grepl('animategraphics', hook_plot_tex(
+    'foo-3.pdf', opts(animation.hook = 'ffmpeg', fig.cur = 3, fig.num = 3)
+  ), fixed = TRUE))
+  for (h in list(hook_ffmpeg_html, hook_gifski, hook_scianimator, hook_r2swf)) {
+    (grepl('animategraphics', hook_plot_tex(
+      'foo-3.pdf', opts(animation.hook = h, fig.cur = 3, fig.num = 3)
+    ), fixed = TRUE))
+    opts_knit$set(animation.fun = h)
+    (grepl('animategraphics', hook_plot_tex(
+      'foo-3.pdf', opts(fig.cur = 3, fig.num = 3)
+    ), fixed = TRUE))
+    opts_knit$set(animation.fun = NULL)
+  }
+
+  # without a hook, \animategraphics{} is generated as before
+  (grepl('animategraphics', hook_plot_tex(
+    'foo-3.pdf', opts(fig.cur = 3, fig.num = 3)
+  ), fixed = TRUE))
+})


### PR DESCRIPTION
`hook_plot_tex()` hardcoded `\animategraphics{}` for chunks with `fig.show='animate'`, so the chunk option `animation.hook` and the package option `animation.fun` were silently ignored for LaTeX output, even though `hook_plot_html()` has always honoured them.

Call the hook when either option is set to a user-provided function, and keep generating `\animategraphics{}` otherwise. The built-in hooks generate HTML, so they stay ignored for LaTeX output and existing documents are unaffected. This lets LaTeX packages other than `animate` be used for animations, e.g. `xmpmulti` for beamer overlays, which is something I need for my course slides that I write in quarto.

I used Claude Code Opus 5 to help out here.