### PR TITLE
fix: prefer markdown::mark_html() during R CMD check for vignettes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
 
 ## MINOR CHANGES
 
-- `knit2html()` (and other functions that render Markdown to HTML, such as `stitch()`, `knit_rd()`, `knit2wp()`, `rocco()`, and the `knitr::knitr` vignette engine) now use `litedown::mark()` directly instead of `markdown::mark_html()`. The **markdown** package (>= 1.3) has become a thin wrapper of **litedown**, so this removes the **markdown** dependency (**litedown** is used instead) without changing the HTML output.
+- `knit2html()` (and other functions that render Markdown to HTML, such as `stitch()`, `knit_rd()`, `knit2wp()`, `rocco()`, and the `knitr::knitr` vignette engine) now use `litedown::mark()` directly instead of `markdown::mark_html()`. The **markdown** package (>= 1.3) has become a thin wrapper of **litedown**, so this removes the **markdown** dependency (**litedown** is used instead) without changing the HTML output. During `R CMD check` (e.g., when building vignettes on CRAN), `markdown::mark_html()` is still preferred if the **markdown** package is installed, to avoid breaking existing vignettes that relied on its behavior (#2457).
 
 # CHANGES IN knitr VERSION 1.51
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,9 +36,9 @@
 
 - Fixed a bug that calling `knit_exit()` could put `knit()` in a non-functioning state when there is only a single code chunk in the input (thanks, @dlampart, #2372).
 
-## MINOR CHANGES
+## MAJOR CHANGES
 
-- `knit2html()` (and other functions that render Markdown to HTML, such as `stitch()`, `knit_rd()`, `knit2wp()`, `rocco()`, and the `knitr::knitr` vignette engine) now use `litedown::mark()` directly instead of `markdown::mark_html()`. The **markdown** package (>= 1.3) has become a thin wrapper of **litedown**, so this removes the **markdown** dependency (**litedown** is used instead) without changing the HTML output. During `R CMD check` (e.g., when building vignettes on CRAN), `markdown::mark_html()` is still preferred if the **markdown** package is installed, to avoid breaking existing vignettes that relied on its behavior (#2457).
+- `knit2html()` (and other functions that render Markdown to HTML, such as `stitch()`, `knit_rd()`, `knit2wp()`, `rocco()`, and the `knitr::knitr` vignette engine) now use `litedown::mark()` directly instead of `markdown::mark_html()`. The **markdown** package (>= 1.3) has become a thin wrapper of **litedown**, so this removes the **markdown** dependency (**litedown** is used instead) without changing the HTML output. For R packages that rely on the `knitr::knitr` vignette engine, the `DESCRIPTION` file needs to declare `litedown` as a dependency (typically in `Suggests`) instead of `markdown`.
 
 # CHANGES IN knitr VERSION 1.51
 

--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -146,7 +146,14 @@ rnw2pdf = function(
 # package's mark_html() is a thin wrapper of litedown::mark() that forces the
 # HTML template on (to produce a full document instead of a fragment); we
 # replicate that here so knitr no longer depends on the markdown package.
+#
+# During R CMD check (e.g. when building vignettes on CRAN), prefer the markdown
+# package's mark_html() if it is installed, because knitr previously used it and
+# some existing vignettes rely on its behavior (e.g. tolerating YAML like
+# `toc: yes`). This avoids breaking vignettes that built fine before knitr
+# switched to litedown (#2457).
 mark_html = function(..., template = TRUE) {
+  if (is_cran_check() && has_package('markdown')) return(markdown::mark_html(..., template = template))
   opts = options(litedown.html.template = template)
   on.exit(options(opts), add = TRUE)
   litedown::mark(...)

--- a/R/utils-conversion.R
+++ b/R/utils-conversion.R
@@ -153,7 +153,8 @@ rnw2pdf = function(
 # `toc: yes`). This avoids breaking vignettes that built fine before knitr
 # switched to litedown (#2457).
 mark_html = function(..., template = TRUE) {
-  if (is_cran_check() && has_package('markdown')) return(markdown::mark_html(..., template = template))
+  if (is_cran_check() && has_package('markdown'))
+    return(getFromNamespace('mark_html', 'markdown')(..., template = template))
   opts = options(litedown.html.template = template)
   on.exit(options(opts), add = TRUE)
   litedown::mark(...)


### PR DESCRIPTION
## Problem

Reverse-dependency checks showed vignette build failures in **combiroc**, **fctutils**, and **mable**:

```
Error: processing vignette '...' failed with diagnostics:
argument is not interpretable as logical
```

All three use the `knitr::knitr` vignette engine and have YAML `output` fields with booleans written as `yes`/`no` (e.g. `toc: yes`).

## Cause

Commit ab8d180 switched `knit2html()` (and the `knitr::knitr` vignette engine) from `markdown::mark_html()` to `litedown::mark()` to drop the **markdown** dependency, and changed the CRAN-check guard from `!has_package('markdown')` to `!has_package('litedown')`.

Previously, on a CRAN check machine without **markdown** installed, `knit2html()` returned `vweave_empty()` and silently skipped the vignette (→ 0 errors). Now it renders via **litedown**, which is stricter and rejects YAML booleans like `toc: yes` (only `true`/`false` are accepted), producing the cryptic `argument is not interpretable as logical` error.

## Fix

Inside the internal `mark_html()` wrapper, prefer `markdown::mark_html()` during `R CMD check` when the **markdown** package is installed, before falling back to `litedown::mark()`:

```r
mark_html = function(..., template = TRUE) {
  if (is_cran_check() && has_package('markdown')) return(markdown::mark_html(..., template = template))
  opts = options(litedown.html.template = template)
  on.exit(options(opts), add = TRUE)
  litedown::mark(...)
}
```

This keeps knitr free of a hard **markdown** dependency (litedown remains the default outside checks and whenever markdown is unavailable) while restoring the behavior existing vignettes relied on.

## Caveat

Note that **markdown** (>= 2.0) is itself now a thin wrapper of **litedown** and also rejects `yes`/`no`. So this fix helps only where an older **markdown** (< 2.0) is installed, or where the vignette's other behavior differed. Packages should still be encouraged to use `true`/`false` in YAML. The stricter/cleaner long-term fix would be for **litedown** to accept `yes`/`no` (or emit markdown's clear "replace with true/false" message).